### PR TITLE
fix(setup): fresh Windows/new-user install — airc on PATH, gh wiring, git identity

### DIFF
--- a/bootstrap-airc.sh
+++ b/bootstrap-airc.sh
@@ -47,16 +47,29 @@ else
   ok "airc already on PATH: $(command -v airc)"
 fi
 
-# 2. pre-flight (catches Tailscale-down, gh-missing, network-out, etc.)
-step "Pre-flight: airc doctor --connect"
-if ! airc doctor --connect; then
+# 2. pre-flight (live route/process state — catches daemon/route issues
+#    before join). The rust-rewrite `airc doctor` exposes `--health` for
+#    this; the old `--connect` flag no longer exists and made this
+#    pre-flight hard-fail on every fresh rust install. Fixed 2026-06-13.
+step "Pre-flight: airc doctor --health"
+if ! airc doctor --health; then
   die "Pre-flight failed. Fix the items above, then re-run this script."
 fi
 
-# 3. gh auth if needed
+# 3. gh auth if needed. Match install.sh's invocation exactly:
+#    -h github.com pins the host (avoids the interactive host picker),
+#    -s gist requests the scope the substrate needs. After a successful
+#    login, wire gh's token into git's credential helper so gist
+#    fetch/push (airc's rendezvous hot path) doesn't pop a password
+#    prompt on every op. Without setup-git, auth-after-install left the
+#    helper unwired — caught live on Windows 2026-06-13.
 if ! gh auth status >/dev/null 2>&1; then
   step "Authenticating gh (need 'gist' scope for room substrate)"
-  gh auth login -s gist
+  gh auth login -h github.com -s gist
+fi
+# Idempotent (no-op if already configured); safe to always run.
+if ! git config --global --get-all credential.https://github.com.helper 2>/dev/null | grep -q 'gh auth git-credential'; then
+  gh auth setup-git 2>/dev/null && ok "gh token wired into git credential helper" || true
 fi
 
 # 4. join the room

--- a/install.sh
+++ b/install.sh
@@ -431,6 +431,37 @@ ensure_prereqs() {
       fi
     fi
   fi
+
+  # Git author identity. Agents in this substrate commit and open PRs,
+  # and a fresh machine has no global user.name/user.email — the first
+  # commit then dies with "Author identity unknown" (caught live on a
+  # clean Windows box 2026-06-13). Derive it from the authenticated gh
+  # account when unset; never clobber an identity the user already set.
+  # Email prefers the account's public email, falling back to the GitHub
+  # noreply alias (<id>+<login>@users.noreply.github.com), which always
+  # matches the account and avoids leaking a private address.
+  if command -v gh >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    _need_name=0; _need_email=0
+    if [ -z "$(git config --global user.name 2>/dev/null || true)" ]; then _need_name=1; fi
+    if [ -z "$(git config --global user.email 2>/dev/null || true)" ]; then _need_email=1; fi
+    if [ "$_need_name" = 1 ] || [ "$_need_email" = 1 ]; then
+      _gh_login="$(gh api user --jq '.login' 2>/dev/null || true)"
+      _gh_name="$(gh api user --jq '.name // .login' 2>/dev/null || true)"
+      _gh_id="$(gh api user --jq '.id' 2>/dev/null || true)"
+      _gh_email="$(gh api user --jq '.email // empty' 2>/dev/null || true)"
+      if [ -z "$_gh_email" ] && [ -n "$_gh_id" ] && [ -n "$_gh_login" ]; then
+        _gh_email="${_gh_id}+${_gh_login}@users.noreply.github.com"
+      fi
+      if [ "$_need_name" = 1 ] && [ -n "$_gh_name" ]; then
+        git config --global user.name "$_gh_name"
+        info "git user.name set from gh: $_gh_name (override: git config --global user.name ...)"
+      fi
+      if [ "$_need_email" = 1 ] && [ -n "$_gh_email" ]; then
+        git config --global user.email "$_gh_email"
+        info "git user.email set from gh: $_gh_email (override: git config --global user.email ...)"
+      fi
+    fi
+  fi
 }
 
 ensure_prereqs

