### PR TITLE
perf(daemon): reverse-paged Inbox{since:None,limit:N} + daemon-routed cursor reads (card 8428ae8c)

### DIFF
--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -681,6 +681,68 @@ impl EventRouter {
         self.inner.sink.head_cursor(channel).await
     }
 
+    /// **Card 8428ae8c.** The newest `limit` **durable** envelopes on
+    /// `channel`, in ascending total order — the "most recent N" leg of
+    /// the inbox path. Work is bounded by `limit` and the ring capacity,
+    /// NEVER by room depth: the previous shape
+    /// (`resume_from_cursor(channel, None)` + truncate) materialized the
+    /// entire room to answer N.
+    ///
+    /// Merge contract (mirrors [`Self::subscribe`]'s seam, reversed):
+    /// - the hot ring is authoritative for the recent tail — it may hold
+    ///   durables the sink lacks (write-behind lag), and eviction is
+    ///   oldest-first with §3.8 pinning (a durable is never evicted
+    ///   before it is persisted), so the ring's durables are exactly the
+    ///   channel's newest durables and everything older is in the sink;
+    /// - when the ring's durables don't cover `limit`, the remainder
+    ///   comes from ONE [`DurableSink::page_tail`] call for the events
+    ///   strictly before the ring's oldest retained cursor (`None` =
+    ///   channel tail when the ring is empty — fresh-start shape). The
+    ///   sink only ever holds durables, so no class filter is needed on
+    ///   that leg. A sink error propagates — it is never papered over
+    ///   with a full forward scan.
+    pub async fn durable_tail(
+        &self,
+        channel: RoomId,
+        limit: usize,
+    ) -> crate::Result<Vec<Arc<Envelope>>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let (mut tail, ring_oldest) = {
+            let shard = self.shard_for(channel);
+            let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
+            match map.get(&channel.0.as_u128()) {
+                Some(state) => (
+                    state
+                        .ring
+                        .replay_after(None)
+                        .into_iter()
+                        .filter(|env| env.delivery.is_durable())
+                        .collect::<Vec<_>>(),
+                    state.ring.oldest_cursor(),
+                ),
+                None => (Vec::new(), None),
+            }
+        }; // shard lock released before the sink await
+        if tail.len() >= limit {
+            // The ring alone covers N — zero store reads.
+            return Ok(tail.split_off(tail.len() - limit));
+        }
+        // Ring durables are the newest; top up with the sink tail older
+        // than anything the ring still retains. Sink rows strictly
+        // before `ring_oldest` cannot also be in the ring, so the two
+        // legs concatenate with no dup and no gap.
+        let older = self
+            .inner
+            .sink
+            .page_tail(channel, ring_oldest, limit - tail.len())
+            .await?;
+        let mut out: Vec<Arc<Envelope>> = older.into_iter().map(Arc::new).collect();
+        out.append(&mut tail);
+        Ok(out)
+    }
+
     /// Subscribe (§4 subscribe, §3.5 cursor contract).
     ///
     /// Returns a stream that yields **every** envelope on the filter strictly

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -61,6 +61,25 @@ pub trait DurableSink: Send + Sync {
     /// SQLite, back-of-vec on in-memory) or fail loudly.
     async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>>;
 
+    /// **Card 8428ae8c — required, no scan default.** Return the **last**
+    /// `limit` events on `channel` strictly *before* `before` (or the
+    /// channel's tail when `before` is `None`), in ascending total order
+    /// `(epoch, counter, event_id)`. This is the reverse-paging leg of
+    /// the "most recent N" inbox path: the previous shape materialized
+    /// the WHOLE channel via [`DurableSink::page`] and truncated in
+    /// memory — O(room) for an answer of size N. Every impl must answer
+    /// in work bounded by `limit` (SQLite: `ORDER BY … DESC LIMIT N` on
+    /// the composite `(room_id, epoch, counter, event_id)` index, then
+    /// reverse in memory; in-memory: a back-of-vec slice) or fail
+    /// loudly. There is deliberately NO default impl: a sink that cannot
+    /// reverse-page is a compile error, never a silent forward scan.
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>>;
+
     /// **Card 4132f48c.** Whether an event with this `event_id` is already
     /// persisted. This is the durable leg of
     /// [`crate::EventRouter::publish_if_new`]'s idempotency check: an
@@ -180,6 +199,26 @@ impl DurableSink for InMemoryDurableSink {
             .cloned()
             .collect();
         Ok(out)
+    }
+
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>> {
+        let guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(bucket) = guard.events.get(&channel.0.as_u128()) else {
+            return Ok(Vec::new());
+        };
+        // The bucket is kept in ascending total order on insert, so the
+        // tail strictly before `before` is a contiguous back slice.
+        let end = match &before {
+            None => bucket.len(),
+            Some(b) => bucket.partition_point(|e| e.cursor().is_before(b)),
+        };
+        let start = end.saturating_sub(limit);
+        Ok(bucket[start..end].to_vec())
     }
 
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool> {

--- a/crates/airc-bus/tests/common/mod.rs
+++ b/crates/airc-bus/tests/common/mod.rs
@@ -141,6 +141,15 @@ impl DurableSink for GatedSink {
         self.inner.head_cursor(channel).await
     }
 
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner.page_tail(channel, before, limit).await
+    }
+
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
         self.inner.contains(event_id).await
     }

