### PR TITLE
fix(test-harness): stop temp-home daemon leaks — RAII teardown + self-exit + home-derived sockets (card f122b5b5)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -200,3 +200,28 @@ jobs:
             ${{ runner.os }}-cargo-test-
       - name: cargo test --workspace --all-features
         run: cargo test --workspace --all-features
+      # Card f122b5b5 ZERO-LEAK GUARD: the acceptance is that a full
+      # `cargo test --workspace` leaves ZERO airc daemon processes whose
+      # `--home` is under a temp dir. Test daemons get RAII teardown + a
+      # temp-home idle self-exit watchdog; this step is the backstop that
+      # FAILS the leg if either defense ever regresses. ps-based and
+      # portable (ubuntu + macos); skipped on Windows where `ps`/`pgrep`
+      # differ and the self-hosted runner makes process scans noisy.
+      - name: zero leaked temp-home daemons
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          # Match an `airc ... daemon` process whose `--home` argument
+          # points under a temp root (/tmp, /var/folders, /private/...,
+          # $TMPDIR). Production daemons (home under $HOME/.airc or a
+          # repo `.airc`) never match.
+          leaked="$(ps -Ao pid=,args= \
+            | grep -E '(^|/)airc .* daemon' \
+            | grep -E -- '--home[ =](/private)?(/tmp|/var/folders|/var/tmp)/' \
+            || true)"
+          if [ -n "$leaked" ]; then
+            echo "::error::card f122b5b5 — temp-home airc daemons survived the test suite:"
+            echo "$leaked"
+            exit 1
+          fi
+          echo "zero leaked temp-home airc daemons after the suite (card f122b5b5)"

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -60,3 +60,9 @@ libc = "0.2"
 [dev-dependencies]
 tempfile = "3"
 temp-env = "0.3"
+
+# Card f122b5b5: the daemon-teardown guard (tests/common) needs
+# kill(2)/ESRCH probing to reap daemons the CLI auto-spawned for
+# temp homes.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -206,17 +206,12 @@ pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
     // SUN_LEN fallback root for deep-home cases (see machine_socket_path).
     // The OS per-user temp dir is short; never used for normal homes.
     let short_fallback = std::env::temp_dir();
-    let project_socket = home
-        .parent()
-        .map(|root| crate::runtime_dir::project_socket_path(root).ok())
-        .unwrap_or(None);
     let socket = resolve_socket_path(
         home,
         &machine_home,
         user_home.as_deref(),
         runtime_dir.as_deref(),
         Some(short_fallback.as_path()),
-        project_socket,
     );
     // runtime_dir() created ~/.airc/runtime, but the SUN_LEN fallback dir
     // (<temp>/airc) may not exist yet — ensure the chosen socket's parent
@@ -244,16 +239,12 @@ pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
 ///   `$USERPROFILE`). `None` ⇒ treat every scope as isolated.
 /// - `runtime_dir`: result of [`crate::runtime_dir::runtime_dir`].
 ///   `None` ⇒ the legacy home-private fallback.
-/// - `project_socket`: result of
-///   [`crate::runtime_dir::project_socket_path`] for the scope's
-///   project root. Only consulted when the scope is isolated.
 fn resolve_socket_path(
     home: &std::path::Path,
     machine_home: &std::path::Path,
     user_home: Option<&std::path::Path>,
     runtime_dir: Option<&std::path::Path>,
     short_fallback_dir: Option<&std::path::Path>,
-    project_socket: Option<PathBuf>,
 ) -> PathBuf {
     // `machine_account_home(scope_home)` returns `$HOME/.airc` when
     // scope_home is under `$HOME`, otherwise returns scope_home
@@ -264,8 +255,8 @@ fn resolve_socket_path(
     //   (a) `home` IS literally `$HOME/.airc` — already
     //       machine-singular; share.
     //   (b) `home` is an isolated scope (CI temp dir, test root) —
-    //       use the per-project socket so parallel isolated scopes
-    //       don't collide.
+    //       derive the socket from the SCOPE HOME so parallel isolated
+    //       scopes don't collide and nothing lands under the user home.
     // Case (a) must be an EQUALITY check, not "machine_home under
     // user_home": on Windows `%TEMP%` lives under `%USERPROFILE%`, so
     // the prefix form classified temp-rooted isolated scopes as
@@ -301,10 +292,38 @@ fn resolve_socket_path(
             legacy_fallback,
         );
     }
-    // Isolated scope (CI temp, test root outside `$HOME`): per-project
-    // socket so multiple isolated tests can run in parallel without
-    // colliding on the same daemon.
-    project_socket.unwrap_or(legacy_fallback)
+    // Isolated scope (CI temp, test root outside `$HOME`): the socket
+    // derives from the DAEMON'S OWN HOME, never the user home — card
+    // f122b5b5. The prior form keyed the NAME by project-root hash but
+    // placed the FILE in `runtime_dir` = `~/.airc/runtime`, so every
+    // hermetic temp-home test daemon planted its socket (and stale
+    // remains: airc-10e8167b5d5b936d-v5.sock, observed live) under the
+    // PRODUCTION runtime dir. Same-home processes still rendezvous —
+    // they compute the same home-derived path — and parallel isolated
+    // scopes still can't collide (distinct homes ⇒ distinct paths).
+    //
+    // `legacy_fallback` IS `home/daemon-v<N>.sock` here (machine_home ==
+    // home for isolated scopes). Deep tempdir homes can overflow
+    // SUN_LEN, so fall back to the short OS temp dir with the home
+    // HASHED into the name — still derived from the daemon's home,
+    // still never under `~/.airc/runtime`.
+    if fits_socket_limit(&legacy_fallback) {
+        return legacy_fallback;
+    }
+    if let Some(short) = short_fallback_dir {
+        let candidate = short.join("airc").join(format!(
+            "airc-scope-{}-v{}.sock",
+            machine_account_key(home),
+            airc_ipc::IPC_PROTOCOL_VERSION
+        ));
+        if fits_socket_limit(&candidate) {
+            return candidate;
+        }
+    }
+    // Nothing shorter available — return the home-derived path and let
+    // bind surface a clear SUN_LEN error rather than silently landing
+    // in a shared directory.
+    legacy_fallback
 }
 
 /// `sockaddr_un.sun_path` is 104 bytes on macOS (incl. NUL) and 108 on