--- a/install.sh
+++ b/install.sh
@@ -537,38 +537,74 @@ fi
 
 _add_path_entry() {
   local path_entry="$1"
-  local rc
+  local rc rc_target=""
   # Always reconcile the rc file regardless of current-shell PATH
   # state. The rc is persistent; $PATH is transient and may have been
   # manually augmented by the operator in this shell. Conflating them
   # (early-return when PATH already contains the entry) was the bug
   # that left stale airc-managed PATH lines in ~/.zshrc after install
   # re-runs — caught live 2026-05-20.
+  #
+  # Pass 1: reconcile EVERY rc that already exists (strip stale
+  # airc-managed lines so reruns are idempotent and entries pointing at
+  # retired install dirs don't accumulate), and remember the first
+  # existing one as the write target.
   for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
     [ -f "$rc" ] || continue
     # Strip any pre-existing airc-managed PATH lines (marked with the
-    # trailing `# airc` comment) so reruns are idempotent and stale
-    # entries pointing at retired install dirs (e.g., ~/.local/bin from
-    # the pre-rust-rewrite install) don't accumulate. We only touch
-    # lines we ourselves wrote; user-managed PATH lines stay put.
+    # trailing `# airc` comment). We only touch lines we ourselves
+    # wrote; user-managed PATH lines stay put.
     if grep -qE '^export PATH=.*# airc$' "$rc"; then
       local tmp; tmp="$(mktemp "${rc}.airc.XXXXXX")"
-      grep -vE '^export PATH=.*# airc$' "$rc" > "$tmp" && mv "$tmp" "$rc"
+      # `|| true` is load-bearing: when the rc contains ONLY airc-managed
+      # lines (e.g. a freshly-created ~/.bashrc holding just our PATH
+      # entry), grep -v emits nothing and exits 1, which would skip the
+      # mv under `&&` and leave the stale line in place — duplicating it
+      # on the next append. Decouple the mv from grep's exit code.
+      grep -vE '^export PATH=.*# airc$' "$rc" > "$tmp" || true
+      mv "$tmp" "$rc"
     fi
-    # Ensure rc ends with a newline so the append starts on its own
-    # line. Without this, an rc that ends with `alias foo="bar"` (no
-    # trailing \n) produces the broken line
-    # `alias foo="bar"export PATH="...:$PATH"  # airc`
-    # which zsh parses as one malformed alias declaration and never
-    # sets PATH. Caught live 2026-05-20 — Joel's `airc` resolved fine
-    # from a manually-augmented PATH but new shells got nothing.
-    if [ -s "$rc" ] && [ "$(tail -c1 "$rc")" != "$(printf '\n')" ]; then
-      printf '\n' >> "$rc"
-    fi
-    printf 'export PATH="%s:$PATH"  # airc\n' "$path_entry" >> "$rc"
-    ok "Added $path_entry to PATH in $(basename "$rc")"
-    break
+    [ -z "$rc_target" ] && rc_target="$rc"
   done
+  # No rc file existed at all. A fresh Git Bash / MSYS box ships NONE of
+  # ~/.bashrc / ~/.bash_profile / ~/.profile, so the old "[ -f ] ||
+  # continue" loop wrote the PATH line to NOTHING and `airc` ended up on
+  # PATH in no shell — current OR future. Caught live on a clean Windows
+  # Git Bash box 2026-06-13. Create the rc that matches the user's
+  # shell so the entry has a home.
+  if [ -z "$rc_target" ]; then
+    case "${SHELL:-}" in
+      *zsh) rc_target="$HOME/.zshrc" ;;
+      *)    rc_target="$HOME/.bashrc" ;;
+    esac
+    : > "$rc_target"
+    info "Created $(basename "$rc_target") (no shell rc existed) for the airc PATH entry"
+    # Login bash (Git Bash launches `bash --login -i`) sources
+    # ~/.bash_profile / ~/.bash_login / ~/.profile, NOT ~/.bashrc, unless
+    # told to. Without this shim the freshly-created ~/.bashrc is never
+    # read by a login shell and the PATH entry is dead on arrival. Only
+    # create the shim when no login file already exists (don't clobber a
+    # user's own ~/.bash_profile).
+    if [ "$rc_target" = "$HOME/.bashrc" ] \
+       && [ ! -f "$HOME/.bash_profile" ] \
+       && [ ! -f "$HOME/.bash_login" ] \
+       && [ ! -f "$HOME/.profile" ]; then
+      printf '# created by airc installer: load ~/.bashrc in login shells\nif [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n' > "$HOME/.bash_profile"
+      info "Created ~/.bash_profile to source ~/.bashrc in login shells"
+    fi
+  fi
+  # Ensure rc ends with a newline so the append starts on its own
+  # line. Without this, an rc that ends with `alias foo="bar"` (no
+  # trailing \n) produces the broken line
+  # `alias foo="bar"export PATH="...:$PATH"  # airc`
+  # which zsh parses as one malformed alias declaration and never
+  # sets PATH. Caught live 2026-05-20 — Joel's `airc` resolved fine
+  # from a manually-augmented PATH but new shells got nothing.
+  if [ -s "$rc_target" ] && [ "$(tail -c1 "$rc_target")" != "$(printf '\n')" ]; then
+    printf '\n' >> "$rc_target"
+  fi
+  printf 'export PATH="%s:$PATH"  # airc\n' "$path_entry" >> "$rc_target"
+  ok "Added $path_entry to PATH in $(basename "$rc_target")"
   # Only export into current env if not already there. Avoids
   # gratuitously prepending duplicate PATH segments when the operator
   # has already sourced their rc.