--- a/crates/airc-bus/tests/durable_tail.rs
+++ b/crates/airc-bus/tests/durable_tail.rs
@@ -1,0 +1,384 @@
+//! Card 8428ae8c — `EventRouter::durable_tail`, the bounded
+//! "most recent N" read behind `Inbox { since: None, limit: N }`.
+//!
+//! The perf claim is tested STRUCTURALLY, not by timing: the sink is
+//! wrapped in a counting decorator, and a most-recent-N read on a room
+//! thousands of events deep must complete with **zero `page` calls**
+//! (the O(room) forward-scan primitive) and at most one `page_tail`
+//! call whose requested limit is bounded by N. The previous shape
+//! (`resume_from_cursor(channel, None)` + truncate) materialized the
+//! WHOLE room — exactly one `page(…, None, usize::MAX)` — to answer N.
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use airc_bus::envelope::{Cursor, DeliveryClass, Envelope, Kind};
+use airc_bus::{
+    BusError, DurableSink, EventRouter, InMemoryDurableSink, InMemoryEpochStore, ManualClock,
+    RouterConfig, SeqSource,
+};
+use airc_core::{ClientId, EventId, PeerId, RoomId};
+
+mod common;
+use common::GatedSink;
+
+/// A [`DurableSink`] decorator that counts how the router reads from
+/// the durable tier: `page` is the O(room) forward-scan primitive,
+/// `page_tail` the bounded reverse page. The tail tests assert on these
+/// counters — a most-recent-N read that forward-pages even once is a
+/// failed bounded-work claim.
+struct CountingSink {
+    inner: Arc<InMemoryDurableSink>,
+    page_calls: AtomicU64,
+    page_tail_calls: AtomicU64,
+    max_page_tail_limit: AtomicUsize,
+}
+
+impl CountingSink {
+    fn new(inner: Arc<InMemoryDurableSink>) -> Self {
+        Self {
+            inner,
+            page_calls: AtomicU64::new(0),
+            page_tail_calls: AtomicU64::new(0),
+            max_page_tail_limit: AtomicUsize::new(0),
+        }
+    }
+
+    fn page_calls(&self) -> u64 {
+        self.page_calls.load(Ordering::SeqCst)
+    }
+
+    fn page_tail_calls(&self) -> u64 {
+        self.page_tail_calls.load(Ordering::SeqCst)
+    }
+
+    fn max_page_tail_limit(&self) -> usize {
+        self.max_page_tail_limit.load(Ordering::SeqCst)
+    }
+
+    fn reset(&self) {
+        self.page_calls.store(0, Ordering::SeqCst);
+        self.page_tail_calls.store(0, Ordering::SeqCst);
+        self.max_page_tail_limit.store(0, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl DurableSink for CountingSink {
+    async fn append(&self, e: &Envelope) -> Result<(), BusError> {
+        self.inner.append(e).await
+    }
+
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.page_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.page(channel, from_cursor, limit).await
+    }
+
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        self.inner.head_cursor(channel).await
+    }
+
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.page_tail_calls.fetch_add(1, Ordering::SeqCst);
+        self.max_page_tail_limit.fetch_max(limit, Ordering::SeqCst);
+        self.inner.page_tail(channel, before, limit).await
+    }
+
+    async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
+        self.inner.contains(event_id).await
+    }
+}
+
+/// A sink whose `page_tail` fails — proves the most-recent-N read
+/// surfaces a store error loudly instead of falling back to the
+/// forward scan (whose `page` panics to enforce exactly that).
+struct FailingTailSink;
+
+#[async_trait]
+impl DurableSink for FailingTailSink {
+    async fn append(&self, _e: &Envelope) -> Result<(), BusError> {
+        Ok(())
+    }
+
+    async fn page(
+        &self,
+        _channel: RoomId,
+        _from_cursor: Option<Cursor>,
+        _limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        panic!("durable_tail must NEVER forward-page the room — that is the scan it replaces");
+    }
+
+    async fn head_cursor(&self, _channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        Ok(None)
+    }
+
+    async fn page_tail(
+        &self,
+        _channel: RoomId,
+        _before: Option<Cursor>,
+        _limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        Err(BusError::Sink("reverse index unavailable".to_string()))
+    }
+
+    async fn contains(&self, _event_id: airc_core::EventId) -> Result<bool, BusError> {
+        Ok(false)
+    }
+}
+
+/// Router over a counting sink. Small ring so deep history genuinely
+/// lives only in the sink; large write-behind so a publish burst never
+/// sheds.
+fn counted_router(ring_capacity: usize) -> (EventRouter, Arc<CountingSink>) {
+    let sink = Arc::new(CountingSink::new(Arc::new(InMemoryDurableSink::new())));
+    let epoch_store = InMemoryEpochStore::new();
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let router = EventRouter::new(
+        RouterConfig {
+            ring_capacity,
+            write_behind_buffer: 16_384,
+            ..RouterConfig::default()
+        },
+        Arc::new(ManualClock::new(1_700_000_000_000)),
+        seq,
+        sink.clone(),
+    );
+    (router, sink)
+}
+
+fn event(channel: RoomId, marker: u128, delivery: DeliveryClass) -> Envelope {
+    Envelope::new(
+        channel,
+        (PeerId::from_u128(1), ClientId::from_u128(1)),
+        Kind::Message,
+        delivery,
+        Bytes::from_static(b"tail-page"),
+    )
+    .with_event_id(EventId::from_u128(marker + 1))
+}
+
+fn markers(events: &[Arc<Envelope>]) -> Vec<u128> {
+    events.iter().map(|e| e.event_id.0.as_u128() - 1).collect()
+}
+
+/// The bounded-work proof: most-recent-N on a room 5,000 events deep
+/// (ring capacity 64, so the depth genuinely lives in the sink) must
+/// do ZERO forward-scan (`page`) calls and at most ONE reverse page
+/// whose requested limit never exceeds N — while returning exactly the
+/// newest N in ascending order across the sink→ring seam.
+#[tokio::test]
+async fn most_recent_n_on_deep_room_does_bounded_store_work() {
+    const DEEP: u128 = 5_000;
+    const N: usize = 200;
+
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0xdeeb);
+
+    for n in 0..DEEP {
+        router
+            .publish(event(channel, n, DeliveryClass::Durable))
+            .await
+            .expect("publish");
+        if n % 256 == 0 {
+            // Let the write-behind drain so the bounded queue never sheds.
+            tokio::task::yield_now().await;
+        }
+    }
+
+    sink.reset();
+    let tail = router.durable_tail(channel, N).await.expect("tail");
+
+    let expected: Vec<u128> = (DEEP - N as u128..DEEP).collect();
+    assert_eq!(
+        markers(&tail),
+        expected,
+        "exactly the newest N, ascending, no gap and no dup at the sink→ring seam"
+    );
+    assert_eq!(
+        sink.page_calls(),
+        0,
+        "5000-deep room: most-recent-N must not forward-scan the room"
+    );
+    assert!(
+        sink.page_tail_calls() <= 1,
+        "at most one reverse page, got {}",
+        sink.page_tail_calls()
+    );
+    assert!(
+        sink.max_page_tail_limit() <= N,
+        "the reverse page is bounded by N, asked for {}",
+        sink.max_page_tail_limit()
+    );
+}
+
+/// When the hot ring alone covers N, the store is not touched at all.
+#[tokio::test]
+async fn ring_covered_n_does_zero_store_reads() {
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0x717);
+
+    for n in 0..100u128 {
+        router
+            .publish(event(channel, n, DeliveryClass::Durable))
+            .await
+            .expect("publish");
+    }
+
+    sink.reset();
+    let tail = router.durable_tail(channel, 10).await.expect("tail");
+
+    let expected: Vec<u128> = (90..100).collect();
+    assert_eq!(markers(&tail), expected, "newest 10, ascending");
+    assert_eq!(sink.page_calls(), 0);
+    assert_eq!(
+        sink.page_tail_calls(),
+        0,
+        "ring covers N — zero store reads"
+    );
+}
+
+/// N larger than the room returns the whole room; the empty room and
+/// a zero limit return nothing.
+#[tokio::test]
+async fn n_beyond_room_size_and_degenerate_shapes() {
+    let (router, _sink) = counted_router(64);
+    let channel = RoomId::from_u128(0xb16);
+
+    // Empty room.
+    assert!(
+        router
+            .durable_tail(channel, 50)
+            .await
+            .expect("tail")
+            .is_empty(),
+        "empty room has no tail"
+    );
+
+    for n in 0..10u128 {
+        router
+            .publish(event(channel, n, DeliveryClass::Durable))
+            .await
+            .expect("publish");
+    }
+
+    let all = router.durable_tail(channel, 100).await.expect("tail");
+    let expected: Vec<u128> = (0..10).collect();
+    assert_eq!(markers(&all), expected, "N > room size returns the room");
+
+    assert!(
+        router
+            .durable_tail(channel, 0)
+            .await
+            .expect("tail")
+            .is_empty(),
+        "limit 0 reads nothing"
+    );
+}
+
+/// `durable_tail` is the DURABLE transcript tail: newer non-durable
+/// traffic (stream chunks riding the same ring) never appears in it.
+#[tokio::test]
+async fn non_durable_traffic_is_excluded_from_the_tail() {
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0x5c);
+
+    for n in 0..5u128 {
+        router
+            .publish(event(channel, n, DeliveryClass::Durable))
+            .await
+            .expect("publish durable");
+    }
+    for n in 5..15u128 {
+        router
+            .publish(event(channel, n, DeliveryClass::StreamChunk))
+            .await
+            .expect("publish chunk");
+    }
+
+    sink.reset();
+    let tail = router.durable_tail(channel, 3).await.expect("tail");
+
+    let expected: Vec<u128> = (2..5).collect();
+    assert_eq!(
+        markers(&tail),
+        expected,
+        "stream chunks do not ride the durable tail"
+    );
+    assert_eq!(sink.page_calls(), 0);
+}
+
+/// §3.8 write-behind lag: a durable still pending persistence (the
+/// sink hasn't seen it yet) must appear in the tail — the ring is
+/// authoritative for the recent edge, the sink only lags it.
+#[tokio::test]
+async fn pending_unpersisted_durable_is_served_from_the_ring() {
+    let inner = Arc::new(InMemoryDurableSink::new());
+    let gated = Arc::new(GatedSink::new(inner));
+    let epoch_store = InMemoryEpochStore::new();
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let router = EventRouter::new(
+        RouterConfig {
+            ring_capacity: 64,
+            ..RouterConfig::default()
+        },
+        Arc::new(ManualClock::new(1_700_000_000_000)),
+        seq,
+        gated.clone(),
+    );
+    let channel = RoomId::from_u128(0x9e4d);
+
+    // Appends are gated CLOSED: everything published lives only in the
+    // ring (pinned un-persisted, §3.8).
+    for n in 0..5u128 {
+        router
+            .publish(event(channel, n, DeliveryClass::Durable))
+            .await
+            .expect("publish");
+    }
+
+    let tail = router.durable_tail(channel, 10).await.expect("tail");
+    let expected: Vec<u128> = (0..5).collect();
+    assert_eq!(
+        markers(&tail),
+        expected,
+        "un-persisted durables are in the tail — the ring leads the sink"
+    );
+
+    gated.open(); // release the write-behind so the router task drains
+}
+
+/// No-fallback contract: when the store cannot reverse-page, the read
+/// fails loudly. It must never quietly degrade to materializing the
+/// room (the failing sink's `page` panics to enforce that).
+#[tokio::test]
+async fn tail_surfaces_sink_error_instead_of_scanning() {
+    let epoch_store = InMemoryEpochStore::new();
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let router = EventRouter::new(
+        RouterConfig::default(),
+        Arc::new(ManualClock::new(1_700_000_000_000)),
+        seq,
+        Arc::new(FailingTailSink),
+    );
+
+    let result = router.durable_tail(RoomId::from_u128(0xbad), 25).await;
+
+    assert!(
+        result.is_err(),
+        "reverse-page failure is loud, not a scan fallback"
+    );
+}

