### PR TITLE
fix(setup): PowerShell install parity — doctor flag, gh wiring, git identity

### DIFF
--- a/bootstrap-airc.ps1
+++ b/bootstrap-airc.ps1
@@ -116,7 +116,11 @@ if ($LASTEXITCODE -ne 0) {
 }
 # Idempotent: wire the credential helper if gh isn't already registered.
 $ghHelper = & git config --global --get-all credential.https://github.com.helper 2>$null
-if ($ghHelper -notmatch 'gh auth git-credential') {
+# Join to a scalar before -notmatch: --get-all can return multiple helper
+# values (array), and PS -notmatch on an array filters rather than returning
+# a strict boolean. Worst case without this is a redundant (idempotent)
+# setup-git, but the scalar form is correct.
+if ((@($ghHelper) -join "`n") -notmatch 'gh auth git-credential') {
     & gh auth setup-git 2>$null
     if ($LASTEXITCODE -eq 0) { OK 'gh token wired into git credential helper' }
 }

--- a/bootstrap-airc.ps1
+++ b/bootstrap-airc.ps1
@@ -92,20 +92,56 @@ if (-not $airc) {
     OK "airc already on PATH: $($airc.Source)"
 }
 
-# 2. pre-flight (catches Tailscale-down, gh-missing, network-out, etc.)
-Step 'Pre-flight: airc doctor --connect'
-& airc doctor --connect
+# 2. pre-flight (live route/process state before join). The rust-rewrite
+# `airc doctor` exposes `--health`; the old `--connect` flag no longer
+# exists and made this pre-flight hard-fail on every fresh rust install.
+# Mirrors bootstrap-airc.sh. Fixed 2026-06-13.
+Step 'Pre-flight: airc doctor --health'
+& airc doctor --health
 if ($LASTEXITCODE -ne 0) {
     FailOut 'Pre-flight failed. Fix the items above, then re-run this script.'
 }
 
-# 3. gh auth if needed
+# 3. gh auth if needed. Pin -h github.com (matches install.sh / .ps1, skips
+# the interactive host picker) and -s gist for the substrate scope. After
+# a successful login, wire gh's token into git's credential helper so gist
+# fetch/push (the rendezvous hot path) doesn't pop a password prompt.
 & gh auth status 2>$null | Out-Null
 if ($LASTEXITCODE -ne 0) {
     Step "Authenticating gh (need 'gist' scope for room substrate)"
-    & gh auth login -s gist
+    & gh auth login -h github.com -s gist
     if ($LASTEXITCODE -ne 0) {
         FailOut 'gh auth failed. Re-run this script after logging in manually.'
+    }
+}
+# Idempotent: wire the credential helper if gh isn't already registered.
+$ghHelper = & git config --global --get-all credential.https://github.com.helper 2>$null
+if ($ghHelper -notmatch 'gh auth git-credential') {
+    & gh auth setup-git 2>$null
+    if ($LASTEXITCODE -eq 0) { OK 'gh token wired into git credential helper' }
+}
+
+# 3b. Git author identity. Agents commit + open PRs; a fresh box has no
+# global user.name/user.email and the first commit dies with "Author
+# identity unknown". Derive from the authenticated gh account when unset;
+# never clobber an identity the user already set. Mirrors install.sh.
+$gitName  = (& git config --global user.name)  2>$null
+$gitEmail = (& git config --global user.email) 2>$null
+if (-not $gitName -or -not $gitEmail) {
+    $ghLogin = (& gh api user --jq '.login') 2>$null
+    $ghName  = (& gh api user --jq '.name // .login') 2>$null
+    $ghId    = (& gh api user --jq '.id') 2>$null
+    $ghEmail = (& gh api user --jq '.email // empty') 2>$null
+    if (-not $ghEmail -and $ghId -and $ghLogin) {
+        $ghEmail = "$ghId+$ghLogin@users.noreply.github.com"
+    }
+    if (-not $gitName -and $ghName) {
+        & git config --global user.name $ghName
+        OK "git user.name set from gh: $ghName (override: git config --global user.name ...)"
+    }
+    if (-not $gitEmail -and $ghEmail) {
+        & git config --global user.email $ghEmail
+        OK "git user.email set from gh: $ghEmail (override: git config --global user.email ...)"
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -470,13 +470,53 @@ done
     }
 }
 
+# -- gh credential helper + git identity (only when gh is already authed) -
+# install.ps1 doesn't drive gh auth (it prints the next-step below), so
+# this only fires for users who authed before installing. The bootstrap
+# (bootstrap-airc.ps1) covers the fresh-auth path. Mirrors install.sh:
+#   - wire gh's token into git's credential helper (no gist password pops)
+#   - derive git author identity from the gh account when unset, so the
+#     first agent commit doesn't die with "Author identity unknown".
+# Never clobbers an identity the user already set. No hardcoded values.
+$ghAvail  = Get-Command gh  -ErrorAction SilentlyContinue
+$gitAvail = Get-Command git -ErrorAction SilentlyContinue
+if ($ghAvail -and $gitAvail) {
+    & gh auth status 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        $ghHelper = & git config --global --get-all credential.https://github.com.helper 2>$null
+        if ($ghHelper -notmatch 'gh auth git-credential') {
+            & gh auth setup-git 2>$null
+            if ($LASTEXITCODE -eq 0) { Write-Ok 'gh token wired into git credential helper' }
+        }
+        $gitName  = (& git config --global user.name)  2>$null
+        $gitEmail = (& git config --global user.email) 2>$null
+        if (-not $gitName -or -not $gitEmail) {
+            $ghLogin = (& gh api user --jq '.login') 2>$null
+            $ghName  = (& gh api user --jq '.name // .login') 2>$null
+            $ghId    = (& gh api user --jq '.id') 2>$null
+            $ghEmail = (& gh api user --jq '.email // empty') 2>$null
+            if (-not $ghEmail -and $ghId -and $ghLogin) {
+                $ghEmail = "$ghId+$ghLogin@users.noreply.github.com"
+            }
+            if (-not $gitName -and $ghName) {
+                & git config --global user.name $ghName
+                Write-Ok "git user.name set from gh: $ghName"
+            }
+            if (-not $gitEmail -and $ghEmail) {
+                & git config --global user.email $ghEmail
+                Write-Ok "git user.email set from gh: $ghEmail"
+            }
+        }
+    }
+}
+
 # -- Final guidance ------------------------------------------------------
 Write-Host ''
 Write-Ok 'airc installed.'
 Write-Host ''
 Write-Host '  Next:'
 Write-Host '    1. Open a NEW PowerShell window (so PATH refreshes)'
