### PR TITLE
fix(gh-auth): gate hardening — stub-gh tests, named timeout, AIRC_GH_BIN end-to-end, stale-token re-resolve (card 1f2cbffa)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -525,11 +525,21 @@ fn inject_gh_token(command: &mut Command) {
     command.env("GH_TOKEN", token);
 }
 
-/// `gh auth token` from the parent, robust to PATH-resolution quirks in
-/// a bash-descended process (where bare `gh` may not resolve the same as
-/// in an interactive shell). Tries `gh` on PATH first, then known
-/// install locations.
-fn resolve_gh_token() -> Option<String> {
+/// The operator's `AIRC_GH_BIN` override, if set non-empty (card
+/// 1f2cbffa, #1145 audit item 3). When present it is AUTHORITATIVE for
+/// every gh resolution in this process — token extraction, the
+/// daemon's gate + store, the manual `registry sync` gate.
+pub(crate) fn gh_bin_override() -> Option<std::path::PathBuf> {
+    let raw = std::env::var_os("AIRC_GH_BIN")?;
+    if raw.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(raw))
+}
+
+/// Known gh install locations, tried after bare `gh` on PATH. Only
+/// consulted when the operator has NOT set `AIRC_GH_BIN`.
+fn default_gh_candidates() -> Vec<std::path::PathBuf> {
     let mut candidates: Vec<std::path::PathBuf> = vec![std::path::PathBuf::from("gh")];
     #[cfg(windows)]
     {
@@ -546,6 +556,27 @@ fn resolve_gh_token() -> Option<String> {
         candidates.push(std::path::PathBuf::from("/usr/local/bin/gh"));
         candidates.push(std::path::PathBuf::from("/usr/bin/gh"));
     }
+    candidates
+}
+
+/// `gh auth token` from the parent, robust to PATH-resolution quirks in
+/// a bash-descended process (where bare `gh` may not resolve the same as
+/// in an interactive shell). Honors `AIRC_GH_BIN` (the override is the
+/// ONLY candidate — a broken override must fail loudly upstream, never
+/// silently swap to a different gh); otherwise tries `gh` on PATH, then
+/// known install locations.
+fn resolve_gh_token() -> Option<String> {
+    resolve_gh_token_with(gh_bin_override())
+}
+
+/// Env-free body of [`resolve_gh_token`] — `override_bin` is the
+/// operator's `AIRC_GH_BIN`, parameterized so tests can pin the
+/// override contract without racy process-env mutation.
+fn resolve_gh_token_with(override_bin: Option<std::path::PathBuf>) -> Option<String> {
+    let candidates = match override_bin {
+        Some(bin) => vec![bin],
+        None => default_gh_candidates(),
+    };
     for bin in candidates {
         let Ok(output) = std::process::Command::new(&bin)
             .args(["auth", "token"])
@@ -564,31 +595,43 @@ fn resolve_gh_token() -> Option<String> {
     None
 }
 
-/// First gh executable that actually responds (`gh --version` exits
-/// zero), trying PATH then known install locations. The daemon hands
-/// this explicit path to its account-registry gate + store so a
+/// The gh executable the daemon should use. `AIRC_GH_BIN` wins
+/// unconditionally when set (#1145 audit item 3: this used to be
+/// ignored here, and `run_daemon` then clobbered the store's
+/// env-honoring default via `.with_bin(...)`). Otherwise: the first
+/// candidate that actually responds (`gh --version` exits zero),
+/// trying PATH then known install locations. The daemon hands this
+/// explicit path to its account-registry gate + store so a
 /// bash-format / install-dir-less PATH can't make `Command::new("gh")`
 /// silently fail. Returns `None` if gh isn't installed — the daemon then
 /// degrades to bare `gh` (and the rendezvous skips cleanly if that too
 /// can't resolve).
 fn resolve_gh_bin() -> Option<std::path::PathBuf> {
-    let mut candidates: Vec<std::path::PathBuf> = vec![std::path::PathBuf::from("gh")];
-    #[cfg(windows)]
-    {
-        candidates.push(std::path::PathBuf::from(
-            r"C:\Program Files\GitHub CLI\gh.exe",
-        ));
-        candidates.push(std::path::PathBuf::from(
-            r"C:\Program Files (x86)\GitHub CLI\gh.exe",
-        ));
+    resolve_gh_bin_with(gh_bin_override())
+}
+
+/// Env-free body of [`resolve_gh_bin`] — `override_bin` is the
+/// operator's `AIRC_GH_BIN`, parameterized so tests can pin the
+/// override contract without racy process-env mutation.
+///
+/// The override is returned EVEN IF nothing exists at that path —
+/// with a loud stderr line, never a silent fallback to a PATH-resolved
+/// gh: an operator override that quietly stops applying is the worst
+/// failure shape (every subsequent gh spawn then fails loudly per
+/// tick, which is diagnosable; a wrong-but-working gh is not).
+fn resolve_gh_bin_with(override_bin: Option<std::path::PathBuf>) -> Option<std::path::PathBuf> {
+    if let Some(bin) = override_bin {
+        if !bin.exists() {
+            eprintln!(
+                "airc: AIRC_GH_BIN is set to {} but no file exists there — honoring the \
+                 override anyway (no silent fallback to a PATH-resolved gh); gh calls will \
+                 fail loudly until the path is fixed or the override unset",
+                bin.display()
+            );
+        }
+        return Some(bin);
     }
-    #[cfg(not(windows))]
-    {
-        candidates.push(std::path::PathBuf::from("/opt/homebrew/bin/gh"));
-        candidates.push(std::path::PathBuf::from("/usr/local/bin/gh"));
-        candidates.push(std::path::PathBuf::from("/usr/bin/gh"));
-    }
-    for bin in candidates {
+    for bin in default_gh_candidates() {
         if let Ok(output) = std::process::Command::new(&bin).arg("--version").output() {
             if output.status.success() {
                 return Some(bin);
@@ -1258,14 +1301,22 @@ pub async fn run_daemon(
                 bin.display()
             );
         }
+        // Stale-token recovery slot (card 1f2cbffa): the SAME slot
+        // goes to the gate (which re-resolves on auth failure) and the
+        // store (whose gh spawns then carry the recovered token), so a
+        // mid-session token rotation no longer bricks the rendezvous
+        // until daemon restart.
+        let gh_token_override = airc_lib::GhTokenOverride::new();
         let store = match &gh_bin {
             Some(bin) => airc_lib::GhAccountRegistryStore::new(event_store, &registry_home)
                 .with_bin(bin.clone()),
             None => airc_lib::GhAccountRegistryStore::new(event_store, &registry_home),
-        };
+        }
+        .with_token_override(gh_token_override.clone());
         let gate = airc_lib::RegistryRefreshGate::GhAuth {
             gh_bin: gh_bin.clone(),
             scope_home: registry_home.clone(),
+            token_override: Some(gh_token_override),
         };
         airc_lib::run_registry_refresh_loop(
             airc,
@@ -2100,5 +2151,65 @@ mod tests {
     #[test]
     fn daemon_status_without_metadata_is_stale() {
         assert!(!daemon_status_is_current(&status(None, None)));
+    }
+
+    // Card 1f2cbffa item 3 (#1145 audit): AIRC_GH_BIN is the
+    // operator's authoritative gh override. `resolve_gh_bin` used to
+    // ignore it entirely, and `run_daemon` then clobbered the store's
+    // env-honoring default via `.with_bin(...)`. These pins drive the
+    // env-free `_with` body so no racy process-env mutation is needed.
+    #[test]
+    fn resolve_gh_bin_honors_airc_gh_bin_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let custom = dir.path().join("custom-gh");
+        std::fs::write(&custom, "").expect("write stub");
+        assert_eq!(
+            resolve_gh_bin_with(Some(custom.clone())),
+            Some(custom),
+            "an existing AIRC_GH_BIN must be returned verbatim, not a PATH-resolved gh"
+        );
+    }
+
+    // A broken override must surface loudly downstream (every gh
+    // spawn fails per tick), NEVER silently swap to a PATH gh the
+    // operator deliberately overrode away from. Mutation check:
+    // re-adding a PATH fallback for a missing override makes this
+    // return a real gh on any gh-installed machine and the assert
+    // fails.
+    #[test]
+    fn resolve_gh_bin_broken_override_never_falls_back_to_path() {
+        let missing = std::path::PathBuf::from("/nonexistent/airc-gh-override-pin-1f2cbffa/gh");
+        assert_eq!(
+            resolve_gh_bin_with(Some(missing.clone())),
+            Some(missing),
+            "a missing AIRC_GH_BIN must still be honored (loud failure downstream), \
+             never silently replaced by a PATH-resolved gh"
+        );
+    }
+
+    // Token extraction goes through the SAME override: with
+    // AIRC_GH_BIN set, only that binary is consulted.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_gh_token_uses_the_override_binary_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stub = dir.path().join("gh");
+        std::fs::write(&stub, "#!/bin/sh\nprintf 'override-token\\n'\nexit 0\n")
+            .expect("write stub");
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod stub");
+        assert_eq!(
+            resolve_gh_token_with(Some(stub)).as_deref(),
+            Some("override-token")
+        );
+        // Broken override: no silent fallback to a PATH gh's token.
+        assert_eq!(
+            resolve_gh_token_with(Some(std::path::PathBuf::from(
+                "/nonexistent/airc-gh-override-pin-1f2cbffa/gh"
+            ))),
+            None,
+            "a broken AIRC_GH_BIN must yield no token, never a PATH gh's token"
+        );
     }
 }

--- a/crates/airc-cli/src/registry_commands.rs
+++ b/crates/airc-cli/src/registry_commands.rs
@@ -131,8 +131,15 @@ pub async fn run_sync(
     let event_store = Arc::new(SqliteEventStore::open_path(&db_path).await?);
     let store = GhAccountRegistryStore::new(event_store, home);
     let gate = RegistryRefreshGate::GhAuth {
-        gh_bin: None,
+        // Honor the operator's AIRC_GH_BIN here too (card 1f2cbffa):
+        // the store's `new()` already reads it, but the gate used to
+        // probe bare `gh` — an override pointing at a different gh
+        // would pass/fail the gate against the WRONG binary. `None`
+        // token slot: a manual sync runs in the operator's live
+        // session, where env/keyring are already current.
+        gh_bin: crate::commands::gh_bin_override(),
         scope_home: home.to_path_buf(),
+        token_override: None,
     };
 
     // Gate FIRST (hermetic, then gh-auth): a blocked scope must hear

--- a/crates/airc-lib/src/gh_account_registry.rs
+++ b/crates/airc-lib/src/gh_account_registry.rs
@@ -227,6 +227,61 @@ fn sanitize_writer_component(raw: &str) -> String {
     }
 }
 
+/// Shared fresh-token slot for a daemon's gh transport (card 1f2cbffa).
+///
+/// `GH_TOKEN` is injected into the daemon's environment ONCE at spawn
+/// (the CLI's `inject_gh_token`) because a detached daemon can't always
+/// reach the OS keyring. But gh tokens rotate mid-session (documented
+/// operational fact on the shared joelteply identity) and process env
+/// is immutable — so a long-lived daemon holding a rotated/revoked
+/// snapshot fails every registry tick until restart. When the gate's
+/// auth probe fails, it makes ONE recovery attempt per tick
+/// ([`re_resolve_gh_token`], mirroring `ReqwestGhClient`'s #1147
+/// 401-refresh); a recovered token lands here, and every subsequent gh
+/// spawn — the gate's `gh auth status` probe AND the store's
+/// publish/refresh commands — overrides the stale env copy with it via
+/// `cmd.env("GH_TOKEN", ...)`.
+#[derive(Clone, Default)]
+pub struct GhTokenOverride {
+    inner: Arc<std::sync::RwLock<Option<String>>>,
+}
+
+impl GhTokenOverride {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Read the recovered token, surviving lock poisoning (a panicked
+    /// holder can't corrupt an `Option<String>` — either value is a
+    /// valid state; same posture as `ReqwestGhClient::cached_token`).
+    pub fn get(&self) -> Option<String> {
+        match self.inner.read() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    /// Replace the recovered token.
+    pub fn set(&self, token: String) {
+        let mut guard = match self.inner.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = Some(token);
+    }
+}
+
+// Manual Debug — the derived impl would print the live token through
+// any `{:?}` (RegistryRefreshGate derives Debug and carries this).
+// Tokens are NEVER logged; only whether one has been recovered.
+impl std::fmt::Debug for GhTokenOverride {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GhTokenOverride")
+            .field("token", &self.get().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
 /// gh-gist-backed account-registry store.
 #[derive(Clone)]
 pub struct GhAccountRegistryStore {
@@ -236,6 +291,12 @@ pub struct GhAccountRegistryStore {
     /// Required at construction so no gh-backed store can exist
     /// without a gate (no silent ungated path).
     scope_home: PathBuf,
+    /// Daemon-shared recovered-token slot (card 1f2cbffa). When
+    /// populated, every gh spawn carries it as `GH_TOKEN`, overriding
+    /// a stale spawn-time env snapshot. `None` outside the daemon loop
+    /// (a manual `registry sync` runs in the operator's live session,
+    /// where env/keyring are already current).
+    token_override: Option<GhTokenOverride>,
 }
 
 impl GhAccountRegistryStore {
@@ -256,12 +317,22 @@ impl GhAccountRegistryStore {
             ),
             store,
             scope_home: scope_home.into(),
+            token_override: None,
         }
     }
 
     /// Override the `gh` binary path. Used in tests.
     pub fn with_bin(mut self, gh_bin: impl Into<PathBuf>) -> Self {
         self.gh_bin = gh_bin.into();
+        self
+    }
+
+    /// Attach the daemon-shared recovered-token slot (card 1f2cbffa).
+    /// The daemon hands the SAME slot to its `RegistryRefreshGate`, so
+    /// a token the gate recovers after a stale-auth tick reaches this
+    /// store's gh spawns too.
+    pub fn with_token_override(mut self, token_override: GhTokenOverride) -> Self {
+        self.token_override = Some(token_override);
         self
     }
 
@@ -321,6 +392,12 @@ impl GhAccountRegistryStore {
     ) -> Result<(bool, String, String), AccountRegistryError> {
         let mut cmd = Command::new(&self.gh_bin);
         cmd.args(args);
+        // Recovered-token override (card 1f2cbffa): a fresh token the
+        // gate re-resolved after a stale-auth tick beats the daemon's
+        // immutable spawn-time `GH_TOKEN` env snapshot.
+        if let Some(token) = self.token_override.as_ref().and_then(GhTokenOverride::get) {
+            cmd.env("GH_TOKEN", token);
+        }
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
         if stdin.is_some() {
@@ -661,37 +738,113 @@ fn gh_no_window(cmd: &mut Command) {
     let _ = cmd;
 }
 
+/// Budget for the `gh auth status` probe in [`gh_auth_ready`] (and the
+/// `gh auth token` re-resolve in [`re_resolve_gh_token`]).
+///
+/// `gh auth status` is slower than it looks: gh's startup + an OS
+/// keyring lookup runs ~900ms on Windows (measured on bigmama:
+/// 881–950ms), well past the previous 750ms budget — so the gate timed
+/// out on EVERY tick and reported "not authenticated" despite valid
+/// auth, which is why same-account cross-machine discovery never
+/// published a beacon and peers could enrol but never route (the
+/// days-long keystone blocker, fixed in #1145). A genuinely
+/// unauthenticated `gh auth status` still fails fast (well under a
+/// second), so the wider budget only ever costs latency on the
+/// slow-but-authed path it exists to allow. 5s = the measured ~1s
+/// worst case with generous headroom for cold starts / loaded CI.
+pub const GH_AUTH_READY_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Probe whether the local `gh` is authenticated against GitHub.
-/// Returns Ok(()) if `gh auth status` exits zero. Used by callers
-/// (e.g., `Airc::join_default_context`) to skip publish/refresh
-/// cleanly when the operator isn't logged in.
+/// Returns true if `gh auth status` exits zero within
+/// [`GH_AUTH_READY_TIMEOUT`]. Used by callers (e.g.,
+/// `Airc::join_default_context`) to skip publish/refresh cleanly when
+/// the operator isn't logged in.
 pub async fn gh_auth_ready(gh_bin: Option<&Path>) -> bool {
+    gh_auth_ready_with_token(gh_bin, None).await
+}
+
+/// Like [`gh_auth_ready`], but the probe carries an explicit
+/// `GH_TOKEN` (card 1f2cbffa): after a stale-token recovery the gate
+/// must re-probe with the FRESH token — gh prefers an env token over
+/// its keyring copy, so without the override the probe would keep
+/// failing on the daemon's immutable spawn-time snapshot.
+pub async fn gh_auth_ready_with_token(gh_bin: Option<&Path>, gh_token: Option<&str>) -> bool {
     let bin = gh_bin.unwrap_or_else(|| Path::new("gh"));
     let mut cmd = Command::new(bin);
     cmd.args(["auth", "status"])
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    if let Some(token) = gh_token {
+        cmd.env("GH_TOKEN", token);
+    }
     gh_no_window(&mut cmd);
     let mut child = match cmd.spawn() {
         Ok(child) => child,
         Err(_) => return false,
     };
-    // `gh auth status` is slower than it looks: gh's startup + an OS
-    // keyring lookup runs ~900ms on Windows (measured on bigmama:
-    // 881-950ms), well past a 750ms budget — so the gate timed out on
-    // EVERY tick and reported "not authenticated" despite valid auth,
-    // which is why same-account cross-machine discovery never published
-    // a beacon and peers could enrol but never route (the days-long
-    // keystone blocker). A genuinely-unauthenticated `gh auth status`
-    // still fails fast (well under this), so the wider budget only ever
-    // costs latency on the slow-but-authed path it exists to allow.
-    match timeout(Duration::from_secs(5), child.wait()).await {
+    match timeout(GH_AUTH_READY_TIMEOUT, child.wait()).await {
         Ok(Ok(status)) => status.success(),
         Ok(Err(_)) => false,
         Err(_) => {
             let _ = child.kill().await;
             false
         }
+    }
+}
+
+/// ONE stale-token recovery attempt for a long-lived daemon (card
+/// 1f2cbffa, mirroring `ReqwestGhClient`'s #1147 401-refresh): spawn
+/// `gh auth token` with `GH_TOKEN`/`GITHUB_TOKEN` REMOVED from the
+/// child env. gh prefers an env token over its keyring copy, so with
+/// the daemon's stale injected env in place `gh auth token` would just
+/// echo the stale token back — stripping the env is what makes the
+/// keyring copy (which usually outlives a rotated env snapshot)
+/// reachable at all.
+///
+/// The env re-read leg of #1147's chain (GH_TOKEN → GITHUB_TOKEN →
+/// spawn) is deliberately absent here: gh child processes already
+/// inherit the daemon's env token, so re-reading our own immutable
+/// process env can never change the probe outcome — that frozen
+/// snapshot IS the bug being recovered from.
+///
+/// A detached daemon may lack keychain access entirely (that is WHY
+/// spawn-time injection exists); then this returns `None` and the
+/// caller falls through to the existing loud skip diagnostic — one
+/// extra recovery attempt, no new failure modes.
+pub async fn re_resolve_gh_token(gh_bin: Option<&Path>) -> Option<String> {
+    let bin = gh_bin.unwrap_or_else(|| Path::new("gh"));
+    let mut cmd = Command::new(bin);
+    cmd.args(["auth", "token"])
+        .env_remove("GH_TOKEN")
+        .env_remove("GITHUB_TOKEN")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    gh_no_window(&mut cmd);
+    let mut child = cmd.spawn().ok()?;
+    let mut stdout = child.stdout.take()?;
+    // Bounded like the auth probe; a hung gh is killed, never awaited
+    // indefinitely (hazard d2ba719c — all waits bounded).
+    let status = match timeout(GH_AUTH_READY_TIMEOUT, child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(_)) => return None,
+        Err(_) => {
+            let _ = child.kill().await;
+            return None;
+        }
+    };
+    if !status.success() {
+        return None;
+    }
+    // The child has exited; the pipe holds at most a token-sized line.
+    let mut buf = String::new();
+    use tokio::io::AsyncReadExt;
+    stdout.read_to_string(&mut buf).await.ok()?;
+    let token = buf.trim().to_string();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token)
     }
 }
 
@@ -799,6 +952,7 @@ mod tests {
         const STUB_SCRIPT: &str = r#"#!/bin/sh
 S="__STATE__"
 printf '%s\n' "$*" >> "$S/calls.log"
+printf '%s\n' "${GH_TOKEN-unset}" >> "$S/token.log"
 case "$1" in
   auth)
     exit 0
@@ -875,6 +1029,14 @@ exit 0
 
             fn calls(&self) -> Vec<String> {
                 std::fs::read_to_string(self.state.join("calls.log"))
+                    .map(|log| log.lines().map(str::to_string).collect())
+                    .unwrap_or_default()
+            }
+
+            /// The `GH_TOKEN` each gh spawn carried (`unset` when absent),
+            /// one line per call — the card-1f2cbffa recovered-token pin.
+            fn tokens(&self) -> Vec<String> {
+                std::fs::read_to_string(self.state.join("token.log"))
                     .map(|log| log.lines().map(str::to_string).collect())
                     .unwrap_or_default()
             }
@@ -1191,6 +1353,160 @@ exit 0
                 merged_a.endpoints, peer_a.endpoints,
                 "peer A's dialable endpoints must survive the merge"
             );
+        }
+
+        // Card 1f2cbffa item 4: once the gate's stale-token recovery
+        // lands a fresh token in the shared slot, EVERY gh spawn the
+        // store makes must carry it as GH_TOKEN — otherwise recovery
+        // passes the gate and then the publish fails with the same
+        // stale spawn-time env snapshot. Mutation check: removing the
+        // `cmd.env("GH_TOKEN", …)` application in `gh_run` makes every
+        // token.log line read `unset` (or the host's ambient token),
+        // failing the assert.
+        #[tokio::test]
+        async fn store_gh_spawns_carry_the_recovered_token() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+            let slot = GhTokenOverride::new();
+            slot.set("tok-fresh-after-rotation".to_string());
+            let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc")
+                .await
+                .with_token_override(slot);
+
+            store.publish(&document(1_000, Vec::new())).await.unwrap();
+
+            let tokens = stub.tokens();
+            assert!(
+                !tokens.is_empty(),
+                "publish must have spawned gh at least once"
+            );
+            assert!(
+                tokens.iter().all(|t| t == "tok-fresh-after-rotation"),
+                "every gh spawn must carry the recovered token, got: {tokens:?}"
+            );
+        }
+    }
+
+    // gh-auth gate stub tests (card 1f2cbffa item 1, upstreamed from
+    // the #1145 post-merge audit's throwaway evidence). cfg(unix): the
+    // stub is a shell script; hosted ubuntu + macos legs run these
+    // (precedent: #1150).
+    #[cfg(unix)]
+    mod gh_auth_gate_stub {
+        use super::*;
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::Instant;
+
+        fn install_stub(dir: &Path, name: &str, body: &str) -> PathBuf {
+            let bin = dir.join(name);
+            std::fs::write(&bin, body).unwrap();
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            bin
+        }
+
+        // THE #1145 PIN: a gh that takes ~1s to answer but IS
+        // authenticated must pass the gate. This is the measured
+        // 881–950ms Windows `gh auth status` class that the previous
+        // 750ms budget timed out on EVERY tick, breaking same-account
+        // cross-machine discovery for days. Mutation check (verified
+        // in the audit): shrink GH_AUTH_READY_TIMEOUT to 750ms and
+        // this fails in ~0.76s.
+        #[tokio::test]
+        async fn gate_allows_slow_but_authed_gh_900ms_class() {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = install_stub(dir.path(), "gh", "#!/bin/sh\nsleep 1\nexit 0\n");
+            assert!(
+                gh_auth_ready(Some(&bin)).await,
+                "slow-but-authed gh (the measured Windows ~900ms class) must pass the gate"
+            );
+        }
+
+        // A genuinely-unauthenticated gh exits non-zero fast; the gate
+        // must report not-ready WITHOUT consuming the timeout budget
+        // (the budget exists only for the slow-but-authed path).
+        #[tokio::test]
+        async fn gate_fails_fast_for_unauthed_gh() {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = install_stub(dir.path(), "gh", "#!/bin/sh\nexit 1\n");
+            let start = Instant::now();
+            assert!(
+                !gh_auth_ready(Some(&bin)).await,
+                "unauthed gh must fail the gate"
+            );
+            assert!(
+                start.elapsed() < Duration::from_secs(2),
+                "unauthed gh must fail FAST, not burn the {GH_AUTH_READY_TIMEOUT:?} budget; took {:?}",
+                start.elapsed()
+            );
+        }
+
+        // A hung gh (stalled keyring, dead network) is KILLED at the
+        // deadline — the gate answers not-ready in ~GH_AUTH_READY_TIMEOUT,
+        // never the stub's 30s. `exec` makes the kill hit the sleep
+        // itself (no orphaned child outliving the test).
+        #[tokio::test]
+        async fn gate_kills_hung_gh_at_the_deadline() {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = install_stub(dir.path(), "gh", "#!/bin/sh\nexec sleep 30\n");
+            let start = Instant::now();
+            assert!(
+                !gh_auth_ready(Some(&bin)).await,
+                "hung gh must fail the gate"
+            );
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed >= GH_AUTH_READY_TIMEOUT - Duration::from_millis(100),
+                "the gate must grant the full budget before giving up; took {elapsed:?}"
+            );
+            assert!(
+                elapsed < GH_AUTH_READY_TIMEOUT + Duration::from_secs(10),
+                "hung gh must be killed at the deadline, not awaited to completion; took {elapsed:?}"
+            );
+        }
+
+        // Card 1f2cbffa item 4: the recovery spawn strips the stale
+        // env so gh reads its keyring copy instead of echoing the
+        // injected token back. The stub mirrors real gh precedence
+        // (env token wins when present): if the test environment (or a
+        // mutation removing `env_remove`) leaks a GH_TOKEN/GITHUB_TOKEN
+        // into the spawn, the stub echoes THAT instead of the keyring
+        // copy and the assert bites.
+        #[tokio::test]
+        async fn re_resolve_strips_stale_env_and_reads_keyring_copy() {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = install_stub(
+                dir.path(),
+                "gh",
+                r#"#!/bin/sh
+if [ "$1 $2" = "auth token" ]; then
+  if [ -n "${GH_TOKEN-}" ]; then printf '%s\n' "$GH_TOKEN"; exit 0; fi
+  if [ -n "${GITHUB_TOKEN-}" ]; then printf '%s\n' "$GITHUB_TOKEN"; exit 0; fi
+  printf 'fresh-keyring-token\n'
+  exit 0
+fi
+exit 1
+"#,
+            );
+            assert_eq!(
+                re_resolve_gh_token(Some(&bin)).await.as_deref(),
+                Some("fresh-keyring-token"),
+                "re-resolve must reach the keyring copy, never echo an env token"
+            );
+        }
+
+        // The keychain-less daemon case (the reason injection exists):
+        // `gh auth token` fails → the recovery attempt yields None and
+        // the caller falls through to the existing loud skip. No new
+        // failure modes.
+        #[tokio::test]
+        async fn re_resolve_returns_none_when_keyring_unreachable() {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = install_stub(
+                dir.path(),
+                "gh",
+                "#!/bin/sh\necho 'keyring unavailable' >&2\nexit 1\n",
+            );
+            assert_eq!(re_resolve_gh_token(Some(&bin)).await, None);
         }
     }
 }

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -128,8 +128,9 @@ pub use external_identity::{
     HEADER_BRIDGE_HANDLE, HEADER_BRIDGE_SOURCE,
 };
 pub use gh_account_registry::{
-    account_registry_block, gh_auth_ready, writer_filename, writer_key, AccountRegistryBlock,
-    GhAccountRegistryStore, AIRC_DISABLE_ACCOUNT_REGISTRY_ENV,
+    account_registry_block, gh_auth_ready, gh_auth_ready_with_token, re_resolve_gh_token,
+    writer_filename, writer_key, AccountRegistryBlock, GhAccountRegistryStore, GhTokenOverride,
+    AIRC_DISABLE_ACCOUNT_REGISTRY_ENV, GH_AUTH_READY_TIMEOUT,
 };
 pub use gh_client::{
     parse_pr_url, parse_pr_view, GhCheck, GhClient, GhError, MergeReceipt, PrCreateArgs, PrCreated,

--- a/crates/airc-lib/src/registry_refresh.rs
+++ b/crates/airc-lib/src/registry_refresh.rs
@@ -88,6 +88,16 @@ pub enum RegistryRefreshGate {
     GhAuth {
         gh_bin: Option<PathBuf>,
         scope_home: PathBuf,
+        /// Daemon-shared recovered-token slot (card 1f2cbffa). When
+        /// `Some`, a failed auth probe triggers ONE re-resolve +
+        /// re-probe per tick (`gh auth token` with the stale env
+        /// stripped — mirrors `ReqwestGhClient`'s #1147 401-refresh);
+        /// a recovered token lands in the slot so the store's gh
+        /// spawns use it too. `None` (manual `registry sync`, tests)
+        /// = no recovery: outside the daemon a recovered token could
+        /// not reach the store, so passing the gate with it would
+        /// just move the same failure into the publish.
+        token_override: Option<crate::gh_account_registry::GhTokenOverride>,
     },
     /// No gate — always run the tick. Used by Sqlite/in-memory stores
     /// that need no external auth (acceptance test + manual `registry
@@ -130,15 +140,51 @@ impl RegistryRefreshGate {
     /// endpoint refusal.
     pub async fn block(&self) -> Option<GateBlock> {
         match self {
-            RegistryRefreshGate::GhAuth { gh_bin, scope_home } => {
+            RegistryRefreshGate::GhAuth {
+                gh_bin,
+                scope_home,
+                token_override,
+            } => {
                 if let Some(block) = crate::gh_account_registry::account_registry_block(scope_home)
                 {
                     return Some(GateBlock::Hermetic(block));
                 }
-                if !crate::gh_account_registry::gh_auth_ready(gh_bin.as_deref()).await {
-                    return Some(GateBlock::GhNotReady);
+                let recovered = token_override.as_ref().and_then(|slot| slot.get());
+                if crate::gh_account_registry::gh_auth_ready_with_token(
+                    gh_bin.as_deref(),
+                    recovered.as_deref(),
+                )
+                .await
+                {
+                    return None;
                 }
-                None
+                // Stale-token recovery (card 1f2cbffa): the daemon's
+                // GH_TOKEN env is a spawn-time snapshot and tokens
+                // rotate mid-session, so before declaring the
+                // transport unavailable make ONE re-resolve + re-probe
+                // attempt. Failure falls through to the existing loud
+                // GhNotReady skip — no new failure modes.
+                if let Some(slot) = token_override {
+                    if let Some(fresh) =
+                        crate::gh_account_registry::re_resolve_gh_token(gh_bin.as_deref()).await
+                    {
+                        if crate::gh_account_registry::gh_auth_ready_with_token(
+                            gh_bin.as_deref(),
+                            Some(&fresh),
+                        )
+                        .await
+                        {
+                            eprintln!(
+                                "airc daemon: gh auth probe failed with the current token, but a \
+                                 re-resolved `gh auth token` passed (token rotated mid-session?) \
+                                 — continuing registry ticks with the fresh token"
+                            );
+                            slot.set(fresh);
+                            return None;
+                        }
+                    }
+                }
+                Some(GateBlock::GhNotReady)
             }
             RegistryRefreshGate::Always => None,
         }
@@ -448,6 +494,7 @@ mod tests {
         let gate = RegistryRefreshGate::GhAuth {
             gh_bin: Some(PathBuf::from("airc-nonexistent-gh-binary-for-gate-test")),
             scope_home: PathBuf::from("/machine/prod/.airc"),
+            token_override: None,
         };
         let outcome = sync_once(&airc, &store, &gate).await.unwrap();
         assert_eq!(
@@ -455,6 +502,93 @@ mod tests {
             SyncOutcome::Skipped(GateBlock::GhNotReady),
             "unready gate must skip with the gh-not-ready reason"
         );
+    }
+
+    // STALE-TOKEN RECOVERY (card 1f2cbffa item 4, mirrors #1147's
+    // 401-refresh): a daemon whose spawn-time GH_TOKEN snapshot went
+    // stale must NOT skip the tick — the gate makes ONE re-resolve
+    // (`gh auth token`, stale env stripped) + re-probe, and the
+    // recovered token lands in the shared slot for the store's gh
+    // spawns. The stub mirrors real gh: `auth status` passes only with
+    // the fresh token in GH_TOKEN; `auth token` echoes an env token
+    // when one is present (so only an env-stripped spawn reaches the
+    // keyring copy). The test process has no fresh token in ITS env —
+    // recovery is the only path to a pass. Mutation check: removing
+    // the re-resolve arm from `block()` makes the first assert see
+    // GhNotReady; removing `slot.set(fresh)` fails the second.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn gate_recovers_from_stale_daemon_token_with_one_re_resolve() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join("gh");
+        std::fs::write(
+            &bin,
+            r#"#!/bin/sh
+case "$1 $2" in
+  "auth status")
+    [ "${GH_TOKEN-}" = "fresh-token" ] && exit 0
+    exit 1
+    ;;
+  "auth token")
+    if [ -n "${GH_TOKEN-}" ]; then printf '%s\n' "$GH_TOKEN"; exit 0; fi
+    if [ -n "${GITHUB_TOKEN-}" ]; then printf '%s\n' "$GITHUB_TOKEN"; exit 0; fi
+    printf 'fresh-token\n'
+    exit 0
+    ;;
+esac
+exit 1
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let slot = crate::gh_account_registry::GhTokenOverride::new();
+        // scope_home is production-shaped so the hermetic arm does not
+        // fire first (same setup as the gate-skip test above).
+        let gate = RegistryRefreshGate::GhAuth {
+            gh_bin: Some(bin),
+            scope_home: PathBuf::from("/machine/prod/.airc"),
+            token_override: Some(slot.clone()),
+        };
+
+        assert!(
+            gate.block().await.is_none(),
+            "a stale-token tick must recover via one re-resolve instead of skipping"
+        );
+        assert_eq!(
+            slot.get().as_deref(),
+            Some("fresh-token"),
+            "the recovered token must land in the shared slot so the store's gh spawns carry it"
+        );
+        // Next tick passes directly on the slot token (no fresh
+        // failure-then-recover cycle needed).
+        assert!(gate.block().await.is_none());
+    }
+
+    // Without a shared slot (manual `registry sync` — no daemon store
+    // to hand a recovered token to), the gate must NOT attempt
+    // recovery: a stale env still yields the plain GhNotReady skip.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn gate_without_slot_skips_stale_token_without_recovery() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join("gh");
+        // auth status always fails; auth token would "succeed" — but
+        // with no slot the gate must never even try it.
+        std::fs::write(
+            &bin,
+            "#!/bin/sh\nif [ \"$1 $2\" = \"auth token\" ]; then echo t; exit 0; fi\nexit 1\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let gate = RegistryRefreshGate::GhAuth {
+            gh_bin: Some(bin),
+            scope_home: PathBuf::from("/machine/prod/.airc"),
+            token_override: None,
+        };
+        assert_eq!(gate.block().await, Some(GateBlock::GhNotReady));
     }
 
     // HERMETIC GATE (card d793c242): a gh-gated scope whose home is
@@ -476,6 +610,7 @@ mod tests {
         let gate = RegistryRefreshGate::GhAuth {
             gh_bin: Some(PathBuf::from("airc-nonexistent-gh-binary-for-gate-test")),
             scope_home: machine.clone(),
+            token_override: None,
         };
         match sync_once(&airc, &store, &gate).await.unwrap() {
             SyncOutcome::Skipped(GateBlock::Hermetic(


### PR DESCRIPTION
Card **1f2cbffa-7887-4378-9213-77c03b3d0392** — gh-auth gate hardening: the four post-merge-audit residuals from #1145 ([audit comment](https://github.com/CambrianTech/airc/pull/1145#issuecomment-4686386364)).

## 1. Stub-gh tests upstreamed (audit risk note 1)

The audit's throwaway evidence is now a permanent `cfg(unix)` suite (`gh_account_registry::tests::gh_auth_gate_stub`; hosted ubuntu+macos run it, precedent #1150):

- `gate_allows_slow_but_authed_gh_900ms_class` — a stub gh that sleeps ~1s then exits 0 must pass the gate. This is the measured 881–950ms Windows `gh auth status` class that the pre-#1145 750ms budget timed out on every tick.
- `gate_fails_fast_for_unauthed_gh` — exit-1 stub fails the gate in well under 2s (the budget exists only for the slow-but-authed path).
- `gate_kills_hung_gh_at_the_deadline` — an `exec sleep 30` stub is killed at the deadline; the gate answers in ~`GH_AUTH_READY_TIMEOUT`, never 30s.

## 2. Named timeout constant (audit risk note 1)

`GH_AUTH_READY_TIMEOUT: Duration = Duration::from_secs(5)` (pub, `gh_account_registry.rs`) replaces the inline magic `Duration::from_secs(5)`; its doc comment carries the bigmama-measured rationale that previously lived as an inline comment. The probe, the kill-deadline, and the new `gh auth token` re-resolve all share it.

## 3. AIRC_GH_BIN honored end-to-end (audit risk note 3)

- `resolve_gh_bin` now returns the operator override **unconditionally** when set — with a loud stderr line if nothing exists at that path, and **no silent fallback to PATH** (an override that quietly stops applying is the worst failure shape; a broken one fails loudly per tick, which is diagnosable). `run_daemon`'s `.with_bin(...)` therefore carries the override instead of clobbering the store's env-honoring default.
- `resolve_gh_token` consults only the override when set (token extraction from the wrong gh is the same bug).
- The manual `registry sync` gate (`registry_commands::run_sync`) now probes the overridden binary instead of hardcoded bare `gh`.
- Pinned via env-free `_with()` bodies (`resolve_gh_bin_with` / `resolve_gh_token_with`) so the tests need no racy process-env mutation: `resolve_gh_bin_honors_airc_gh_bin_override`, `resolve_gh_bin_broken_override_never_falls_back_to_path`, `resolve_gh_token_uses_the_override_binary_only`.

## 4. Stale-token re-resolve for the daemon's gh transport (audit risk note 2)

`GH_TOKEN` is snapshotted into the daemon env at spawn (`inject_gh_token`) and tokens rotate mid-session (documented operational fact), so a long-lived daemon's registry ticks failed until restart. Mirroring `ReqwestGhClient`'s #1147 401-refresh:

- On a failed auth probe, the gate makes **one recovery attempt per tick**: `re_resolve_gh_token` spawns `gh auth token` with `GH_TOKEN`/`GITHUB_TOKEN` **stripped from the child env** — gh prefers an env token over its keyring copy, so without the strip it would just echo the stale injected token back; stripping is what makes the keyring copy (which usually outlives a rotated env snapshot) reachable at all.
- A recovered token lands in a shared `GhTokenOverride` slot (Debug redacts it) that `run_daemon` hands to **both** the gate (re-probes with the fresh token) and the `GhAccountRegistryStore` (every gh spawn carries it via `cmd.env("GH_TOKEN", …)`), so recovery doesn't just pass the gate and then fail the publish.
- If the daemon lacks keychain access (the reason injection exists in the first place), the attempt returns `None` and the **existing** loud `GhNotReady` skip diagnostic fires — one extra recovery attempt, no new failure modes. Recovery success logs one loud line.

**Said-so (per the card's instruction to state limits rather than invent fallbacks):**
- The "re-read GH_TOKEN env" leg of #1147's chain is deliberately absent: gh child processes already inherit the daemon's env token, so re-reading our own immutable process env can never change the probe outcome — that frozen snapshot *is* the bug being recovered from. The only recoverable source from inside the daemon is the keyring via the env-stripped `gh auth token` spawn.
- If the daemon has neither keyring access nor a still-valid env token, recovery cannot succeed — behavior is then identical to before this PR (loud per-tick skip until restart). That is the honest limit of daemon-side recovery; restart remains the fix for that case.
- Manual `registry sync` gets `token_override: None` (no recovery): it runs in the operator's live session where env/keyring are already current, and without a daemon store to hand the token to, passing the gate with a recovered token would just move the same failure into the publish.

## Mutation evidence (each pin run failed, then restored green)

| Mutation | Result |
|---|---|
| `GH_AUTH_READY_TIMEOUT` 5s → 750ms | `gate_allows_slow_but_authed_gh_900ms_class` **FAILED in 0.76s** (exact audit repro; `re_resolve_strips_stale_env_and_reads_keyring_copy` also failed) |
| `resolve_gh_bin_with` ignores the override | both AIRC_GH_BIN bin pins **FAILED** |
| `resolve_gh_token_with` falls back to default candidates despite override | `resolve_gh_token_uses_the_override_binary_only` **FAILED** |
| re-resolve arm removed from `RegistryRefreshGate::block` | `gate_recovers_from_stale_daemon_token_with_one_re_resolve` **FAILED** |
| store's `cmd.env("GH_TOKEN", …)` application removed from `gh_run` | `store_gh_spawns_carry_the_recovered_token` **FAILED** |

## Gate

- `cargo fmt --all -- --check` — PASS
- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` — PASS
- `cargo test --workspace -- --skip codex_hook` — PASS (see thread)
- No daemons spawned by the new tests (stub scripts only); #1159 RAII/zero-leak posture untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
