### PR TITLE
fix(test-harness): ps-scan + multi-sweep daemon reaper — close macOS leak from #1159/#1160 (card f122b5b5)

### DIFF
--- a/crates/airc-cli/tests/common/mod.rs
+++ b/crates/airc-cli/tests/common/mod.rs
@@ -53,11 +53,50 @@ impl Drop for DaemonTempDir {
     }
 }
 
-/// Walk `root` for `daemon.pid` files and reap the processes they
-/// name: SIGTERM, poll until gone (the daemon's graceful path removes
-/// its socket + pidfile), escalate to SIGKILL at the deadline. Pid 0 /
-/// our own pid are never signalled.
+/// Reap every airc daemon belonging to `root`: SIGTERM, poll until
+/// gone (the daemon's graceful path removes its socket + pidfile),
+/// escalate to SIGKILL at the deadline. Pid 0 / our own pid are never
+/// signalled.
+///
+/// TWO discovery sources, unioned, because a daemon's `daemon.pid`
+/// lands in `machine_account_home(home)` — which, depending on whether
+/// the spawning process had `HOME` pointed at the tempdir, may be
+/// `<root>/.airc`, `<scope>/.airc`, or the isolated scope itself. The
+/// pid-file walk catches the common cases, but a `ps`-scan for any
+/// `airc … daemon` whose `--home`/`--socket` argument lives under
+/// `root` is the belt-and-braces that catches the rest (the macOS-only
+/// isolated-`codex`-scope leak the CI guard found). Process scan is
+/// Unix-only; Windows relies on the pid-file walk + the daemon's own
+/// temp-home self-exit.
 pub fn reap_daemons_under(root: &Path) {
+    // A few bounded sweeps, because a daemon spawned by a DETACHED
+    // grandchild (`ensure_daemon_running` → `setsid`) can appear a beat
+    // AFTER the test body returns — on a loaded CI runner it may not
+    // exist yet at the first sweep (the macOS race the zero-leak guard
+    // caught). Re-scan a couple times with a short settle so a
+    // late-arriving daemon is still reaped. Stops early once a sweep
+    // finds nothing.
+    for sweep in 0..4 {
+        let mut pids = pids_from_pidfiles(root);
+        pids.extend(pids_from_process_scan(root));
+        pids.sort_unstable();
+        pids.dedup();
+        if pids.is_empty() {
+            if sweep > 0 {
+                return; // a clean follow-up sweep — nothing late arrived
+            }
+        } else {
+            for pid in pids {
+                reap_pid(pid);
+            }
+        }
+        // Brief settle for a detached daemon mid-spawn to become visible.
+        std::thread::sleep(Duration::from_millis(150));
+    }
+}
+
+/// `daemon.pid` files anywhere under `root`.
+fn pids_from_pidfiles(root: &Path) -> Vec<u32> {
     let mut pids = Vec::new();
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
@@ -75,9 +114,47 @@ pub fn reap_daemons_under(root: &Path) {
             }
         }
     }