--- a/crates/airc-bus/tests/durable_tip.rs
+++ b/crates/airc-bus/tests/durable_tip.rs
@@ -73,6 +73,15 @@ impl DurableSink for CountingSink {
         self.inner.head_cursor(channel).await
     }
 
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner.page_tail(channel, before, limit).await
+    }
+
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
         self.inner.contains(event_id).await
     }
@@ -98,6 +107,15 @@ impl DurableSink for FailingHeadSink {
     }
 
     async fn head_cursor(&self, _channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        Err(BusError::Sink("index unavailable".to_string()))
+    }
+
+    async fn page_tail(
+        &self,
+        _channel: RoomId,
+        _before: Option<Cursor>,
+        _limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
         Err(BusError::Sink("index unavailable".to_string()))
     }
 

--- a/crates/airc-bus/tests/publish_if_new.rs
+++ b/crates/airc-bus/tests/publish_if_new.rs
@@ -168,6 +168,15 @@ impl DurableSink for FlakyContainsSink {
         self.inner.head_cursor(channel).await
     }
 
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner.page_tail(channel, before, limit).await
+    }
+
     async fn contains(&self, event_id: EventId) -> Result<bool, BusError> {
         if self.fail_next_contains.swap(false, Ordering::SeqCst) {
             return Err(BusError::Sink("transient store outage".into()));

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -206,32 +206,41 @@ async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Respons
             }
         }
     };