-Write-Host '    2. Authenticate gh once:    gh auth login -s gist'
+Write-Host '    2. Authenticate gh once:    gh auth login -h github.com -s gist'
 Write-Host '    3. Join the mesh:           airc join'
 Write-Host ''
 Write-Host '  Diagnose anytime:    airc doctor'

--- a/install.ps1
+++ b/install.ps1
@@ -484,7 +484,10 @@ if ($ghAvail -and $gitAvail) {
     & gh auth status 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
         $ghHelper = & git config --global --get-all credential.https://github.com.helper 2>$null
-        if ($ghHelper -notmatch 'gh auth git-credential') {
+        # Join to a scalar before -notmatch: --get-all can return multiple
+        # helper values (array), and PS -notmatch on an array filters rather
+        # than returning a strict boolean. Scalar form is correct.
+        if ((@($ghHelper) -join "`n") -notmatch 'gh auth git-credential') {
             & gh auth setup-git 2>$null
             if ($LASTEXITCODE -eq 0) { Write-Ok 'gh token wired into git credential helper' }
         }


### PR DESCRIPTION
Mirrors the bash-side fresh-user fixes (#1164) onto the **native-Windows PowerShell** install path, so PowerShell users get the same foolproof bootstrap as Git Bash / mac / linux. Validated on a clean Windows box. All identity-agnostic and gh-derived (multi-tenant safe).

## Fixes
1. **`bootstrap-airc.ps1` preflight `airc doctor --connect`** → `airc doctor --health` (the `--connect` flag doesn't exist in rust-rewrite — same bug as #1164's bash fix).
2. **gh auth in `bootstrap-airc.ps1`**: pin `-h github.com` (matches install.sh/.ps1, skips host picker) + run `gh auth setup-git` after login so gist ops don't pop a credential prompt.
3. **git author identity** derived from `gh api user` when unset — in **both** `bootstrap-airc.ps1` (post-auth, the fresh path) and `install.ps1` (guarded on gh already authed). Never clobbers an existing identity; public email else the `<id>+<login>` noreply alias. **No hardcoded identity.**

## Not changed
- **PATH** — install.ps1 already writes the *registry User PATH* (`SetEnvironmentVariable('PATH', …, 'User')`), which new shells pick up. The bash rc-file trap (#1164 bug 1) does not exist on PowerShell, so no change needed there.

## Validation
- Both scripts AST-parse clean (`[Parser]::ParseFile`).
- Stubbed-gh test of the identity block: derives for a fresh account (noreply fallback), preserves an existing identity (no clobber).

## Related follow-up (separate PR)
- The **bash** `bootstrap-airc.sh` has the same identity gap on the truly-fresh path (install runs pre-auth → install.sh identity block skipped → bootstrap then auths but doesn't set identity). Will fix after #1164 merges to avoid a conflict on that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)