-    for pid in pids {
-        reap_pid(pid);
+    pids
+}
+
+/// Running `airc … daemon …` processes whose command line references a
+/// path under `root` (its `--home` or `--socket`). Catches daemons
+/// whose pid file landed outside the walked tree, or never got written.
+#[cfg(unix)]
+fn pids_from_process_scan(root: &Path) -> Vec<u32> {
+    let Some(root_str) = root.to_str() else {
+        return Vec::new();
+    };
+    let output = match std::process::Command::new("ps")
+        .args(["-Ao", "pid=,args="])
+        .output()
+    {
+        Ok(output) if output.status.success() => output.stdout,
+        _ => return Vec::new(),
+    };
+    let me = std::process::id();
+    let mut pids = Vec::new();
+    for line in String::from_utf8_lossy(&output).lines() {
+        let line = line.trim_start();
+        let Some((pid_str, args)) = line.split_once(char::is_whitespace) else {
+            continue;
+        };
+        // An airc daemon process whose args mention a path under root.
+        if !(args.contains("airc") && args.contains(" daemon") && args.contains(root_str)) {
+            continue;
+        }
+        if let Ok(pid) = pid_str.trim().parse::<u32>() {
+            if pid != 0 && pid != me {
+                pids.push(pid);
+            }
+        }
     }
+    pids
+}
+
+#[cfg(not(unix))]
+fn pids_from_process_scan(_root: &Path) -> Vec<u32> {
+    Vec::new()
 }
 
 fn read_pid(path: &Path) -> Option<u32> {

--- a/crates/airc-cli/tests/daemon_teardown.rs
+++ b/crates/airc-cli/tests/daemon_teardown.rs
@@ -161,6 +161,47 @@ fn reaper_finds_and_kills_a_spawned_daemon() {
     // guard drop is now a no-op (already reaped) — proves idempotence.
 }
 
+/// ps-scan layer — the reaper kills a daemon whose `daemon.pid` is NOT
+/// discoverable under `root` (its home derivation put the pidfile
+/// elsewhere, or it never wrote one) purely from its `--home` argument
+/// being under `root`. This is the belt-and-braces that fixed the
+/// macOS-only leak the CI zero-leak guard caught: a daemon whose pidfile
+/// landed outside the walked tree.
+///
+/// MUTATION PIN: delete `pids_from_process_scan` (or its union in
+/// `reap_daemons_under`) and, with the pidfile removed, the reaper can
+/// no longer find the daemon — `wait_child_gone` times out and this
+/// fails.
+#[cfg(unix)]
+#[test]
+fn reaper_ps_scan_kills_daemon_with_no_discoverable_pidfile() {
+    let guard = common::daemon_tempdir();
+    let root = guard.path().to_path_buf();
+    let home = root.join(".airc");
+    let socket = home.join("daemon.sock");
+
+    let mut child = spawn_daemon(&home, &socket, None);
+    let pid = wait_for_pidfile(&root, Duration::from_secs(10));
+
+    // Simulate the failure mode: the pidfile is not where the reaper's
+    // tree-walk looks (deleted here). Only the ps-scan over `--home`
+    // can still find the live daemon.
+    let _ = std::fs::remove_file(home.join("daemon.pid"));
+    assert_eq!(
+        common::find_daemon_pid_under(&root),
+        None,
+        "precondition: no pidfile is discoverable under root"
+    );
+
+    common::reap_daemons_under(&root);
+
+    assert!(
+        wait_child_gone(&mut child, Duration::from_secs(8)),
+        "the ps-scan must reap a daemon whose --home is under root even \
+         with no discoverable pidfile (pid {pid})"
+    );
+}
+
 /// Layer 2 — belt-and-braces self-exit. A temp-home daemon with no
 /// connected client must exit BY ITSELF after the (test-shortened)
 /// idle window, WITHOUT any teardown. This is what catches a SIGKILLed


### PR DESCRIPTION
fix(test-harness): ps-scan + multi-sweep daemon reaper — close the macOS leak the CI guard caught (card f122b5b5)

#1159's zero-leak guard did its job: it caught a temp-home daemon
surviving the suite on macOS-latest (a daemon with
--home <tmp>/.tmpXXX/codex). #1160 fixed the sibling-share half but one
daemon still leaked, so rust-rewrite's macOS test leg stayed red. This
closes it.

Two root causes, both in the test reaper (tests/common):

1. pidfile location. A daemon's `daemon.pid` lands in
   `machine_account_home(home)`, which — depending on whether the
   spawning process had HOME pointed at the tempdir — can be
   `<root>/.airc`, `<scope>/.airc`, or the isolated scope itself. The
   pidfile tree-walk missed the macOS isolated-scope case (HOME not
   temp-rooted on the runner → the temp carve-out fires → pidfile lands
   outside the walked subtree). Fix: union the pidfile walk with a
   `ps`-scan for any `airc … daemon` whose `--home`/`--socket` argument
   lives under `root`. Unix-only; Windows keeps the pidfile walk + the
   daemon's own temp-home self-exit.

2. detached-spawn race. A daemon spawned by a DETACHED grandchild
   (`ensure_daemon_running` → `setsid`) can appear a beat AFTER the test
   body returns; on a loaded CI runner it may not exist yet at the first
   reap sweep. Fix: `reap_daemons_under` now does a few bounded sweeps
   with a short settle, stopping early once a sweep is clean, so a
   late-arriving daemon is still reaped.

Test: `reaper_ps_scan_kills_daemon_with_no_discoverable_pidfile` pins
the ps-scan layer — spawns a daemon, removes its pidfile so tree-walk
discovery returns None, and asserts the reaper still kills it via the
`--home` ps-scan. Mutation: drop `pids_from_process_scan` → the daemon
survives → fail.

Verified: full `airc-cli` integration suite under CI-like env (HOME
non-temp, TMPDIR temp — the condition that triggers the carve-out)
leaves ZERO temp-home daemons; all 5 daemon_teardown tests pass; fmt +
production clippy gate clean.

card f122b5b5

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