-    let from = request
-        .since
-        .map(|c| Cursor::new(Seq::new(c.epoch, c.counter), c.event_id));
-    let mut events = match state.router.resume_from_cursor(channel, from).await {
-        Ok(events) => events,
-        Err(error) => {
-            return Response::Error {
-                message: format!("inbox: {error}"),
+    let limit = request.limit.unwrap_or(INBOX_DEFAULT_LIMIT);
+    let events = match request.since {
+        // "Most recent N" when no cursor (card 8428ae8c): reverse-paged
+        // at the store layer — work bounded by N (ring tail + at most
+        // one indexed `page_tail`), NEVER a full-room replay truncated
+        // in memory. `durable_tail` is durable-only by contract.
+        None => match state.router.durable_tail(channel, limit).await {
+            Ok(events) => events,
+            Err(error) => {
+                return Response::Error {
+                    message: format!("inbox: {error}"),
+                }
             }
+        },
+        // "First N after the cursor" when resuming.
+        Some(c) => {
+            let from = Some(Cursor::new(Seq::new(c.epoch, c.counter), c.event_id));
+            let mut events = match state.router.resume_from_cursor(channel, from).await {
+                Ok(events) => events,
+                Err(error) => {
+                    return Response::Error {
+                        message: format!("inbox: {error}"),
+                    }
+                }
+            };
+            // `inbox` is the DURABLE transcript. `resume_from_cursor`
+            // merges the hot ring (which transiently holds every class,
+            // incl. StreamChunk / EphemeralLatest for live attach-replay)
+            // with the sink, so filter to durable here — non-durable
+            // classes never belong in a replay (§3.4).
+            events.retain(|env| env.delivery.is_durable());
+            events.truncate(limit);
+            events
         }
     };
-    // `inbox` is the DURABLE transcript. `resume_from_cursor` merges the
-    // hot ring (which transiently holds every class, incl. StreamChunk /
-    // EphemeralLatest for live attach-replay) with the sink, so filter to
-    // durable here — non-durable classes never belong in a replay (§3.4).
-    events.retain(|env| env.delivery.is_durable());
-    let limit = request.limit.unwrap_or(INBOX_DEFAULT_LIMIT);
-    if events.len() > limit {
-        if request.since.is_none() {
-            // "Most recent N" when no cursor: keep the newest `limit`.
-            events = events.split_off(events.len() - limit);
-        } else {
-            // "First N after the cursor" when resuming.
-            events.truncate(limit);
-        }
-    }
     let envelopes: Vec<Vec<u8>> = events
         .iter()
         .map(|e| airc_wire::encode(e).to_vec())

--- a/crates/airc-daemon/tests/inbox_paging.rs
+++ b/crates/airc-daemon/tests/inbox_paging.rs
@@ -1,0 +1,322 @@
+//! Card 8428ae8c — `Inbox { since: None, limit: N }` against the LIVE
+//! daemon: "most recent N" must cost O(N), not O(room).
+//!
+//! Before this card, the no-cursor inbox path called
+//! `resume_from_cursor(channel, None)` — materializing EVERY durable
+//! envelope in the room — and then threw away all but the newest N.
+//! PR #1144 (card a1562dbc) removed the dominant caller (the tip probe)
+//! but any remaining most-recent-N caller still paid the full-room
+//! replay. These tests pin the correctness of the paged path (exact
+//! tail, ordering, N > room, empty room) and print measured numbers on
+//! a deep room so the O(room)→O(N) claim is backed by real data (the
+//! structural zero-scan proof lives in `airc-bus/tests/durable_tail.rs`).
+//!
+//! The test model IS the production model: a real `DaemonState` over a
+//! real SQLite ORM on a Unix socket, driven by the real `DaemonClient`.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use airc_core::{Headers, PeerId, RoomId};
+use airc_daemon::{run, DaemonRuntimeInfo, DaemonState};
+use airc_ipc::{
+    DaemonClient, InboxRequest, IpcDelivery, IpcKind, IpcTarget, PublishRequest, PublishResponse,
+};
+use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_store::{EventStore, InMemoryEventStore};
+use tokio::task::JoinHandle;
+
+/// A live daemon on a Unix socket, owning a real router + SQLite ORM.
+struct TestDaemon {
+    socket: PathBuf,
+    handle: JoinHandle<()>,
+    _home: tempfile::TempDir,
+}
+
+fn unique_socket() -> PathBuf {
+    // Short /tmp path keeps us well under macOS SUN_LEN (104 bytes).
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!("/tmp/airc-ipg-{}-{n}.sock", std::process::id()))
+}
+
+async fn start_daemon() -> TestDaemon {
+    let home = tempfile::TempDir::new().expect("tempdir");
+    let db_path = home.path().join("events.sqlite");
+    let peer_id = PeerId::new();
+    let keypair = PeerKeypair::generate();
+    let registry = PeerKeyRegistry::new();
+    registry
+        .enrol(peer_id, 0, keypair.public_bytes())
+        .expect("enrol self");
+    let coordinator: Arc<dyn EventStore> = Arc::new(InMemoryEventStore::new());
+    let state = Arc::new(
+        DaemonState::build(
+            peer_id,
+            keypair,
+            Arc::new(registry),
+            VerificationPolicy::Strict,
+            home.path().to_path_buf(),
+            &db_path,
+            coordinator,
+            DaemonRuntimeInfo::unknown(),
+        )
+        .await
+        .expect("build daemon state"),
+    );
+    let socket = unique_socket();
+    let server_state = state.clone();
+    let server_socket = socket.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run(server_state, server_socket).await;
+    });
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    TestDaemon {
+        socket,
+        handle,
+        _home: home,
+    }
+}
+
+impl TestDaemon {
+    async fn stop(self) {
+        let _ = DaemonClient::new(self.socket.clone()).stop().await;
+        let _ = tokio::time::timeout(Duration::from_secs(3), self.handle).await;
+    }
+}
+
+fn durable_text(channel: RoomId, text: &str) -> PublishRequest {
+    PublishRequest {
+        channel: channel.as_uuid(),
+        from_peer: uuid::Uuid::from_u128(0xA11CE),
+        from_client: uuid::Uuid::from_u128(0x7AB),
+        kind: IpcKind::Message,
+        delivery: IpcDelivery::Durable,
+        target: IpcTarget::All,
+        correlation_id: None,
+        coalesce_key: None,
+        payload: text.as_bytes().to_vec(),
+        headers: Headers::new(),
+    }
+}
+
+fn stream_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
+    PublishRequest {
+        channel: channel.as_uuid(),
+        from_peer: uuid::Uuid::from_u128(0xA11CE),
+        from_client: uuid::Uuid::from_u128(0x7AB),
+        kind: IpcKind::StreamChunk,
+        delivery: IpcDelivery::StreamChunk,
+        target: IpcTarget::All,
+        correlation_id: None,
+        coalesce_key: None,
+        payload: bytes.to_vec(),
+        headers: Headers::new(),
+    }
+}
+
+async fn publish_n(client: &DaemonClient, channel: RoomId, n: usize) -> PublishResponse {
+    let mut last = None;
+    for i in 0..n {
+        let request = durable_text(channel, &format!("event {i}"));
+        // The write-behind queue is bounded: on a slow runner a tight
+        // publish loop can outpace the SQLite drain, and the daemon
+        // sheds with a LOUD typed error (§3.8 — the designed
+        // back-pressure signal, never a silent drop). Honour the
+        // contract the way a real producer would: back off and retry
+        // the same event. Any other error is a real failure.
+        let mut receipt = None;
+        for _ in 0..500 {
+            match client.publish(request.clone()).await {
+                Ok(r) => {
+                    receipt = Some(r);
+                    break;
+                }
+                Err(error) => {
+                    let message = error.to_string();
+                    assert!(
+                        message.contains("saturated"),
+                        "unexpected publish error: {message}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        }
+        last = Some(receipt.expect("publish kept saturating after 500 backoff retries"));
+    }
+    last.expect("n > 0")
+}
+
+/// Decode the payload text out of a wire envelope buffer.
+fn payload_text(bytes: Vec<u8>) -> String {
+    let env = airc_wire::decode(bytes.into()).expect("decode wire envelope");
+    String::from_utf8(env.payload.to_vec()).expect("utf8 payload")
+}
+
+/// Correctness pins for the most-recent-N path: exact newest N in
+/// ascending order, N > room size returns the whole room, the empty
+/// room returns nothing, and a non-durable burst never rides along.
+#[tokio::test]
+async fn inbox_most_recent_n_returns_exact_ascending_tail() {
+    let daemon = start_daemon().await;
+    let client = DaemonClient::new(daemon.socket.clone());
+    let channel = RoomId::from_u128(0x7a11);
+
+    // Empty room: no envelopes, no newest cursor.
+    let empty = client
+        .inbox(InboxRequest {
+            since: None,
+            channel: Some(channel),
+            limit: Some(10),
+        })
+        .await
+        .expect("inbox on empty room");
+    assert!(empty.envelopes.is_empty(), "empty room pages empty");
+    assert_eq!(empty.newest, None);
+
+    let receipt = publish_n(&client, channel, 25).await;
+    // A trailing non-durable burst must not appear in the transcript
+    // tail (inbox is the DURABLE transcript).
+    for _ in 0..8 {
+        client
+            .publish(stream_chunk(channel, b"\x01\x02\x03"))
+            .await
+            .expect("publish chunk");
+    }
+
+    // Most recent 10 of 25: events 15..=24, ascending.
+    let page = client
+        .inbox(InboxRequest {
+            since: None,
+            channel: Some(channel),
+            limit: Some(10),
+        })
+        .await
+        .expect("inbox limit 10");
+    let texts: Vec<String> = page.envelopes.into_iter().map(payload_text).collect();
+    let expected: Vec<String> = (15..25).map(|i| format!("event {i}")).collect();
+    assert_eq!(texts, expected, "exact newest N, ascending order");
+    let newest = page.newest.expect("newest cursor");
+    assert_eq!(
+        (newest.epoch, newest.counter, newest.event_id),
+        (receipt.epoch, receipt.counter, receipt.event_id),
+        "newest cursor is the last durable publish receipt"
+    );
+
+    // N larger than the room: the whole room, still ascending.
+    let all = client
+        .inbox(InboxRequest {
+            since: None,
+            channel: Some(channel),
+            limit: Some(500),
+        })
+        .await
+        .expect("inbox limit 500");
+    let texts: Vec<String> = all.envelopes.into_iter().map(payload_text).collect();
+    let expected: Vec<String> = (0..25).map(|i| format!("event {i}")).collect();
+    assert_eq!(texts, expected, "N > room size returns the full room");
+
+    daemon.stop().await;
+}
+
+/// The honest perf evidence (card 8428ae8c): on a room thousands of
+/// events deep, `Inbox { since: None, limit: N }` for small N must cost
+/// a fraction of materializing the room. The measured µs/op for the
+/// paged probe is printed for the PR body; the hard structural gate
+/// (zero full-scan calls) lives in `airc-bus/tests/durable_tail.rs`.
+#[tokio::test]
+async fn deep_room_most_recent_n_costs_by_n_not_room_depth() {
+    const DEEP: usize = 5_000;
+    const N: usize = 50;
+    const PROBES: u32 = 20;
+
+    let daemon = start_daemon().await;
+    let client = DaemonClient::new(daemon.socket.clone());
+    let channel = RoomId::from_u128(0xd44b);
+
+    let receipt = publish_n(&client, channel, DEEP).await;
+
+    // Paged path: most recent N on the deep room.
+    let paged_start = Instant::now();
+    let mut paged_newest = None;
+    let mut paged_len = 0;
+    for _ in 0..PROBES {
+        let page = client
+            .inbox(InboxRequest {
+                since: None,
+                channel: Some(channel),
+                limit: Some(N),
+            })
+            .await
+            .expect("inbox limit N");
+        paged_len = page.envelopes.len();
+        paged_newest = page.newest;
+    }
+    let paged_elapsed = paged_start.elapsed();
+
+    // Full-tail shape for comparison: N >= room size genuinely returns
+    // every envelope, so its cost is the O(room) floor.
+    let full_start = Instant::now();
+    let mut full_newest = None;
+    let mut full_len = 0;
+    for _ in 0..PROBES {
+        let page = client
+            .inbox(InboxRequest {
+                since: None,
+                channel: Some(channel),
+                limit: Some(DEEP),
+            })
+            .await
+            .expect("inbox limit DEEP");
+        full_len = page.envelopes.len();
+        full_newest = page.newest;
+    }
+    let full_elapsed = full_start.elapsed();
+
+    // Same answer at the tail…
+    assert_eq!(paged_len, N, "paged path returns exactly N");
+    assert_eq!(full_len, DEEP, "full path returns the whole room");
+    let paged_newest = paged_newest.expect("paged newest");
+    let full_newest = full_newest.expect("full newest");
+    assert_eq!(
+        paged_newest, full_newest,
+        "paged and full tails agree on the newest cursor"
+    );
+    assert_eq!(
+        (paged_newest.epoch, paged_newest.counter),
+        (receipt.epoch, receipt.counter),
+        "and both are the last publish receipt"
+    );
+
+    let paged_us = paged_elapsed.as_micros() / u128::from(PROBES);
+    let full_us = full_elapsed.as_micros() / u128::from(PROBES);
+    eprintln!(
+        "card 8428ae8c: room depth {DEEP}, {PROBES} probes each — \
+         inbox(since:None, limit:{N}): {paged_us} µs/op; \
+         inbox(since:None, limit:{DEEP}) full tail: {full_us} µs/op"
+    );
+
+    // …at strictly lower cost: the paged probe's work tracks N, not the
+    // room depth. The margin is deliberately 10x, not 2x: the OLD
+    // full-materialize-then-truncate shape already sat ~6x under the
+    // full tail (it skipped the encode of 4,950 envelopes), so a 2x
+    // assertion could not detect a regression to it. The reverse-paged
+    // path measures ~100x under the full tail locally, leaving an order
+    // of magnitude of headroom for CI scheduling noise — and the ratio
+    // is contention-stable because both legs ride the same daemon.
+    assert!(
+        paged_elapsed * 10 < full_elapsed,
+        "most-recent-{N} ({paged_us} µs/op) must be at least 10x cheaper than \
+         materializing the {DEEP}-deep room ({full_us} µs/op) — a fall-back to \
+         full-room replay sits ~6x under it and must fail here"
+    );
+
+    daemon.stop().await;
+}

--- a/crates/airc-daemon/tests/room_tip_probe.rs
+++ b/crates/airc-daemon/tests/room_tip_probe.rs
@@ -220,14 +220,22 @@ async fn room_tip_is_none_for_empty_room_and_tracks_publishes() {
     daemon.stop().await;
 }
 
-/// The honest perf evidence (card a1562dbc): on a room thousands of
-/// events deep, the typed tip probe answers the same cursor as the old
-/// `Inbox { since: None, limit: 1 }` shape — which forces a full-room
-/// replay inside the daemon — at a fraction of the cost. Real measured
-/// numbers are printed for the PR body; the hard structural O(1) gate
-/// (zero scan calls) lives in `airc-bus/tests/durable_tip.rs`.
+/// Card a1562dbc: on a room thousands of events deep, the typed tip
+/// probe answers the same cursor as `Inbox { since: None, limit: 1 }`.
+///
+/// History: when this test was written the inbox shape forced a
+/// full-room replay (99,129 µs/op vs the probe's 441 µs/op on this
+/// room — #1144's evidence) and the test asserted the probe was at
+/// least 2x cheaper. Card 8428ae8c then fixed the inbox path itself
+/// (reverse paging — `EventRouter::durable_tail`), making both legs
+/// bounded (~hundreds of µs, IPC-dominated), so the timing race
+/// between two O(1) paths became scheduling noise and was removed.
+/// What remains load-bearing here is the AGREEMENT pin; the hard
+/// structural no-scan gates live in `airc-bus/tests/durable_tip.rs`
+/// (the probe) and `airc-bus/tests/durable_tail.rs` (the inbox path).
+/// Measured numbers are still printed for the record.
 #[tokio::test]
-async fn deep_room_tip_probe_matches_inbox_scan_and_is_cheaper() {
+async fn deep_room_tip_probe_matches_inbox_newest() {
     const DEEP: usize = 5_000;
     const PROBES: u32 = 20;
 
@@ -237,8 +245,7 @@ async fn deep_room_tip_probe_matches_inbox_scan_and_is_cheaper() {
 
     let receipt = publish_n(&client, channel, DEEP).await;
 
-    // Old path: inbox with no cursor — daemon replays all DEEP events
-    // and returns the newest 1.
+    // Inbox shape: most-recent-1 (reverse-paged since card 8428ae8c).
     let scan_start = Instant::now();
     let mut scan_newest = None;
     for _ in 0..PROBES {
@@ -280,18 +287,8 @@ async fn deep_room_tip_probe_matches_inbox_scan_and_is_cheaper() {
     let probe_us = probe_elapsed.as_micros() / u128::from(PROBES);
     eprintln!(
         "card a1562dbc: room depth {DEEP}, {PROBES} probes each — \
-         inbox(limit:1) full-room scan: {scan_us} µs/op; \
+         inbox(limit:1) most-recent-1: {scan_us} µs/op; \
          room_tip probe: {probe_us} µs/op"
-    );
-
-    // …at strictly lower cost. The scan materializes DEEP envelopes per
-    // call; the probe reads one ring slot / one indexed row. A generous
-    // margin (2x) keeps this stable under CI scheduling noise — locally
-    // the gap is orders of magnitude.
-    assert!(
-        probe_elapsed * 2 < scan_elapsed,
-        "tip probe ({probe_us} µs/op) should be far cheaper than the \
-         full-room inbox scan ({scan_us} µs/op) on a {DEEP}-deep room"
     );
 
     daemon.stop().await;

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -382,6 +382,35 @@ impl Airc {
         }))
     }
 
+    /// Cursor of the newest transcript event on `channel` — via the
+    /// daemon's O(1) `room_tip` when attached, the local store's
+    /// indexed `latest_cursor` otherwise.
+    ///
+    /// Card 8428ae8c: this is THE channel-tip read for every consumer
+    /// surface (`latest_cursor`, `subscription_cursor`, the work-board
+    /// freshness probe). Daemon-attached scopes used to read the LOCAL
+    /// store here — a pre-existing inconsistency: under the owner-core
+    /// model the daemon's ORM is the transcript, and an attached
+    /// scope's local store can be empty or stale, so the local read
+    /// answered `None`/old for rooms with live daemon history. The
+    /// typed `room_tip` op (card a1562dbc) makes asking the daemon as
+    /// cheap as the local index, so attached instances now get the
+    /// daemon's view. No new IPC op is needed for the subscription
+    /// shape: a subscription cursor IS the tip of the subscription's
+    /// room, and the subscription set itself is local scope config.
+    pub(crate) async fn channel_latest_cursor(
+        &self,
+        channel: RoomId,
+    ) -> Result<Option<TranscriptCursor>, AircError> {
+        if self.is_daemon_attached() {
+            return self.daemon_latest_transcript_cursor(channel).await;
+        }
+        self.event_store()
+            .latest_cursor(Some(channel))
+            .await
+            .map_err(AircError::from)
+    }
+
     /// Live subscribe across `channels` via the daemon: open one IPC
     /// attach per channel, decode each into a `TranscriptEvent`, and
     /// merge them into a single [`EventStream`]. The attach tasks are

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -368,10 +368,13 @@ impl Airc {
             .collect())
     }
 
-    /// Cursor of the newest event in the current room.
+    /// Cursor of the newest event in the current room — via the daemon
+    /// when attached (its ORM is the transcript; the local store can be
+    /// empty/stale on an attached scope), the local store otherwise
+    /// (card 8428ae8c).
     pub async fn latest_cursor(&self) -> Result<Option<TranscriptCursor>, AircError> {
         let room = self.current_room().await?;
-        Ok(self.inner.store.latest_cursor(Some(room.channel)).await?)
+        self.channel_latest_cursor(room.channel).await
     }
 
     /// Append a `TranscriptEvent` to the durable store directly.

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -499,7 +499,10 @@ impl Airc {
         self.current_room().await
     }
 
-    /// Cursor of the newest event in a subscribed channel.
+    /// Cursor of the newest event in a subscribed channel — via the
+    /// daemon when attached (its ORM is the transcript; the local store
+    /// can be empty/stale on an attached scope), the local store
+    /// otherwise (card 8428ae8c).
     ///
     /// `None` means either the channel has no events yet or this
     /// scope is not subscribed to it. Use [`Self::is_subscribed`] when
@@ -512,11 +515,7 @@ impl Airc {
         let Some(subscription) = set.subscribed.get(channel) else {
             return Ok(None);
         };
-        Ok(self
-            .inner
-            .store
-            .latest_cursor(Some(subscription.room_id))
-            .await?)
+        self.channel_latest_cursor(subscription.room_id).await
     }
 
     pub(crate) async fn subscribed_event_filter(

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -1057,18 +1057,12 @@ impl Airc {
 
     /// Cursor of the newest transcript event on `room`'s channel, or
     /// `None` for an empty room — via the daemon when attached, the
-    /// local store otherwise.
+    /// local store otherwise (the shared card-8428ae8c tip read).
     async fn room_latest_cursor(
         &self,
         room: &crate::Room,
     ) -> Result<Option<airc_core::TranscriptCursor>, AircError> {
-        if self.is_daemon_attached() {
-            return self.daemon_latest_transcript_cursor(room.channel).await;
-        }
-        self.event_store()
-            .latest_cursor(Some(room.channel))
-            .await
-            .map_err(AircError::from)
+        self.channel_latest_cursor(room.channel).await
     }
 
     /// Return work cards this peer could reasonably take next. This

--- a/crates/airc-lib/tests/daemon_cursor_reads.rs
+++ b/crates/airc-lib/tests/daemon_cursor_reads.rs
@@ -1,0 +1,81 @@
+//! Card 8428ae8c — daemon-attached cursor reads ask the DAEMON.
+//!
+//! `Airc::latest_cursor` / `Airc::subscription_cursor` used to read the
+//! LOCAL store even when the scope was daemon-attached. Under the
+//! owner-core model the daemon's ORM is the transcript and an attached
+//! scope's local store can be empty or stale — so those reads answered
+//! `None` (or an old cursor) for rooms with live daemon history. With
+//! the typed O(1) `room_tip` op (card a1562dbc) asking the daemon is as
+//! cheap as the local index, so attached instances now route through
+//! it. Local (non-attached) instances are unchanged.
+//!
+//! The discriminating actor is a scope that never wrote anything to its
+//! own store: if the routing regresses to the local read, every
+//! assertion below sees `None` instead of the daemon's tip.
+
+mod common;
+
+use airc_lib::ChannelName;
+use common::Machine;
+
+#[tokio::test]
+async fn attached_latest_cursor_is_the_daemon_tip_not_the_local_store() {
+    let machine = Machine::boot().await;
+    let (alice, bob) = machine.pair_in("cursor-reads").await;
+
+    // History exists only in the DAEMON's ORM — neither scope's local
+    // store has these events.
+    alice.say("one").await.expect("say one");
+    alice.say("two").await.expect("say two");
+    let last = alice.say("three").await.expect("say three");
+
+    // Bob never wrote anything; his local store knows nothing. The
+    // daemon-attached read must still see the room tip.
+    let cursor = bob
+        .latest_cursor()
+        .await
+        .expect("latest_cursor")
+        .expect("attached read sees the daemon's history");
+    assert_eq!(
+        cursor.event_id, last,
+        "latest_cursor is the daemon's newest durable, not local state"
+    );
+
+    // And it agrees with the sender's view of the same room.
+    let alice_cursor = alice
+        .latest_cursor()
+        .await
+        .expect("latest_cursor")
+        .expect("sender sees the tip too");
+    assert_eq!(alice_cursor, cursor, "both scopes read the same tip");
+}
+
+#[tokio::test]
+async fn attached_subscription_cursor_is_the_daemon_tip() {
+    let machine = Machine::boot().await;
+    let (alice, bob) = machine.pair_in("sub-cursor").await;
+
+    let last = alice.say("newest").await.expect("say");
+
+    let channel = ChannelName::new("sub-cursor").expect("channel name");
+    let cursor = bob
+        .subscription_cursor(&channel)
+        .await
+        .expect("subscription_cursor")
+        .expect("subscribed channel with daemon history has a cursor");
+    assert_eq!(
+        cursor.event_id, last,
+        "subscription_cursor is the daemon's room tip"
+    );
+
+    // A channel this scope is not subscribed to still answers None —
+    // the subscription gate is unchanged by the daemon routing.
+    let unsubscribed = ChannelName::new("not-joined").expect("channel name");
+    assert_eq!(
+        bob.subscription_cursor(&unsubscribed)
+            .await
+            .expect("subscription_cursor"),
+        None,
+        "unsubscribed channel stays None"
+    );
+}

--- a/crates/airc-store/src/bus_sink.rs
+++ b/crates/airc-store/src/bus_sink.rs
@@ -180,6 +180,63 @@ impl DurableSink for SqliteDurableSink {
         rows.into_iter().map(from_model).collect()
     }
 
+    /// Card 8428ae8c: the reverse-paging leg of "most recent N". One
+    /// indexed query — `ORDER BY (epoch, counter, event_id) DESC
+    /// LIMIT n` rides the same composite
+    /// `(room_id, epoch, counter, event_id)` index as [`Self::page`]
+    /// (SQLite B-tree indexes serve both scan directions) — then the
+    /// page is reversed in memory so callers get ascending total
+    /// order. Cost is bounded by `limit`, never by channel depth.
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        // Same bind clamp as `page`: a huge limit means "the whole
+        // tail", never a `usize::MAX` sentinel reaching SQL.
+        let bounded = u64::try_from(limit)
+            .unwrap_or(u64::MAX)
+            .min(i64::MAX as u64);
+
+        let mut query =
+            bus_event::Entity::find().filter(bus_event::Column::RoomId.eq(channel.as_uuid()));
+
+        // Strictly before the cursor in generational order — the exact
+        // mirror of `page`'s strictly-after predicate:
+        //   epoch < c.epoch
+        //   OR (epoch == c.epoch AND counter < c.counter)
+        //   OR (epoch == c.epoch AND counter == c.counter
+        //       AND event_id < c.event_id).
+        if let Some(c) = before {
+            let epoch = c.seq.epoch as i64;
+            let counter = c.seq.counter as i64;
+            let event_id = c.event_id.as_uuid();
+            let strictly_before = Expr::col(bus_event::Column::Epoch)
+                .lt(epoch)
+                .or(Expr::col(bus_event::Column::Epoch)
+                    .eq(epoch)
+                    .and(Expr::col(bus_event::Column::Counter).lt(counter)))
+                .or(Expr::col(bus_event::Column::Epoch)
+                    .eq(epoch)
+                    .and(Expr::col(bus_event::Column::Counter).eq(counter))
+                    .and(Expr::col(bus_event::Column::EventId).lt(event_id)));
+            query = query.filter(strictly_before);
+        }
+
+        let rows = query
+            .order_by_desc(bus_event::Column::Epoch)
+            .order_by_desc(bus_event::Column::Counter)
+            .order_by_desc(bus_event::Column::EventId)
+            .limit(bounded)
+            .all(&self.db)
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+
+        // DESC off the index, ascending to the caller.
+        rows.into_iter().rev().map(from_model).collect()
+    }
+
     /// Card 7d5b6a65: efficient head-cursor query for the
     /// `AttachRequest::from_now` path. The trait's default impl pages
     /// the entire channel to find the last cursor; the SQLite override
@@ -502,6 +559,72 @@ mod tests {
         let after = sink.page(ch, Some(lo.cursor()), 10).await.unwrap();
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].event_id, hi.event_id);
+    }
+
+    #[tokio::test]
+    async fn page_tail_returns_newest_n_ascending() {
+        // Card 8428ae8c: the reverse page returns the LAST n in
+        // ascending order — one DESC-indexed query, reversed in memory.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(0x7a11);
+        for c in 0..10u64 {
+            sink.append(&durable_at(ch, 1, c)).await.unwrap();
+        }
+
+        let tail = sink.page_tail(ch, None, 4).await.unwrap();
+        let counters: Vec<u64> = tail.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(counters, vec![6, 7, 8, 9], "newest 4, ascending");
+
+        // n beyond the channel: the whole channel.
+        let all = sink.page_tail(ch, None, 100).await.unwrap();
+        let counters: Vec<u64> = all.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(counters, (0..10).collect::<Vec<u64>>());
+
+        // Empty channel: empty tail.
+        assert!(sink
+            .page_tail(RoomId::from_u128(0xd0), None, 5)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Channel isolation: another channel's events never ride along.
+        let other = RoomId::from_u128(0x7a12);
+        sink.append(&durable_at(other, 1, 99)).await.unwrap();
+        let tail = sink.page_tail(ch, None, 100).await.unwrap();
+        assert_eq!(tail.len(), 10, "tail is per-channel");
+    }
+
+    #[tokio::test]
+    async fn page_tail_strictly_before_cursor_across_epochs() {
+        // The `before` bound mirrors `page`'s strictly-after predicate
+        // in generational order: epoch dominates counter, event_id
+        // tiebreaks — and the row AT the cursor is excluded.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(0xe9);
+        // Appended out of order on purpose; total order is
+        // (1,0) (1,1) (1,2) (2,0) (2,1).
+        sink.append(&durable_at(ch, 2, 1)).await.unwrap();
+        sink.append(&durable_at(ch, 1, 2)).await.unwrap();
+        sink.append(&durable_at(ch, 1, 0)).await.unwrap();
+        sink.append(&durable_at(ch, 2, 0)).await.unwrap();
+        sink.append(&durable_at(ch, 1, 1)).await.unwrap();
+
+        let before = durable_at(ch, 2, 0).cursor();
+        let tail = sink.page_tail(ch, Some(before), 2).await.unwrap();
+        let order: Vec<(u64, u64)> = tail.iter().map(|e| (e.seq.epoch, e.seq.counter)).collect();
+        assert_eq!(
+            order,
+            vec![(1, 1), (1, 2)],
+            "newest 2 strictly before (2,0): the cursor row is excluded, epoch dominates"
+        );
+
+        // A cursor before everything: empty tail.
+        let before = durable_at(ch, 1, 0).cursor();
+        assert!(sink
+            .page_tail(ch, Some(before), 10)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/airc-store/tests/bus_router_durable_tier.rs
+++ b/crates/airc-store/tests/bus_router_durable_tier.rs
@@ -79,6 +79,15 @@ impl DurableSink for GatedSqliteSink {
         self.inner.head_cursor(channel).await
     }
 
+    async fn page_tail(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner.page_tail(channel, before, limit).await
+    }
+
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
         self.inner.contains(event_id).await
     }


### PR DESCRIPTION
## What / why

Card `8428ae8c` (P2) — the residual from #1144 (card a1562dbc, O(1) `room_tip`). Two items:

### 1. Indexed reverse paging for `Inbox { since: None, limit: N }`

The "most recent N" inbox path still materialized the WHOLE room before truncating: `handle_inbox` called `resume_from_cursor(channel, None)` (deep sink page with `usize::MAX` + ring merge + sort + dedup), then kept the newest N. #1144 removed the dominant caller (the work-board tip probe) but any remaining most-recent-N caller — e.g. `airc-lib`'s `daemon_page_recent` / `daemon_page_recent_subscribed` — paid O(room) per call.

This adds **reverse paging at the store layer**, wired daemon → sink:

- **airc-bus**: new required `DurableSink::page_tail(channel, before, limit)` — the last `limit` events strictly before a cursor (or the channel tail when `None`), ascending. **NO default impl** (mirroring #1144's removal of the scan-shaped `head_cursor` default): a sink that cannot reverse-page is a **compile error**, never a silent forward scan. `EventRouter::durable_tail(channel, limit)`: ring durables are the channel's newest durables (oldest-first eviction + §3.8 pinned-until-persisted ⇒ everything older is in the sink), topped up by ONE `page_tail` strictly before the ring's oldest retained cursor — no dup, no gap, durable-only. A sink error **propagates**; there is no scan fallback.
- **airc-store**: SQLite `page_tail` = `ORDER BY (epoch, counter, event_id) DESC LIMIT n` with a strictly-before generational predicate (exact mirror of `page`'s strictly-after), reversed in memory. It rides the **existing** composite index `idx_bus_events_room_epoch_counter_event_id` (verified in `m20260526_000011_create_bus_events.rs`; SQLite B-tree indexes serve both scan directions with an equality prefix on `room_id`) — no migration needed.
- **airc-daemon**: `handle_inbox`'s `since: None` arm now answers from `durable_tail`. The `since: Some` resume arm is unchanged. **No IPC change** — `InboxRequest`/`InboxResponse` wire shapes untouched.

### 2. Daemon-attached cursor reads no longer bypass the daemon

`Airc::latest_cursor` / `Airc::subscription_cursor` read the LOCAL store even when daemon-attached — pre-existing inconsistency (flagged in #1144's residual notes): under the owner-core model the daemon's ORM is the transcript and an attached scope's local store can be empty/stale, so those reads answered `None`/old for rooms with live daemon history. #1144's `room_tip` makes asking the daemon O(1), so both now route through the new shared `Airc::channel_latest_cursor` → `daemon_latest_transcript_cursor` (`room_tip`) when attached, local store otherwise. `work.rs::room_latest_cursor` (which already branched) is deduplicated onto the same helper. Local (non-attached) instances are unchanged.

**No new IPC op was needed for `subscription_cursor`** (the card asked to check): a subscription cursor IS the tip of the subscription's room — `room_tip` (card a1562dbc) is the typed op; the subscription set itself is local scope config. Audited: nothing else in the workspace reads a channel tip behind the daemon's back.

## O(room) → O(N) evidence

**Measured, live daemon over a Unix socket, real SQLite ORM, debug build, idle machine, same benchmark file at base vs head** (`airc-daemon/tests/inbox_paging.rs::deep_room_most_recent_n_costs_by_n_not_room_depth`, 5,000-event room, 20 probes each):

```
BEFORE (80122ad):  inbox(since:None, limit:50):  105,820 µs/op
AFTER  (this PR):  inbox(since:None, limit:50):    6,204 µs/op   (~17x)
full tail (limit:5000, the O(room) floor):  636,248 → 638,795 µs/op (unchanged)
```

The remaining ~6 ms is N-proportional work (50-row indexed read + envelope encode + IPC round-trip), independent of room depth; the full-tail floor is untouched, so the win is pure removal of the O(room) materialize.

Corroborated by #1144's own benchmark (`room_tip_probe.rs`, same 5,000-event room): `inbox(since:None, limit:1)` — measured at **99,129 µs/op** when #1144 landed — now answers in **511 µs/op (~194x)**, within ~1.7x of the `room_tip` probe itself (302 µs/op). That converged so hard it **broke #1144's `probe*2 < scan` timing race** (the O(room) leg it raced against no longer exists): `deep_room_tip_probe_matches_inbox_scan_and_is_cheaper` is renamed `deep_room_tip_probe_matches_inbox_newest`, keeping the cursor-agreement pin + printed numbers and dropping the now-noise race between two bounded paths (history preserved in its doc comment).

**Structural proof, not vibes** (`airc-bus/tests/durable_tail.rs`): counting-sink decorator — most-recent-200 on a 5,000-deep room (ring capacity 64, depth genuinely in the sink) must complete with **zero `page` calls** (the forward-scan primitive), **≤1 `page_tail`** call, and a requested reverse-page limit **≤ N**, while returning exactly the newest N ascending across the sink→ring seam. The no-fallback contract is enforced with a sink whose `page` *panics* and whose `page_tail` errors: `durable_tail` surfaces the error, never scans.

## Tests

- `airc-bus/tests/durable_tail.rs` (6): 5,000-deep bounded-work proof; ring-covered N does zero store reads; N > room + empty room + limit 0; non-durable traffic excluded; §3.8 un-persisted pending durable served from the ring (gated sink); sink error is loud (no scan fallback).
- `airc-store` `bus_sink.rs` unit tests (2): `page_tail` newest-N ascending / N>channel / empty / channel isolation; strictly-before predicate across epochs (epoch dominates, cursor row excluded).
- `airc-daemon/tests/inbox_paging.rs` (2): live-daemon correctness pins (exact ascending tail, newest cursor = last receipt, N > room, empty room, stream-chunk burst excluded) + the measured deep-room evidence with a **10x** margin (deliberately not 2x: the old full-materialize shape already sat ~6x under the full tail since it skipped encoding 4,950 envelopes — a 2x gate could not detect a regression to it; the paged path measures ~100x under, leaving an order of magnitude of CI headroom).
- `airc-lib/tests/daemon_cursor_reads.rs` (2): attached scope whose local store never saw the events reads the daemon tip via `latest_cursor` and `subscription_cursor`; unsubscribed channel still answers `None` (the subscription gate is unchanged).

## Mutation evidence (each applied, observed failing, restored)

- **M1** — revert `EventRouter::durable_tail` to the full-materialize shape (`resume_from_cursor(channel, None)` + retain + truncate): 4/6 `durable_tail.rs` tests **FAILED** (zero-`page` structural gate; panicking no-fallback sink). Restored → green.
- **M2** — revert ONLY the `handle_inbox` wiring to the old full-room replay (leaving `durable_tail` intact): `inbox_paging.rs` deep test **FAILED** the 10x margin (91,085 µs/op vs 551,960 — ~6x). Restored → green. This is exactly the regression the 2x-style margin would have missed.
- **M3** — revert `channel_latest_cursor` to always-local: both `daemon_cursor_reads.rs` tests **FAILED**. Restored → green.
- **M4** — drop the in-memory reversal in SQLite `page_tail` (DESC handed to the caller): both `bus_sink` `page_tail` unit tests **FAILED**. Restored → green.

(No wire pins to mutate: this PR adds no IPC variants/fields — item 1 changes only who answers `Inbox{since:None}`, item 2 reuses `room_tip`'s pinned wire shape from #1144.)

## Gate

- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` → clean
- `cargo fmt --all -- --check` → clean
- `cargo test --workspace -- --skip codex_hook` → all green (codex_hook skipped per macOS hang)
- Zero leaked temp-home daemons (in-process daemon fixtures only; #1159/#1161 guarded harness untouched)

Card: 8428ae8c-e62d-40de-8de2-19a81633f614
Lineage: #1144 (card a1562dbc) — this card is its declared residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