@@ -879,10 +898,6 @@ mod tests {
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
             None,
-            // project_socket is irrelevant for machine-account scopes;
-            // pass a distinct value per call to assert we don't accidentally
-            // fall through to it.
-            Some(runtime_dir.join("airc-project-a-v0.sock")),
         );
         let socket_b = resolve_socket_path(
             &project_b,
@@ -890,7 +905,6 @@ mod tests {
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
             None,
-            Some(runtime_dir.join("airc-project-b-v0.sock")),
         );
 
         assert_eq!(
@@ -916,7 +930,7 @@ mod tests {
     /// the real daemon. Pure path math, so this pins the Windows shape
     /// on every platform. With the b0a81c31 lib fix,
     /// `machine_account_home(temp_scope)` returns the scope itself, and
-    /// this function must then treat it as ISOLATED (per-project
+    /// this function must then treat it as ISOLATED (home-derived
     /// socket), never the machine-account socket.
     #[test]
     fn temp_rooted_scope_under_userprofile_never_resolves_the_machine_socket() {
@@ -927,7 +941,6 @@ mod tests {
         let temp_scope = user_home
             .join("AppData/Local/Temp/.tmpAbC123")
             .join("agent");
-        let project_socket = runtime_dir.join("airc-temp-scope-v0.sock");
 
         let socket = resolve_socket_path(
             &temp_scope,
@@ -937,15 +950,15 @@ mod tests {
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
             None,
-            Some(project_socket.clone()),
         );
 
-        assert_eq!(
-            socket, project_socket,
+        assert!(
+            socket.starts_with(&temp_scope),
             "a temp-rooted scope under the user profile must stay \
-             isolated (per-project socket); resolving the machine \
+             isolated (home-derived socket); resolving the machine \
              socket here is how integration tests reached — and \
-             stopped — the production daemon (card b0a81c31 bite 3)"
+             stopped — the production daemon (card b0a81c31 bite 3); \
+             got {socket:?}"
         );
         // And the literal machine home keeps sharing (case (a) of the
         // clause this test tightened — equality, not prefix).
@@ -956,7 +969,6 @@ mod tests {
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
             None,
-            Some(project_socket.clone()),
         );
         assert!(
             machine_socket.to_string_lossy().contains("airc-machine-"),
@@ -965,13 +977,14 @@ mod tests {
         );
     }
 
-    /// Card e51ab14e: scopes OUTSIDE the OS user account (CI temp
-    /// roots, isolated test trees) keep their per-project socket so
-    /// parallel test runs do not collide on the same daemon. This
-    /// preserves PR #1040's original guarantee for the case it was
-    /// solving for.
+    /// Card e51ab14e + f122b5b5: scopes OUTSIDE the OS user account
+    /// (CI temp roots, isolated test trees) get HOME-DERIVED sockets so
+    /// parallel test runs do not collide on the same daemon — and so
+    /// nothing they create lands under the user home. This preserves
+    /// PR #1040's isolation guarantee while moving the file out of
+    /// `~/.airc/runtime`.
     #[test]
-    fn isolated_scopes_outside_user_home_keep_per_project_sockets() {
+    fn isolated_scopes_outside_user_home_get_home_derived_sockets() {
         use super::resolve_socket_path;
         let user_home = std::path::PathBuf::from("/synthetic/user-home");
         let runtime_dir = std::path::PathBuf::from("/synthetic/runtime");
@@ -980,8 +993,6 @@ mod tests {
         // (production behaviour). Pass the same here.
         let scope_a = std::path::PathBuf::from("/synthetic/isolated/a/.airc");
         let scope_b = std::path::PathBuf::from("/synthetic/isolated/b/.airc");
-        let project_socket_a = runtime_dir.join("airc-isolated-a-v0.sock");
-        let project_socket_b = runtime_dir.join("airc-isolated-b-v0.sock");
 
         let socket_a = resolve_socket_path(
             &scope_a,
@@ -989,7 +1000,6 @@ mod tests {
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
             None,
-            Some(project_socket_a.clone()),
         );
         let socket_b = resolve_socket_path(
             &scope_b,
@@ -997,18 +1007,59 @@ mod tests {
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
             None,
-            Some(project_socket_b.clone()),
         );
 
         assert_ne!(
             socket_a, socket_b,
             "isolated scopes outside the OS user account must keep \
-             per-project sockets so parallel test runs don't collide; \
+             distinct sockets so parallel test runs don't collide; \
              got the same socket for two unrelated isolated roots: \
              {socket_a:?}"
         );
-        assert_eq!(socket_a, project_socket_a);
-        assert_eq!(socket_b, project_socket_b);
+        assert!(socket_a.starts_with(&scope_a), "home-derived: {socket_a:?}");
+        assert!(socket_b.starts_with(&scope_b), "home-derived: {socket_b:?}");
+    }
+
+    /// Card f122b5b5 PIN — the production-pollution bug. An EXPLICIT
+    /// temp home (a hermetic test daemon's `--home` under the OS temp
+    /// dir, with the operator's REAL user home + runtime dir in env)
+    /// must NEVER resolve a socket under the user's `~/.airc/runtime`.
+    /// The pre-fix code keyed the socket NAME by project-root hash but
+    /// placed the FILE in `runtime_dir`, which is how the stale
+    /// `airc-10e8167b5d5b936d-v5.sock` landed in the production
+    /// `~/.airc/runtime` (observed live, card body). Mutation: revert
+    /// the isolated branch to the runtime-dir placement → this fails.
+    #[test]
+    fn explicit_temp_home_never_places_socket_under_user_runtime_dir() {
+        use super::resolve_socket_path;
+        let user_home = std::path::PathBuf::from("/Users/operator");
+        let runtime_dir = user_home.join(".airc").join("runtime");
+        // The literal shape of a leaked daemon's home: tempfile tempdir
+        // under macOS's /var/folders, no HOME override.
+        let temp_home = std::path::PathBuf::from("/var/folders/8d/x/T/.tmpQwErTy/agent");
+
+        let socket = resolve_socket_path(
+            &temp_home,
+            &temp_home, // machine_account_home(temp) == temp (isolated)
+            Some(user_home.as_path()),
+            Some(runtime_dir.as_path()),
+            Some(std::path::Path::new("/tmp")),
+        );
+
+        assert!(
+            !socket.starts_with(&runtime_dir) && !socket.starts_with(&user_home),
+            "an explicit temp home must NEVER place its socket under the \
+             user home / production runtime dir (card f122b5b5), got {socket:?}"
+        );
+        assert!(
+            socket.starts_with(&temp_home) || socket.starts_with("/tmp"),
+            "the socket must derive from the daemon's own home (or the \
+             short temp fallback hashed from it), got {socket:?}"
+        );
+        assert!(
+            socket.as_os_str().len() < super::MAX_SOCKET_PATH_LEN,
+            "and it must still fit sockaddr_un: {socket:?}"
+        );
     }
 
     /// Card e51ab14e: when `runtime_dir` resolution fails (`$HOME`
@@ -1027,7 +1078,6 @@ mod tests {
             &project,
             &machine_home,
             Some(user_home.as_path()),
-            None,
             None,
             None,
         );
@@ -1062,7 +1112,6 @@ mod tests {
             Some(user_home.as_path()),
             Some(deep_runtime.as_path()),
             Some(short_fallback.as_path()),
-            None,
         );
 
         assert!(

--- a/crates/airc-cli/src/runtime_dir.rs
+++ b/crates/airc-cli/src/runtime_dir.rs
@@ -28,8 +28,7 @@
 //! test daemons at throwaway dirs so they don't collide with the real
 //! machine daemon. Normal operation never sets it.
 
-use sha2::{Digest, Sha256};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// The runtime directory for `airc` — where `airc-<hash>-v<N>.sock`
 /// files live. Created if absent.
@@ -77,42 +76,13 @@ fn resolve_runtime_dir(
     Ok(PathBuf::from(home).join(".airc").join("runtime"))
 }
 
-/// Project-derived socket path. The hash of the canonicalized project
-/// root is stable across runs, so every agent in the same project
-/// computes the same socket path and reaches the same daemon — no
-/// discovery indirection needed.
-///
-/// `project_root` is typically the git working tree (the parent of
-/// `.airc/`). The hash is 16 hex chars of SHA-256, collision-resistant
-/// at the scale of "projects on one machine."
-pub fn project_socket_path(project_root: &Path) -> std::io::Result<PathBuf> {
-    let dir = runtime_dir()?;
-    let key = project_key(project_root);
-    Ok(dir.join(format!(
-        "airc-{}-v{}.sock",
-        key,
-        airc_ipc::IPC_PROTOCOL_VERSION
-    )))
-}
-
-/// 16-char hex prefix of SHA-256(canonical(project_root)). Same scheme
-/// as `discovery::project_key` so the transition produces consistent
-/// keys; once discovery is removed this is the only definition.
-fn project_key(project_root: &Path) -> String {
-    let canon = project_root
-        .canonicalize()
-        .unwrap_or_else(|_| project_root.to_path_buf());
-    let mut h = Sha256::new();
-    h.update(canon.as_os_str().as_encoded_bytes());
-    let digest = h.finalize();
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut s = String::with_capacity(16);
-    for b in &digest[..8] {
-        s.push(HEX[(b >> 4) as usize] as char);
-        s.push(HEX[(b & 0xf) as usize] as char);
-    }
-    s
-}
+// NOTE (card f122b5b5): `project_socket_path` used to live here — a
+// project-root-hashed socket NAME placed in `runtime_dir()`. That
+// placement is exactly how hermetic temp-home test daemons planted
+// sockets under the PRODUCTION `~/.airc/runtime` (stale
+// `airc-10e8167b5d5b936d-v5.sock` observed live). Isolated scopes now
+// derive their socket from the daemon's own home in
+// `cli::resolve_socket_path`; nothing project-hashed lands here.
 
 #[cfg(test)]
 mod tests {
@@ -149,21 +119,6 @@ mod tests {
     }
 
     #[test]
-    fn project_key_is_stable_across_calls() {
-        let a = project_key(Path::new("/Users/joel/Development/airc"));
-        let b = project_key(Path::new("/Users/joel/Development/airc"));
-        assert_eq!(a, b);
-        assert_eq!(a.len(), 16);
-    }
-
-    #[test]
-    fn project_key_distinguishes_paths() {
-        let a = project_key(Path::new("/Users/joel/Development/airc"));
-        let b = project_key(Path::new("/Users/joel/Development/continuum"));
-        assert_ne!(a, b);
-    }
-
-    #[test]
     fn runtime_dir_honors_airc_runtime_dir_env() {
         // Use a unique path to avoid colliding with other test runs
         let unique = std::env::temp_dir().join(format!(
@@ -193,39 +148,6 @@ mod tests {
                 Some(v) => std::env::set_var("AIRC_RUNTIME_DIR", v),
                 None => std::env::remove_var("AIRC_RUNTIME_DIR"),
             }
-        }
-        let _ = std::fs::remove_dir_all(&unique);
-    }
-
-    #[test]
-    fn project_socket_path_contains_hash_and_version() {
-        // Confirm the filename shape: airc-<16hex>-v<N>.sock
-        let unique = std::env::temp_dir().join(format!(
-            "airc-socket-shape-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0),
-        ));
-        // SAFETY: env::set_var is unsafe in Rust 2024 due to inherent
-        // thread-safety concerns; tests run serially so this is OK.
-        unsafe {
-            std::env::set_var("AIRC_RUNTIME_DIR", &unique);
-        }
-        let pr = Path::new("/Users/joel/Development/airc");
-        let socket = project_socket_path(pr).expect("succeeds");
-        let name = socket.file_name().unwrap().to_str().unwrap();
-        assert!(name.starts_with("airc-"), "name starts with airc-: {name}");
-        assert!(name.ends_with(".sock"), "extension is .sock: {name}");
-        assert!(
-            name.contains(&format!("v{}", airc_ipc::IPC_PROTOCOL_VERSION)),
-            "version is embedded: {name}"
-        );
-        // SAFETY: env::set_var is unsafe in Rust 2024 due to inherent
-        // thread-safety concerns; tests run serially so this is OK.
-        unsafe {
-            std::env::remove_var("AIRC_RUNTIME_DIR");
         }
         let _ = std::fs::remove_dir_all(&unique);
     }

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::Duration;
 
 use serde_json::Value;
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -15,7 +15,7 @@ fn airc_core() -> &'static str {
 
 #[test]
 fn codex_hook_emits_context_and_advances_cursor() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -45,7 +45,7 @@ fn codex_hook_emits_context_and_advances_cursor() {
 
 #[test]
 fn codex_hook_excludes_self_echoes_but_still_advances_cursor() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -67,7 +67,7 @@ fn codex_hook_excludes_self_echoes_but_still_advances_cursor() {
 
 #[test]
 fn codex_hook_filters_by_runtime_client_header_not_persisted_identity() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -87,7 +87,7 @@ fn codex_hook_filters_by_runtime_client_header_not_persisted_identity() {
 
 #[test]
 fn codex_hook_keeps_stamped_peer_events_when_runtime_client_is_unknown() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -104,7 +104,7 @@ fn codex_hook_keeps_stamped_peer_events_when_runtime_client_is_unknown() {
 
 #[test]
 fn codex_hook_suggests_claimable_work_on_work_events() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -132,7 +132,7 @@ fn codex_hook_suggests_claimable_work_on_work_events() {
 
 #[test]
 fn codex_hook_suggests_availability_on_availability_events() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -162,7 +162,7 @@ fn codex_hook_suggests_availability_on_availability_events() {
 
 #[test]
 fn codex_hook_raw_mode_preserves_full_event_lines() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -186,7 +186,7 @@ fn codex_hook_raw_mode_preserves_full_event_lines() {
 
 #[test]
 fn codex_hook_poll_prints_plain_digest_and_advances_cursor() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -211,7 +211,7 @@ fn codex_hook_poll_prints_plain_digest_and_advances_cursor() {
 
 #[test]
 fn codex_hook_poll_filters_runtime_self_echoes() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -235,7 +235,7 @@ fn codex_hook_poll_filters_runtime_self_echoes() {
 
 #[test]
 fn codex_hook_poll_waits_for_one_new_event() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -265,7 +265,7 @@ fn codex_hook_poll_waits_for_one_new_event() {
 
 #[test]
 fn codex_hook_installer_replaces_existing_managed_hook() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
     std::fs::create_dir_all(&codex_home).expect("codex home");
@@ -311,7 +311,7 @@ fn codex_hook_installer_replaces_existing_managed_hook() {
 
 #[test]
 fn codex_hook_installer_replaces_existing_managed_hook_command() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
     std::fs::create_dir_all(&codex_home).expect("codex home");
@@ -351,7 +351,7 @@ fn codex_hook_installer_replaces_existing_managed_hook_command() {
 
 #[test]
 fn codex_hook_installer_adds_turn_contract_when_unset() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
     std::fs::create_dir_all(&codex_home).expect("codex home");
@@ -376,7 +376,7 @@ fn codex_hook_installer_adds_turn_contract_when_unset() {
 
 #[test]
 fn codex_hook_installer_preserves_custom_developer_instructions() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
     std::fs::create_dir_all(&codex_home).expect("codex home");
@@ -405,7 +405,7 @@ fn codex_hook_installer_preserves_custom_developer_instructions() {
 
 #[test]
 fn codex_hook_installer_removes_managed_filesystem_profile() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
     std::fs::create_dir_all(&codex_home).expect("codex home");
@@ -447,7 +447,7 @@ enabled = true
 
 #[test]
 fn codex_hook_uninstaller_removes_managed_hooks_only() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
     std::fs::create_dir_all(&codex_home).expect("codex home");

--- a/crates/airc-cli/tests/common/mod.rs
+++ b/crates/airc-cli/tests/common/mod.rs
@@ -1,0 +1,170 @@
+//! Card f122b5b5 — RAII teardown for CLI-spawned daemons.
+//!
+//! THE leak: almost every `airc` verb spawn-or-connects a DETACHED
+//! daemon (`ensure_daemon_running` → `setsid`/`DETACHED_PROCESS`), so
+//! any integration test that runs the binary against a tempdir home
+//! strands that daemon when the test ends — it outlives the test
+//! binary BY DESIGN (it's a daemon). Measured in one session: ~40,
+//! 131, 405+86, 154 leaked temp-home daemons across `cargo test`
+//! runs; 800+ killed by hand.
+//!
+//! The fix shape: tests never hold a raw `TempDir` for a home a daemon
+//! may serve — they hold a [`DaemonTempDir`], whose Drop walks the
+//! tree for the `daemon.pid` files every daemon now writes
+//! (airc-daemon `PidFileGuard`) and reaps those processes
+//! (SIGTERM → poll-gone → SIGKILL). Because the helper ONLY returns
+//! the guarded form, a test cannot forget teardown; the guard runs on
+//! every exit path, including assert panics.
+//!
+//! Shared by multiple test binaries; not every helper is used by each,
+//! hence `dead_code` is allowed.
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// A tempdir that reaps every daemon whose home lives under it when
+/// dropped. Drop-in replacement for the `TempDir` the tests used to
+/// hold: same `path()` surface.
+pub struct DaemonTempDir {
+    // Our Drop impl runs BEFORE the field's Drop (Rust drop order), so
+    // daemons are reaped while their home still exists, then TempDir
+    // deletes the tree.
+    dir: tempfile::TempDir,
+}
+
+/// The ONLY way tests get a home-bearing tempdir — returns the guarded
+/// form so teardown cannot be forgotten (card f122b5b5).
+pub fn daemon_tempdir() -> DaemonTempDir {
+    DaemonTempDir {
+        dir: tempfile::TempDir::new().expect("create guarded tempdir"),
+    }
+}
+
+impl DaemonTempDir {
+    pub fn path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+impl Drop for DaemonTempDir {
+    fn drop(&mut self) {
+        reap_daemons_under(self.dir.path());
+    }
+}
+
+/// Walk `root` for `daemon.pid` files and reap the processes they
+/// name: SIGTERM, poll until gone (the daemon's graceful path removes
+/// its socket + pidfile), escalate to SIGKILL at the deadline. Pid 0 /
+/// our own pid are never signalled.
+pub fn reap_daemons_under(root: &Path) {
+    let mut pids = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.file_name().and_then(|n| n.to_str()) == Some("daemon.pid") {
+                if let Some(pid) = read_pid(&path) {
+                    pids.push(pid);
+                }
+            }
+        }
+    }
+    for pid in pids {
+        reap_pid(pid);
+    }
+}
+
+fn read_pid(path: &Path) -> Option<u32> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let pid: u32 = raw.trim().parse().ok()?;
+    if pid == 0 || pid == std::process::id() {
+        return None;
+    }
+    Some(pid)
+}
+
+#[cfg(unix)]
+fn reap_pid(pid: u32) {
+    let pid = pid as libc::pid_t;
+    // SAFETY: kill with a valid signal number; worst case ESRCH.
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        // SAFETY: signal 0 = existence probe, no side effects.
+        if unsafe { libc::kill(pid, 0) } != 0 {
+            return; // gone
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    // SAFETY: as above; the daemon ignored SIGTERM long enough.
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+}
+
+#[cfg(windows)]
+fn reap_pid(pid: u32) {
+    // Best-effort forced kill; `taskkill` is present on every
+    // supported Windows. /T takes the daemon's children with it.
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .output();
+}
+
+/// Find the pid of a daemon serving a home under `root`, if any —
+/// lets tests assert both directions (daemon IS up; daemon is GONE).
+pub fn find_daemon_pid_under(root: &Path) -> Option<u32> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.file_name().and_then(|n| n.to_str()) == Some("daemon.pid") {
+                if let Some(pid) = read_pid(&path) {
+                    return Some(pid);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// True while `pid` names a live process.
+#[cfg(unix)]
+pub fn pid_alive(pid: u32) -> bool {
+    // SAFETY: signal 0 = existence probe, no side effects.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(windows)]
+pub fn pid_alive(pid: u32) -> bool {
+    std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).contains(&pid.to_string()))
+        .unwrap_or(false)
+}
+
+/// Poll until `pid` is gone, up to `budget`. Returns true if it exited.
+pub fn wait_pid_gone(pid: u32, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if !pid_alive(pid) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    !pid_alive(pid)
+}

--- a/crates/airc-cli/tests/daemon_lifecycle.rs
+++ b/crates/airc-cli/tests/daemon_lifecycle.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::process::Command;
 use std::thread;
 
-use tempfile::TempDir;
+mod common;
 
 fn airc() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -105,7 +105,7 @@ fn stop_daemon(account: &Path) {
 
 #[test]
 fn one_daemon_serves_many_tabs_through_a_full_room_lifecycle() {
-    let account = TempDir::new().expect("account tempdir");
+    let account = common::daemon_tempdir();
     let acct = account.path();
 
     // --- Launch: the first tab brings up exactly one daemon. ---
@@ -194,7 +194,7 @@ fn one_daemon_serves_many_tabs_through_a_full_room_lifecycle() {
 
 #[test]
 fn daemon_survives_shutdown_and_restart_with_durable_history_intact() {
-    let account = TempDir::new().expect("account tempdir");
+    let account = common::daemon_tempdir();
     let acct = account.path();
 
     // Durable chat into a room.

--- a/crates/airc-cli/tests/daemon_route_refresh.rs
+++ b/crates/airc-cli/tests/daemon_route_refresh.rs
@@ -17,7 +17,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use airc_lib::{endpoints_to_json, Airc, PeerSpec, RouteEndpoint};
-use tempfile::TempDir;
+mod common;
 
 fn airc_bin() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -88,8 +88,8 @@ async fn daemon_dials_stored_endpoint_without_transport_health() {
 }
 
 async fn scenario() {
-    let tmp_alice = TempDir::new().expect("alice tempdir");
-    let tmp_bob = TempDir::new().expect("bob tempdir");
+    let tmp_alice = common::daemon_tempdir();
+    let tmp_bob = common::daemon_tempdir();
     let alice_home = tmp_alice.path().join(".airc");
     let bob_home = tmp_bob.path().join(".airc");
 

--- a/crates/airc-cli/tests/daemon_teardown.rs
+++ b/crates/airc-cli/tests/daemon_teardown.rs
@@ -1,0 +1,262 @@
+//! Card f122b5b5 — the daemon-leak fix, pinned at every layer.
+//!
+//! The recurring bug: `cargo test --workspace` left airc daemon
+//! processes alive with `--home` under the OS temp dir. Each held RAM
+//! plus an event loop; one session leaked 800+, killed by hand. This
+//! suite pins the three defenses so a regression FAILS here instead of
+//! shipping.
+//!
+//! Layer 1 — RAII teardown: a daemon spawned under a guarded temp home
+//! is reaped when the guard drops (the helper only returns the guarded
+//! form, so a test can't forget). Mutation: delete the guard's Drop and
+//! `leaked_daemon_is_reaped_by_guard_drop` fails.
+//!
+//! Layer 2 — belt-and-braces self-exit: a temp-home daemon with NO
+//! client exits BY ITSELF after the idle window, catching kill-escapes
+//! (SIGKILLed runner). Mutation: disable the watchdog and
+//! `temp_home_daemon_self_exits_when_idle` fails.
+//!
+//! Layer 3 — zero-leak guard bite: the reaper finds a spawned daemon
+//! and leaves zero behind. Mutation: make the daemon skip its pidfile
+//! and `reaper_finds_and_kills_a_spawned_daemon` fails to find it.
+//!
+//! Unix-only: the reaper uses `kill(2)`; the hosted matrix runs
+//! ubuntu + macos, so all three are pinned on both.
+#![cfg(unix)]
+
+mod common;
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn airc() -> &'static str {
+    env!("CARGO_BIN_EXE_airc")
+}
+
+/// Spawn the real `airc daemon` against `home` on `socket`, hermetic
+/// (no gh rendezvous). Returns the child so the test can reason about
+/// the process even though teardown is the guard's job.
+fn spawn_daemon(home: &Path, socket: &Path, idle_ms: Option<u64>) -> Child {
+    std::fs::create_dir_all(home).expect("daemon home");
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(home.join("daemon-test.log"))
+        .expect("daemon log");
+    let stderr = log.try_clone().expect("clone log");
+    let mut command = Command::new(airc());
+    command
+        .arg("--home")
+        .arg(home)
+        .arg("daemon")
+        .arg("--socket")
+        .arg(socket)
+        .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(stderr));
+    if let Some(ms) = idle_ms {
+        command.env("AIRC_TEMP_HOME_IDLE_EXIT_MS", ms.to_string());
+    }
+    command.spawn().expect("daemon must spawn")
+}
+
+/// Poll an OWNED child until it exits, up to `budget`. Returns true if
+/// it terminated. Unlike `kill(pid, 0)`, this reaps the zombie a killed
+/// child leaves behind (the in-test daemon is our child; a *real*
+/// leaked daemon is detached + reparented to init, where the guard's
+/// `kill`-based reaper is correct). So tests confirm death through the
+/// `Child` handle; the reaper itself is still exercised for the signal.
+fn wait_child_gone(child: &mut Child, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        if Instant::now() >= deadline {
+            return matches!(child.try_wait(), Ok(Some(_)));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Wait until `<home>/daemon.pid` names a live process, or panic.
+fn wait_for_pidfile(root: &Path, budget: Duration) -> u32 {
+    let deadline = Instant::now() + budget;
+    loop {
+        if let Some(pid) = common::find_daemon_pid_under(root) {
+            if common::pid_alive(pid) {
+                return pid;
+            }
+        }
+        if Instant::now() >= deadline {
+            let log = std::fs::read_to_string(root.join(".airc").join("daemon-test.log"))
+                .unwrap_or_default();
+            panic!("daemon never wrote a live pidfile under {root:?}; log:\n{log}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Layer 1 — RAII teardown. A daemon spawned under a guarded temp home
+/// is alive while the guard lives and gone once it drops. This is THE
+/// leak the card measured.
+///
+/// MUTATION PIN: delete `impl Drop for DaemonTempDir` (or its
+/// `reap_daemons_under` call) and this test fails — the daemon
+/// survives the guard drop.
+#[test]
+fn leaked_daemon_is_reaped_by_guard_drop() {
+    let guard = common::daemon_tempdir();
+    let root = guard.path().to_path_buf();
+    let home = root.join(".airc");
+    let socket = home.join("daemon.sock");
+
+    let mut child = spawn_daemon(&home, &socket, None);
+    let pid = wait_for_pidfile(&root, Duration::from_secs(10));
+    assert!(common::pid_alive(pid), "daemon must be live before drop");
+
+    // Drop the guard — its Drop reaps every daemon under the tree.
+    drop(guard);
+
+    assert!(
+        wait_child_gone(&mut child, Duration::from_secs(8)),
+        "daemon pid {pid} must be reaped when the guarded tempdir drops"
+    );
+}
+
+/// Layer 3 bite — the reaper actively finds and kills a spawned daemon
+/// (not just "drop cleaned up"): pin that `find_daemon_pid_under`
+/// locates it and `reap_daemons_under` leaves zero behind. This is the
+/// mechanism the CI zero-leak guard relies on.
+///
+/// MUTATION PIN: make the daemon skip writing its pidfile and the
+/// reaper can't find it — `find_daemon_pid_under` returns None and the
+/// first assert fails.
+#[test]
+fn reaper_finds_and_kills_a_spawned_daemon() {
+    let guard = common::daemon_tempdir();
+    let root = guard.path().to_path_buf();
+    let home = root.join(".airc");
+    let socket = home.join("daemon.sock");
+
+    let mut child = spawn_daemon(&home, &socket, None);
+    let pid = wait_for_pidfile(&root, Duration::from_secs(10));
+
+    assert_eq!(
+        common::find_daemon_pid_under(&root),
+        Some(pid),
+        "the reaper must locate the spawned daemon by its pidfile"
+    );
+
+    common::reap_daemons_under(&root);
+
+    assert!(
+        wait_child_gone(&mut child, Duration::from_secs(8)),
+        "reap_daemons_under must leave zero temp-home daemons alive (pid {pid})"
+    );
+    // guard drop is now a no-op (already reaped) — proves idempotence.
+}
+
+/// Layer 2 — belt-and-braces self-exit. A temp-home daemon with no
+/// connected client must exit BY ITSELF after the (test-shortened)
+/// idle window, WITHOUT any teardown. This is what catches a SIGKILLed
+/// test runner whose Drop guards never ran.
+///
+/// MUTATION PIN: disable `spawn_temp_home_idle_watchdog` (return None
+/// unconditionally, or never fire the notifier) and this test fails —
+/// the daemon runs forever and `wait_pid_gone` times out.
+#[test]
+fn temp_home_daemon_self_exits_when_idle() {
+    let guard = common::daemon_tempdir();
+    let root = guard.path().to_path_buf();
+    let home = root.join(".airc");
+    let socket = home.join("daemon.sock");
+
+    // 800ms idle window — long enough the daemon binds and settles,
+    // short enough the test is quick. No client ever connects.
+    let mut child = spawn_daemon(&home, &socket, Some(800));
+    let pid = wait_for_pidfile(&root, Duration::from_secs(10));
+
+    assert!(
+        wait_child_gone(&mut child, Duration::from_secs(15)),
+        "a temp-home daemon with no client must self-exit after the idle \
+         window (card f122b5b5 belt-and-braces); pid {pid} still alive"
+    );
+
+    // And the policy named itself loudly in the log.
+    let log = std::fs::read_to_string(home.join("daemon-test.log")).unwrap_or_default();
+    assert!(
+        log.contains("temp-home idle self-exit"),
+        "the self-exit must be loud and name the policy; log:\n{log}"
+    );
+}
+
+/// Layer 4 — socket-path derivation. A daemon given an EXPLICIT temp
+/// home must place its socket UNDER that home, never under the
+/// operator's `~/.airc/runtime`. The spawn above passes an explicit
+/// `--socket` under the home; this test instead lets the CLI DERIVE
+/// the socket (the production path) and asserts where it lands.
+///
+/// MUTATION PIN: revert `resolve_socket_path`'s isolated branch to the
+/// runtime-dir placement and the derived socket escapes the home →
+/// this fails. (The pure-function form is also pinned in cli.rs unit
+/// tests; this is the end-to-end witness.)
+#[test]
+fn explicit_temp_home_keeps_its_socket_under_the_home() {
+    let guard = common::daemon_tempdir();
+    let root = guard.path().to_path_buf();
+    // An isolated home OUTSIDE any user account — `airc status`
+    // spawn-or-connects a daemon and derives its socket.
+    let home = root.join(".airc");
+
+    let out = Command::new(airc())
+        .arg("--home")
+        .arg(&home)
+        .arg("status")
+        .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+        .output()
+        .expect("airc status runs");
+    assert!(
+        out.status.success(),
+        "airc status failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Whatever socket got created, it must be under the temp root —
+    // not under any `.airc/runtime` outside it. Scan for *.sock files.
+    let socks = find_sockets_under(&root);
+    assert!(
+        !socks.is_empty(),
+        "the daemon must have created a socket under the temp home"
+    );
+    for sock in &socks {
+        assert!(
+            sock.starts_with(&root),
+            "an explicit temp home's socket must stay under the home \
+             (card f122b5b5 socket-path bug), found {sock:?} outside {root:?}"
+        );
+    }
+}
+
+fn find_sockets_under(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("sock") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}

--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -11,7 +11,7 @@ fn airc_core() -> &'static str {
 
 #[test]
 fn events_list_filters_by_kind_and_header_prefix() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -48,7 +48,7 @@ fn events_list_filters_by_kind_and_header_prefix() {
 
 #[test]
 fn events_list_json_emits_machine_readable_contract() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -102,7 +102,7 @@ fn events_list_json_emits_machine_readable_contract() {
 
 #[test]
 fn send_receipt_distinguishes_zero_paired_peers_without_lying_about_delivery() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);

--- a/crates/airc-cli/tests/identity_commands.rs
+++ b/crates/airc-cli/tests/identity_commands.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use base64::{engine::general_purpose, Engine};
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -59,7 +59,7 @@ fn identity_pretty_defaults_unset_fields() {
 
 #[test]
 fn init_as_records_agent_name() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path();
 
     let init = run_ok(home, &["init", "--as", "codex"], "");
@@ -71,7 +71,7 @@ fn init_as_records_agent_name() {
 
 #[test]
 fn init_uses_airc_agent_name_env_when_as_is_absent() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path();
 
     let output = Command::new(airc_core())
@@ -94,7 +94,7 @@ fn init_uses_airc_agent_name_env_when_as_is_absent() {
 
 #[test]
 fn identity_set_link_and_show_round_trip_through_store() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path();
 
     run_ok(
@@ -141,7 +141,7 @@ fn identity_set_link_and_show_round_trip_through_store() {
 
 #[test]
 fn identity_import_continuum_merges_into_store_without_clearing_status() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path();
 
     run_ok(
@@ -170,7 +170,7 @@ fn identity_import_continuum_merges_into_store_without_clearing_status() {
 
 #[test]
 fn legacy_identity_commands_bootstrap_lookup_and_sign() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path();
     let identity_dir = home.join("identity");
     let peers_dir = home.join("peers");
@@ -246,7 +246,7 @@ fn legacy_identity_commands_bootstrap_lookup_and_sign() {
 
 #[test]
 fn legacy_envelope_wrap_encrypts_message_field() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path();
     let alice = home.join("alice");
     let bob = home.join("bob");

--- a/crates/airc-cli/tests/inbox_json.rs
+++ b/crates/airc-cli/tests/inbox_json.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -18,7 +18,7 @@ fn inbox_json_returns_count_events_cursor_shape() {
     // Just asserts the shape — the bare `airc init` flow may
     // emit lifecycle events (RoomJoined, presence beacons)
     // that land in inbox, so we don't pin a specific count.
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -50,7 +50,7 @@ fn inbox_json_returns_count_events_cursor_shape() {
 
 #[test]
 fn inbox_json_carries_events_plus_paging_cursor() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);

--- a/crates/airc-cli/tests/owner_core_cli_dogfood.rs
+++ b/crates/airc-cli/tests/owner_core_cli_dogfood.rs
@@ -10,7 +10,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use tempfile::TempDir;
+mod common;
 
 fn airc() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -58,7 +58,7 @@ fn any_frames_jsonl(dir: &Path) -> Option<PathBuf> {
 
 #[test]
 fn same_machine_round_trips_via_daemon_with_no_frames_jsonl() {
-    let account = TempDir::new().expect("account tempdir");
+    let account = common::daemon_tempdir();
 
     // One scope sends; another scope under the SAME $HOME reads it back —
     // they share the one machine daemon, so the message converges.

--- a/crates/airc-cli/tests/peer_commands.rs
+++ b/crates/airc-cli/tests/peer_commands.rs
@@ -20,7 +20,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -32,7 +32,7 @@ fn airc_core() -> &'static str {
 /// scope. Each call returns a distinct spec — keeps the tests honest
 /// about working with real key material.
 fn mint_peer_spec(seed: &str) -> String {
-    let probe = TempDir::new().expect("probe tempdir");
+    let probe = common::daemon_tempdir();
     let probe_home = probe.path().join(seed);
     let output = Command::new(airc_core())
         .arg("--home")
@@ -115,7 +115,7 @@ fn peer_add_without_tier_flag_defaults_to_untrusted() {
     // Card 34942ec1 Sub-A contract: a fresh peer has tier=Untrusted
     // until something explicitly promotes it. Sub-C must not change
     // that default — existing scripts/sessions stay correct.
-    let ws = TempDir::new().expect("tempdir");
+    let ws = common::daemon_tempdir();
     let home = ws.path().join("agent");
     run_ok(&home, &["init"]);
     let spec = mint_peer_spec("seed-1");
@@ -137,7 +137,7 @@ fn peer_add_with_tier_flag_persists_explicit_tier() {
     // V1 explicit arm: --tier=friend lands the row at Friend, not
     // the default. This is what Joel + Toby will use to pin trust
     // on each other's machine accounts.
-    let ws = TempDir::new().expect("tempdir");
+    let ws = common::daemon_tempdir();
     let home = ws.path().join("agent");
     run_ok(&home, &["init"]);
     let spec = mint_peer_spec("seed-2");
@@ -158,7 +158,7 @@ fn peer_add_accepts_every_trust_tier_variant() {
     // declares must be reachable from the CLI. Forgetting to wire
     // a new variant into the clap value_enum would silently fall
     // through to "default-Untrusted" without this test.
-    let ws = TempDir::new().expect("tempdir");
+    let ws = common::daemon_tempdir();
     let home = ws.path().join("agent");
     run_ok(&home, &["init"]);
 
@@ -194,7 +194,7 @@ fn peer_set_tier_updates_existing_peer() {
     // V2 happy path. Sub-B shipped the store-side
     // set_peer_trust_tier; Sub-C is the CLI surface that consumers
     // (Joel manually pinning Friend on Toby) reach for.
-    let ws = TempDir::new().expect("tempdir");
+    let ws = common::daemon_tempdir();
     let home = ws.path().join("agent");
     run_ok(&home, &["init"]);
     let spec = mint_peer_spec("seed-3");
@@ -228,7 +228,7 @@ fn peer_set_tier_refuses_unknown_peer() {
     // Ok(None) when the peer is missing; the CLI must surface this
     // as a non-zero exit with an explanatory error — silently doing
     // nothing would be misleading ("did it work? did it not?").
-    let ws = TempDir::new().expect("tempdir");
+    let ws = common::daemon_tempdir();
     let home = ws.path().join("agent");
     run_ok(&home, &["init"]);
 
@@ -254,7 +254,7 @@ fn peer_set_tier_is_idempotent_when_already_at_target() {
     // marker. Sub-B's set_peer_trust_tier already shipped this at
     // the store layer; Sub-C must not crash or claim a change
     // happened when nothing did.
-    let ws = TempDir::new().expect("tempdir");
+    let ws = common::daemon_tempdir();
     let home = ws.path().join("agent");
     run_ok(&home, &["init"]);
     let spec = mint_peer_spec("seed-4");
@@ -278,7 +278,7 @@ fn peer_list_json_exposes_tier_field() {
     // off this output to build their routing tables. Without
     // --json, the substrate forces them to scrape human-format
     // text — guaranteed to break. JSON shape is the contract.
-    let ws = TempDir::new().expect("tempdir");
+    let ws = common::daemon_tempdir();
     let home = ws.path().join("agent");
     run_ok(&home, &["init"]);
     let spec_friend = mint_peer_spec("seed-5");

--- a/crates/airc-cli/tests/publish_command.rs
+++ b/crates/airc-cli/tests/publish_command.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -15,7 +15,7 @@ fn airc_core() -> &'static str {
 
 #[test]
 fn publish_emits_json_receipt_with_event_id_and_channel() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -55,7 +55,7 @@ fn publish_emits_json_receipt_with_event_id_and_channel() {
 
 #[test]
 fn publish_refuses_unsubscribed_room_with_clear_error() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -82,7 +82,7 @@ fn publish_refuses_unsubscribed_room_with_clear_error() {
 
 #[test]
 fn publish_requires_one_body_source() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);

--- a/crates/airc-cli/tests/registry_hermetic.rs
+++ b/crates/airc-cli/tests/registry_hermetic.rs
@@ -16,6 +16,8 @@
 //! ubuntu + macos, so the gate is pinned on both.
 #![cfg(unix)]
 
+mod common;
+
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -117,7 +119,7 @@ fn sync_command(home: &Path, stub: &StubGh) -> Command {
 /// must record zero rendezvous calls.
 #[test]
 fn registry_sync_honors_disable_env_and_publishes_nothing() {
-    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp = common::daemon_tempdir();
     let stub = StubGh::install(tmp.path());
     let home = tmp.path().join("scope/.airc");
     std::fs::create_dir_all(&home).expect("home");
@@ -153,7 +155,7 @@ fn registry_sync_honors_disable_env_and_publishes_nothing() {
 /// still refuse, loudly, with zero rendezvous calls.
 #[test]
 fn registry_sync_refuses_temp_home_even_without_env() {
-    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp = common::daemon_tempdir();
     let stub = StubGh::install(tmp.path());
     let home = tmp.path().join("scope/.airc");
     std::fs::create_dir_all(&home).expect("home");
@@ -236,7 +238,7 @@ fn wait_for_log(home: &Path, needle: &str, budget: Duration) -> String {
 /// naming the env gate, and never touches gh.
 #[test]
 fn daemon_with_disable_env_never_runs_registry_loop() {
-    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp = common::daemon_tempdir();
     let stub = StubGh::install(tmp.path());
     let home = tmp.path().join("scope/.airc");
     std::fs::create_dir_all(&home).expect("home");
@@ -265,7 +267,7 @@ fn daemon_with_disable_env_never_runs_registry_loop() {
 /// loop loudly.
 #[test]
 fn daemon_with_temp_home_never_runs_registry_loop() {
-    let tmp = tempfile::tempdir().expect("tempdir");
+    let tmp = common::daemon_tempdir();
     let stub = StubGh::install(tmp.path());
     let home = tmp.path().join("scope/.airc");
     std::fs::create_dir_all(&home).expect("home");

--- a/crates/airc-cli/tests/transport_commands.rs
+++ b/crates/airc-cli/tests/transport_commands.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use tempfile::TempDir;
+mod common;
 
 fn airc() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -10,7 +10,7 @@ fn airc() -> &'static str {
 
 #[test]
 fn transport_health_reports_route_snapshot_from_substrate() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
 
     let output = run_ok(workspace.path(), &["transport", "health"]);
 
@@ -25,7 +25,7 @@ fn transport_health_reports_route_snapshot_from_substrate() {
 
 #[test]
 fn transport_health_degraded_only_is_silent_when_routes_are_clean() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
 
     let output = run_ok(
         workspace.path(),
@@ -37,7 +37,7 @@ fn transport_health_degraded_only_is_silent_when_routes_are_clean() {
 
 #[test]
 fn transport_health_quiet_succeeds_when_routes_are_clean() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
 
     let output = run_raw(
         workspace.path(),

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -16,7 +16,7 @@ fn airc_core() -> &'static str {
 
 #[test]
 fn work_create_claim_release_projects_on_board() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -98,7 +98,7 @@ fn work_create_claim_release_projects_on_board() {
 
 #[test]
 fn work_seed_is_idempotent_for_manager_candidates() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -150,7 +150,7 @@ fn work_seed_is_idempotent_for_manager_candidates() {
 
 #[test]
 fn work_board_surfaces_stale_claims() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -210,7 +210,7 @@ fn work_board_surfaces_stale_claims() {
 
 #[test]
 fn work_availability_projects_to_board() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -244,7 +244,7 @@ fn work_availability_projects_to_board() {
 
 #[test]
 fn work_next_surfaces_availability_and_idle_guidance() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -275,7 +275,7 @@ fn work_next_surfaces_availability_and_idle_guidance() {
 
 #[test]
 fn work_roster_surfaces_availability_and_claims() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -332,7 +332,7 @@ fn work_roster_surfaces_availability_and_claims() {
 
 #[test]
 fn work_next_suggests_claimable_priority_cards() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -374,7 +374,7 @@ fn work_next_suggests_claimable_priority_cards() {
 
 #[test]
 fn work_close_removes_card_from_claimable_next() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -407,7 +407,7 @@ fn work_close_removes_card_from_claimable_next() {
 
 #[test]
 fn work_next_ignores_stale_claim_after_card_is_closed() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -457,7 +457,7 @@ fn work_next_ignores_stale_claim_after_card_is_closed() {
 
 #[test]
 fn lane_create_status_and_state_drive_work_projection() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -506,7 +506,7 @@ fn lane_create_status_and_state_drive_work_projection() {
 
 #[test]
 fn lane_manager_claim_status_and_release_project_from_board() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -547,7 +547,7 @@ fn work_claim_refuses_when_cwd_outside_lease_zone() {
     // test fixture's $HOME is a tempdir, and cwd is the source tree
     // (definitely not inside that tempdir's lease zone), so the
     // bare claim should fail with a clear refusal.
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
@@ -596,7 +596,7 @@ fn work_claim_refuses_when_cwd_outside_lease_zone() {
 
 #[test]
 fn work_board_empty_state_is_explicit() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);

--- a/crates/airc-cli/tests/workspace_commands.rs
+++ b/crates/airc-cli/tests/workspace_commands.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -11,7 +11,7 @@ fn airc_core() -> &'static str {
 
 #[test]
 fn workspace_request_allocate_heartbeat_release_projects_on_list() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);

--- a/crates/airc-cli/tests/worktree_lane_commands.rs
+++ b/crates/airc-cli/tests/worktree_lane_commands.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::process::Command;
 
 use serde_json::Value;
-use tempfile::TempDir;
+mod common;
 
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
@@ -12,7 +12,7 @@ fn airc_core() -> &'static str {
 
 #[test]
 fn worktree_lane_registry_round_trips_from_cli() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let registry = workspace.path().join("lanes.jsonl");
 
     run_ok(
@@ -68,7 +68,7 @@ fn worktree_lane_registry_round_trips_from_cli() {
 
 #[test]
 fn worktree_lane_slug_and_abs_path_match_shell_contract() {
-    let workspace = TempDir::new().expect("tempdir");
+    let workspace = common::daemon_tempdir();
     let cwd = workspace.path();
 
     let slug = run_ok(&["worktree-lane", "slug", "#123: Codex Lane!"], None);

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -22,6 +22,7 @@
 //! - [`filter`]     — self-echo filtering for multi-tab consumers
 //! - [`headers`]    — envelope headers for routing/filtering without body parse
 //! - [`humanhash`]  — stable hash mnemonics for invite/client labels
+//! - [`temp_home`]  — temp-rooted scope-home detection (hermetic test daemons)
 //!
 //! Every public type a consumer needs is re-exported at the crate root so
 //! `use airc_core::Identity;` works without knowing the module split.
@@ -38,6 +39,7 @@ pub mod identity;
 pub mod ids;
 pub mod persona;
 pub mod receipt;
+pub mod temp_home;
 pub mod transcript;
 
 // Re-exports — the public API surface. Callers that want stable imports
@@ -55,4 +57,5 @@ pub use identity::Identity;
 pub use ids::{ClientId, ContentHash, EventId, FileId, PeerId, RoomId};
 pub use persona::{PersonaCapabilities, PersonaCapabilitiesError, PERSONA_CAPABILITIES_KEY};
 pub use receipt::{Receipt, ReceiptKind};
+pub use temp_home::scope_home_is_temp_rooted;
 pub use transcript::{MentionTarget, TranscriptEvent, TranscriptKind};

--- a/crates/airc-core/src/temp_home.rs
+++ b/crates/airc-core/src/temp_home.rs
@@ -1,0 +1,104 @@
+//! Temp-rooted scope-home detection (#1150, card d793c242).
+//!
+//! A scope home rooted under a temp directory is the signature of a
+//! hermetic test / CI daemon — NEVER a production scope. This single
+//! definition is consulted by every layer that must treat such scopes
+//! differently:
+//!
+//!   - `airc-lib`'s account-registry publish/refresh gates (the
+//!     original #1150 consumer — temp daemons must never publish to
+//!     the production gh rendezvous).
+//!   - `airc-daemon`'s temp-home idle self-exit watchdog (card
+//!     f122b5b5 — a daemon whose home is temp-rooted exits on its own
+//!     after an idle window so killed test runners can't strand it).
+//!
+//! It lives in `airc-core` (std-only, no deps) because both crates
+//! above need it and `airc-daemon` must not depend on `airc-lib`.
+
+use std::path::Path;
+
+/// True when `scope_home` is rooted under a temp directory — the
+/// signature of a hermetic test / CI daemon, NEVER a production scope.
+///
+/// Two layers, because this is consulted on BOTH sides of the wire:
+///
+/// 1. **Local resolution** (publish gate / self-exit policy):
+///    canonicalized-prefix match against this machine's
+///    `std::env::temp_dir()` — the same check `machine_account_home`
+///    uses for state isolation (card b0a81c31).
+/// 2. **Cross-platform markers** (reader hygiene): a beacon read from
+///    the rendezvous carries a `scope_home` minted on a DIFFERENT
+///    machine/OS, where our local `temp_dir()` prefix is meaningless.
+///    Recognize the well-known temp roots of every platform airc runs
+///    on: live evidence for card d793c242 was a beacon with scope_home
+///    `C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc` published
+///    to the production joelteply rendezvous.
+pub fn scope_home_is_temp_rooted(scope_home: &Path) -> bool {
+    // Layer 1: this machine's temp root (canonicalize both sides so
+    // macOS's `/tmp` -> `/private/tmp` symlink can't dodge the check).
+    let temp = std::env::temp_dir();
+    let temp = temp.canonicalize().unwrap_or(temp);
+    let resolved = scope_home
+        .canonicalize()
+        .unwrap_or_else(|_| scope_home.to_path_buf());
+    if resolved.starts_with(&temp) {
+        return true;
+    }
+
+    // Layer 2: cross-platform markers, for paths minted elsewhere.
+    // Normalize separators + case so `C:\Users\…\AppData\Local\Temp\…`
+    // and `/tmp/…` both land in one comparison space.
+    let lossy = scope_home
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    lossy == "/tmp"
+        || lossy.starts_with("/tmp/")
+        || lossy.starts_with("/private/tmp/")
+        || lossy.starts_with("/var/folders/")
+        || lossy.starts_with("/private/var/folders/")
+        || lossy.contains("/appdata/local/temp/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn local_temp_dir_is_temp_rooted() {
+        let scope = std::env::temp_dir().join("airc-test-scope/.airc");
+        assert!(scope_home_is_temp_rooted(&scope));
+    }
+
+    #[test]
+    fn cross_platform_markers_are_temp_rooted() {
+        for marker in [
+            "/tmp/x/.airc",
+            "/private/tmp/x/.airc",
+            "/var/folders/zz/abc/T/.tmpX/.airc",
+            "/private/var/folders/zz/abc/T/.tmpX/.airc",
+            "C:\\Users\\green\\AppData\\Local\\Temp\\tmp.Y\\.airc",
+        ] {
+            assert!(
+                scope_home_is_temp_rooted(&PathBuf::from(marker)),
+                "{marker} must be recognized as temp-rooted"
+            );
+        }
+    }
+
+    #[test]
+    fn production_homes_are_not_temp_rooted() {
+        for home in [
+            "/Users/jane/.airc",
+            "/Users/jane/Development/airc/.airc",
+            "/home/runner/work/airc/airc/.airc",
+            "C:\\Users\\green\\.airc",
+        ] {
+            assert!(
+                !scope_home_is_temp_rooted(&PathBuf::from(home)),
+                "{home} must NOT be recognized as temp-rooted"
+            );
+        }
+    }
+}

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -14,7 +14,9 @@
 //! on Unix; no-op on Windows) and returns.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 use futures::StreamExt;
@@ -76,11 +78,26 @@ impl From<std::io::Error> for DaemonError {
 
 /// Run the daemon: bind the IPC listener, serve connections until
 /// shutdown. Returns when the shutdown notifier fires (typically from
-/// a Stop request handler) or the listener errors.
+/// a Stop request handler), the temp-home idle watchdog trips (card
+/// f122b5b5), or the listener errors.
 pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), DaemonError> {
     let _guard = DaemonBindGuard::acquire(&socket_path)?;
     cleanup_stale_socket(&socket_path).map_err(DaemonError::StaleSocket)?;
     let listener = IpcListener::bind(&socket_path).await?;
+
+    // Card f122b5b5: write `<home>/daemon.pid` once the bind guard is
+    // held (only the WINNING daemon for this socket writes), so test
+    // harnesses and operators have a portable kill handle for daemons
+    // they spawned. Removed on graceful exit by the guard below.
+    let _pid_file = PidFileGuard::write(&state.home);
+
+    // Card f122b5b5 belt-and-braces: a daemon whose home is temp-rooted
+    // (#1150 detection) is a hermetic test daemon — if its test runner
+    // dies without tearing it down (SIGKILL escapes every Drop guard),
+    // it must exit BY ITSELF once no client has been connected for the
+    // idle window. Production homes never start this watchdog.
+    let idle_tracker = IdleTracker::new();
+    let watchdog = spawn_temp_home_idle_watchdog(&state, &idle_tracker);
 
     // Keep ONE `Notified` future alive across loop iterations. `select!`
     // otherwise creates and drops a fresh `notified()` each turn, leaving
@@ -102,7 +119,11 @@ pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), Da
             accept = listener.accept() => {
                 let stream = accept?;
                 let state = state.clone();
+                let connection = idle_tracker.connection_opened();
                 tokio::spawn(async move {
+                    // Held for the connection's whole life; dropping it
+                    // stamps the idle clock for the watchdog.
+                    let _connection = connection;
                     if let Err(error) = handle_connection(stream, state).await {
                         StderrJsonDiagnosticSink.emit(
                             DiagnosticEvent::error(
@@ -122,7 +143,170 @@ pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), Da
     // socket file; on Windows named pipes are GCd when handles
     // close, so the call is a no-op.
     listener.cleanup();
+    if let Some(watchdog) = watchdog {
+        watchdog.abort();
+    }
     Ok(())
+}
+
+/// Default idle window for the temp-home self-exit policy: five
+/// minutes without a single connected client. Long enough that a
+/// healthy test (bounded waits, card d2ba719c) never trips it;
+/// short enough that an orphaned daemon frees its RAM + event loop
+/// promptly instead of accumulating by the hundreds (card f122b5b5:
+/// 800+ leaked temp-home daemons killed by hand in one session).
+const TEMP_HOME_IDLE_EXIT_DEFAULT: Duration = Duration::from_secs(300);
+
+/// Env override for the idle window, in milliseconds
+/// (`AIRC_TEMP_HOME_IDLE_EXIT_MS`). Exists so the self-exit tests can
+/// run the policy in seconds, not minutes; a malformed value falls
+/// back to the default LOUDLY rather than disabling the policy.
+const TEMP_HOME_IDLE_EXIT_ENV: &str = "AIRC_TEMP_HOME_IDLE_EXIT_MS";
+
+fn temp_home_idle_exit_window() -> Duration {
+    let Some(raw) = std::env::var_os(TEMP_HOME_IDLE_EXIT_ENV) else {
+        return TEMP_HOME_IDLE_EXIT_DEFAULT;
+    };
+    match raw.to_str().and_then(|v| v.trim().parse::<u64>().ok()) {
+        Some(ms) if ms > 0 => Duration::from_millis(ms),
+        _ => {
+            eprintln!(
+                "airc daemon: ignoring malformed {TEMP_HOME_IDLE_EXIT_ENV}={raw:?} — \
+                 using default {TEMP_HOME_IDLE_EXIT_DEFAULT:?}"
+            );
+            TEMP_HOME_IDLE_EXIT_DEFAULT
+        }
+    }
+}
+
+/// Card f122b5b5: when the daemon's home is temp-rooted (#1150's
+/// detection — hermetic test/CI daemon, never production), spawn a
+/// watchdog that fires the shutdown notifier once no client has been
+/// connected for the idle window. Returns `None` for production homes
+/// — the policy cannot touch them by construction.
+fn spawn_temp_home_idle_watchdog(
+    state: &Arc<DaemonState>,
+    tracker: &Arc<IdleTracker>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if !airc_core::scope_home_is_temp_rooted(&state.home) {
+        return None;
+    }
+    let window = temp_home_idle_exit_window();
+    eprintln!(
+        "airc daemon: temp-home idle self-exit policy ACTIVE (card f122b5b5) — home {} is \
+         temp-rooted; exiting after {window:?} with no connected client \
+         (override: {TEMP_HOME_IDLE_EXIT_ENV})",
+        state.home.display()
+    );
+    let state = state.clone();
+    let tracker = tracker.clone();
+    // Poll often enough that a test-configured sub-second window trips
+    // promptly, but never busier than 20Hz and never lazier than 5s.
+    let poll = (window / 10).clamp(Duration::from_millis(50), Duration::from_secs(5));
+    Some(tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(poll).await;
+            let Some(idle) = tracker.idle_for() else {
+                continue; // a client is connected — never exit under it
+            };
+            if idle >= window {
+                eprintln!(
+                    "airc daemon: temp-home idle self-exit (card f122b5b5) — no client \
+                     connected for {idle:?} (window {window:?}) and home {} is temp-rooted; \
+                     shutting down",
+                    state.home.display()
+                );
+                state.shutdown.notify_waiters();
+                return;
+            }
+        }
+    }))
+}
+
+/// Tracks live connections + the instant the daemon last went idle,
+/// for the temp-home self-exit watchdog. Time is stored as millis
+/// elapsed since `start` so the hot paths stay lock-free atomics.
+struct IdleTracker {
+    start: Instant,
+    connections: AtomicUsize,
+    last_activity_ms: AtomicU64,
+}
+
+impl IdleTracker {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            start: Instant::now(),
+            connections: AtomicUsize::new(0),
+            last_activity_ms: AtomicU64::new(0),
+        })
+    }
+
+    /// Register a newly accepted connection. The returned guard MUST
+    /// live as long as the connection task — its Drop is what marks
+    /// the connection closed and stamps the idle clock.
+    fn connection_opened(self: &Arc<Self>) -> ConnectionGuard {
+        self.connections.fetch_add(1, Ordering::SeqCst);
+        ConnectionGuard(self.clone())
+    }
+
+    /// `Some(duration since the daemon last had a client)` when no
+    /// client is connected; `None` while any connection is live.
+    fn idle_for(&self) -> Option<Duration> {
+        if self.connections.load(Ordering::SeqCst) > 0 {
+            return None;
+        }
+        let last = Duration::from_millis(self.last_activity_ms.load(Ordering::SeqCst));
+        Some(self.start.elapsed().saturating_sub(last))
+    }
+
+    fn stamp_activity(&self) {
+        let elapsed_ms = u64::try_from(self.start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.last_activity_ms.store(elapsed_ms, Ordering::SeqCst);
+    }
+}
+
+/// Drop = connection closed: decrement the live count and stamp the
+/// idle clock so the watchdog's window starts from the LAST disconnect,
+/// not daemon start.
+struct ConnectionGuard(Arc<IdleTracker>);
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.0.stamp_activity();
+        self.0.connections.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Card f122b5b5: `<home>/daemon.pid` — written while the daemon runs,
+/// removed on graceful exit. Best-effort and informational: readers
+/// (test teardown guards, operators) must verify liveness before
+/// trusting it. Failure to write is loud but non-fatal — a daemon that
+/// can't record its pid still serves.
+struct PidFileGuard {
+    path: PathBuf,
+}
+
+impl PidFileGuard {
+    fn write(home: &Path) -> Option<Self> {
+        let path = home.join("daemon.pid");
+        match std::fs::write(&path, format!("{}\n", std::process::id())) {
+            Ok(()) => Some(Self { path }),
+            Err(error) => {
+                eprintln!(
+                    "airc daemon: could not write pid file {} ({error}) — teardown \
+                     guards will not find this daemon by pid",
+                    path.display()
+                );
+                None
+            }
+        }
+    }
+}
+
+impl Drop for PidFileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 struct DaemonBindGuard {

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -11,7 +11,6 @@
 //! media, and model payloads are explicitly out of scope.
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -29,47 +28,12 @@ use crate::Airc;
 
 pub const ACCOUNT_REGISTRY_SCHEMA_VERSION: u16 = 1;
 
-/// True when `scope_home` is rooted under a temp directory — the
-/// signature of a hermetic test / CI daemon, NEVER a production scope.
-///
-/// Two layers, because this is consulted on BOTH sides of the wire:
-///
-/// 1. **Local resolution** (publish gate): canonicalized-prefix match
-///    against this machine's `std::env::temp_dir()` — the same check
-///    `machine_account_home` uses for state isolation (card b0a81c31).
-/// 2. **Cross-platform markers** (reader hygiene): a beacon read from
-///    the rendezvous carries a `scope_home` minted on a DIFFERENT
-///    machine/OS, where our local `temp_dir()` prefix is meaningless.
-///    Recognize the well-known temp roots of every platform airc runs
-///    on: live evidence for card d793c242 was a beacon with scope_home
-///    `C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc` published
-///    to the production joelteply rendezvous.
-pub fn scope_home_is_temp_rooted(scope_home: &Path) -> bool {
-    // Layer 1: this machine's temp root (canonicalize both sides so
-    // macOS's `/tmp` -> `/private/tmp` symlink can't dodge the check).
-    let temp = std::env::temp_dir();
-    let temp = temp.canonicalize().unwrap_or(temp);
-    let resolved = scope_home
-        .canonicalize()
-        .unwrap_or_else(|_| scope_home.to_path_buf());
-    if resolved.starts_with(&temp) {
-        return true;
-    }
-
-    // Layer 2: cross-platform markers, for paths minted elsewhere.
-    // Normalize separators + case so `C:\Users\…\AppData\Local\Temp\…`
-    // and `/tmp/…` both land in one comparison space.
-    let lossy = scope_home
-        .to_string_lossy()
-        .replace('\\', "/")
-        .to_ascii_lowercase();
-    lossy == "/tmp"
-        || lossy.starts_with("/tmp/")
-        || lossy.starts_with("/private/tmp/")
-        || lossy.starts_with("/var/folders/")
-        || lossy.starts_with("/private/var/folders/")
-        || lossy.contains("/appdata/local/temp/")
-}
+/// Temp-rooted scope-home detection (#1150). The definition moved to
+/// [`airc_core::temp_home`] (card f122b5b5) so `airc-daemon`'s idle
+/// self-exit watchdog consults the SAME check without depending on
+/// this crate; re-exported here so existing callers keep their
+/// import path.
+pub use airc_core::scope_home_is_temp_rooted;
 
 /// Outcome of [`merge_registry_documents`]: the merged view plus the
 /// hygiene counters the caller must surface (count, not full dump).
@@ -573,6 +537,7 @@ mod tests {
     use airc_core::PeerId;
     use airc_protocol::PeerKeypair;
     use std::net::SocketAddr;
+    use std::path::Path;
     use tempfile::tempdir;
 
     fn mesh() -> MeshIdentity {


### PR DESCRIPTION
## Card f122b5b5 — test harness leaks daemons

`cargo test --workspace` left airc daemon processes alive with `--home` under the OS temp dir. Counts measured this session: ~40, 131, 405+86, 154 per run — **800+ killed by hand**. Each leaked daemon held RAM + an event loop on the underpowered coordination Mac, and one was observed planting its socket under the PRODUCTION `~/.airc/runtime` (stale `airc-10e8167b5d5b936d-v5.sock`).

### Spawn-site inventory (every distinct path)
- **IMPLICIT (the bulk leak):** almost every `airc <verb>` an integration test runs against a tempdir home calls `ensure_daemon_running`, which spawn-or-connects a **DETACHED** daemon (`setsid` / `DETACHED_PROCESS`). It outlives the test by design (it's a daemon) and **no guard tracked it**. This is the leak the counts came from.
- **EXPLICIT subprocess:** `tests/daemon_route_refresh.rs`, `tests/registry_hermetic.rs` — each already had a kill-on-Drop `DaemonGuard` for the daemon it spawns directly.
- **IN-PROCESS:** `airc-lib tests/common` `DaemonFixture` — already aborts its `JoinHandle` on Drop (no subprocess).

### The four layers

**1. RAII teardown (`crates/airc-cli/tests/common/mod.rs`).** Tests now hold a `DaemonTempDir` instead of a raw `TempDir`; the helper `daemon_tempdir()` ONLY returns the guarded form, so teardown cannot be forgotten. Its `Drop` walks the tree for the `daemon.pid` each daemon now writes (`PidFileGuard`, `airc-daemon`) and reaps them `SIGTERM → poll-gone → SIGKILL`. Every CLI test file migrated to it.

**2. Belt-and-braces self-exit (`crates/airc-daemon/src/server.rs`).** A daemon whose home is temp-rooted exits BY ITSELF after an idle window with no connected client (loud one-line log naming the policy). This catches kill-escapes — a SIGKILLed test runner whose Drop guards never ran. Production homes never arm it. The temp detection (#1150) was hoisted to `airc-core::temp_home::scope_home_is_temp_rooted` so `airc-daemon` can reuse it without depending on `airc-lib` (`airc-lib` re-exports it; no behaviour change). Window overridable via `AIRC_TEMP_HOME_IDLE_EXIT_MS` (tests use ~800ms; default 5 min).

**3. Socket-path bug (`crates/airc-cli/src/cli.rs`, `runtime_dir.rs`).** An explicit temp home no longer places its socket under the user's `~/.airc/runtime`. The isolated-scope branch of `resolve_socket_path` derived the socket NAME from a project-root hash but placed the FILE in `runtime_dir` (= `~/.airc/runtime`) — exactly how the stale production socket appeared. The socket now derives from the daemon's own home; same-home processes still rendezvous, parallel isolated scopes still can't collide. `project_socket_path` (the runtime-dir placement) is removed.

**4. CI zero-leak guard (`.github/workflows/rust.yml`).** A `ps`-based step after `cargo test` (ubuntu + macos; skipped on Windows) FAILS the leg if any `airc` daemon with a temp-rooted `--home` survives the suite — the card's acceptance, enforced. `crates/airc-cli/tests/daemon_teardown.rs` additionally pins all four layers in-suite.

### Mutation evidence (fresh re-runs on this branch)
| Mutation | Test | Result |
|---|---|---|
| Disable `DaemonTempDir::drop` reap | `leaked_daemon_is_reaped_by_guard_drop` | **FAILED** (101) |
| `spawn_temp_home_idle_watchdog` → `None` | `temp_home_daemon_self_exits_when_idle` | **FAILED** (101, times out) |
| Revert socket derivation to runtime-dir | `explicit_temp_home_never_places_socket_under_user_runtime_dir` | **FAILED** (101) |

Each reverted cleanly (working tree matches the commit) and all four `daemon_teardown` tests pass unmutated.

### Verification
- Full `cargo test --workspace -- --skip codex_hook`: **1203 passed, 0 failed**.
- Acceptance: after the full suite, **zero** temp-home airc daemons remained (the one kill-escaped straggler from an aborted run was the exact Layer-2 case and was reaped).
- Production gate green: `cargo fmt --all --check`; clippy production no-silent-fallback gate (`-D unwrap_used/expect_used/panic/todo/unimplemented/wildcard_enum_match_arm`); clippy `--all-targets -D warnings`; rust quality guard.

card f122b5b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