### PR DESCRIPTION
Caught live driving the installer end-to-end on a **clean Windows Git Bash box** (no prior shell rc files, `gh` unauthed at install, no Rust toolchain, no git identity) — the exact fresh-operator path. Four bugs that each break a new user; all fixes are identity-agnostic and gh/`$HOME`-derived (multi-tenant safe — works the same for any operator linking their own grid).

## Fixes

1. **`airc` landed on PATH in no shell** — `install.sh` `_add_path_entry` looped `for rc in ~/.zshrc ~/.bashrc; do [ -f "$rc" ] || continue`. A fresh Git Bash box ships *none* of those, so the PATH line was written nowhere and the only export lived in the installer's own subshell. Now: create the rc matching `$SHELL` when none exists (+ a `~/.bash_profile` shim so login bash sources `~/.bashrc`). Also hardened the stale-line strip with `|| true` — when the rc holds only airc-managed lines, `grep -v` exits 1 and the `&&  mv` was skipped, duplicating the entry on rerun.

2. **`bootstrap-airc.sh` preflight called `airc doctor --connect`** — a flag the rust-rewrite binary doesn't implement, hard-failing every fresh bootstrap at the gate. Switched to `airc doctor --health`.

3. **gh auth after install left git's credential helper unwired** — `install.sh` only runs `gh auth setup-git` when gh is authed *at install time*; auth-after-install caused GUI password popups on gist ops. `bootstrap-airc.sh` now pins `-h github.com` to match `install.sh` and runs `setup-git` (idempotent) after login.

4. **No git author identity on a fresh box** — first agent commit dies with "Author identity unknown". `install.sh` now derives `user.name`/`user.email` from `gh api user` when unset (public email, else the `<id>+<login>` noreply alias). Never clobbers an existing identity. **No hardcoded identity** — fully derived per-operator.

## Validation
- Fresh-HOME sandbox: PATH entry created + resolved by a real login shell; idempotent (3 reruns → 1 line); zsh path; existing user rc content preserved.
- Real box: re-ran installer → `.bashrc` + `.bash_profile` created, login shell resolves `airc`, credential helper wired.
- Stubbed gh: identity derived for a fresh account, preserved when already set.

## Known follow-ups (not in this PR)
- **README + several installed skills reference commands the rust-rewrite binary doesn't have** (`teardown`, `quit`, `list`, `nick`, `away`, `back`, `uninstall`, `doctor --connect`). Docs/skills were written for the old `main` surface. Large reconciliation — worth a dedicated card.
- **Windows update path**: a running daemon locks `airc.exe`, so re-running the installer can't overwrite the binary until `airc stop`. First install is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)