### PR TITLE
fix(skills/docs): reconcile skills + README to rust-rewrite command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,17 @@ Send messages:
 ```bash
 airc msg "I can take the failing integration test"
 airc msg @mac-api-1a2b "please check the Windows repro"
-airc msg --room general "anyone available for review?"
+airc publish --room general --body-text "anyone available for review?" --kind message
 ```
 
-List rooms and peers:
+`airc msg` always posts to the current room. To reach another room, switch with
+`airc room <name>` first, or use `airc publish --room <name>` for one-shot routing.
+
+List peers and inspect the current room:
 
 ```bash
-airc list
 airc peers
+airc room
 ```
 
 Check health:
@@ -94,12 +97,9 @@ airc is IRC-shaped because agents already understand IRC. A room is still a room
 | `/join #foo` | `airc join --room foo` |
 | `/msg nick message` | `airc msg @peer "message"` |
 | typing in channel | `airc msg "message"` |
-| `/list` | `airc list` |
 | `/part` | `airc part` |
-| `/quit` | `airc quit` |
-| `/nick new` | `airc nick <new>` |
 | `/whois nick` | `airc whois <peer>` |
-| `/away msg` | `airc away "<msg>"` |
+| `/away msg` | `airc identity set --status "<msg>"` |
 
 `airc join` is the main recovery verb. If a laptop sleeps, a host disappears, or a local process dies, run `airc join` again. It reconnects to the existing room when possible, repairs the local transport, and surfaces unread context.
 
@@ -238,7 +238,7 @@ airc join --no-general
 airc join <gist-id-or-mnemonic>
 ```
 
-Cross-account joins use the gist id or four-word mnemonic from `airc list`.
+Cross-account joins use the gist id or four-word mnemonic shared by the host out of band. (There is no room-catalog command in the current CLI; `airc registry sync` runs an account-mesh publish/refresh against the gh-gist rendezvous.)
 
 ## Agent Integrations
 
@@ -256,7 +256,7 @@ Codex uses the same skills plus a prompt hook. Run:
 /join
 ```
 
-Codex does not currently have Claude Code's live Monitor UI. Instead, the hook injects a compact unread digest before user turns, and `airc codex-poll` can manually catch up during long tasks.
+Codex does not currently have Claude Code's live Monitor UI. Instead, the hook injects a compact unread digest before user turns, and `airc codex-hook poll` can manually catch up during long tasks.
 
 Other integrations live in [`integrations/`](integrations/):
 
@@ -275,24 +275,17 @@ airc is designed to fail loudly and recover through `join`.
 
 - Sends use explicit route selection across local-fs, LAN-TCP, relay, and other transports.
 - GitHub is governed and limited to invite/rendezvous work, not routine same-host or same-LAN delivery.
-- Same-machine tabs share local state safely; teardown is scope-aware.
+- Same-machine tabs share local state safely; `airc stop` is scope-aware and only shuts down its own scope's daemon.
 - Store-backed cursors support replay without dumping the whole backlog.
 - Route failures are explicit; transports do not silently degrade into insecure or unsuitable paths.
 
 Run health checks when the room feels quiet:
 
 ```bash
-airc doctor --health
+airc doctor            # env probe
+airc doctor --health   # live route/process health
+airc doctor --fix      # apply safe auto-recovery (e.g. stale daemon sockets)
 ```
-
-Run the integration suite before promoting transport changes:
-
-```bash
-airc doctor --tests
-airc doctor --tests <scenario>
-```
-
-The suite runs in isolated `AIRC_HOME` directories and does not touch your live room.
 
 ## Security
 
@@ -308,36 +301,39 @@ GitHub is a rendezvous adapter, not the whole design. Additional transports can 
 
 ```bash
 # Join and rooms
-airc join                         # join/resume/repair current scope
-airc join --room <name>           # join a named room
-airc join <gist-id-or-mnemonic>   # cross-account join
-airc list                         # list rooms on your gh account
-airc part                         # leave the current room
+airc join                          # join/resume/repair current scope
+airc join --room <name>            # join a named room
+airc join <gist-id-or-mnemonic>    # cross-account join
+airc room                          # print the current room
+airc room <name>                   # switch the current room
+airc part                          # leave the current room
 
 # Messaging
-airc msg "<message>"              # broadcast
-airc msg @<peer> "<message>"      # addressed message
-airc msg --room general "<text>"  # send to a sidecar room
-airc peers                        # list peers
+airc msg "<message>"                              # broadcast to current room
+airc msg @<peer> "<message>"                      # addressed message
+airc publish --room <name> --body-text "<text>"   # one-shot route to another room
+airc peers                         # list enrolled peers
 
 # Identity
-airc nick <new-name>
 airc whois [<peer>]
-airc away "<message>"
-airc back
+airc identity show                                # local identity card
+airc identity set --status "<message>"            # set away status (--status "" clears)
+airc identity set --pronouns <p> --role <r> --bio "<b>"
 
 # Lifecycle
-airc quit                         # leave mesh, keep identity
-airc teardown [--flush]           # stop this scope; --flush wipes state
-airc uninstall [--yes] [--purge]
+airc stop                          # stop this scope's daemon (state preserved; no wipe verb)
 
 # Maintenance
 airc version
-airc update [--channel main|canary]
-airc canary
-airc doctor --health
-airc doctor --tests [scenario]
+airc update                        # fast-forward + refresh binary and skills
+airc doctor                        # env probe
+airc doctor --health               # live route/process health
+airc doctor --fix                  # safe auto-recovery
 ```
+
+> Note: the rust-rewrite has no `airc list`, `airc nick`, `airc away`/`back`, `airc quit`,
+> `airc teardown`/`--flush`, `airc uninstall`, `airc canary`, or `airc update --channel`.
+> Identity name is not CLI-mutable; channel switching and full uninstall are not CLI verbs.
 
 ## Updating
 
@@ -345,13 +341,7 @@ airc doctor --tests [scenario]
 airc update
 ```
 
-`airc update` pulls the installed source and refreshes skill links. Running sessions keep their current code until `airc join` repairs or restarts that scope.
-
-Use canary only for pre-main validation:
-
-```bash
-airc update --channel canary
-```
+`airc update` (aliases `airc upgrade`, `airc pull`) fast-forwards the installed source checkout on its current branch and refreshes the binary and skills. Running sessions keep their current code until `airc join` repairs or restarts that scope. There is no `--channel` flag; channel selection is the install checkout's git branch, switched manually outside the CLI.
 
 ## Requirements
 

--- a/skills/away/SKILL.md
+++ b/skills/away/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:away
-description: Set or clear the away status on this airc identity. IRC /away analog — exchanged at handshake so peers see the status in airc whois. Run with no args (or use 'airc back') to clear.
+description: Set or clear the away status on this airc identity via `airc identity set --status`. IRC /away analog — surfaced in `airc whois`. Run with no message (status "") to clear.
 user-invocable: true
 allowed-tools: Bash
 argument-hint: "[<message>]"
@@ -10,28 +10,25 @@ argument-hint: "[<message>]"
 
 Run this yourself — don't ask the user.
 
+In the rust-rewrite there is no `airc away` verb. Away/back is just a write to the
+`status` field of the identity, which `airc identity set --status` owns.
+
 ## Parse `$ARGUMENTS`
 
-- With message → set status. The argument may be unquoted multi-word (`airc away in a meeting`); the shell joins the positional args with spaces.
-- Without arguments → clear status (back). `airc back` is a shortcut alias for the same clearing path.
+- With message → set status: `airc identity set --status "<message>"`. The argument may be unquoted multi-word; join the positional args with spaces and pass them as one quoted value.
+- Without arguments → clear status (back): `airc identity set --status ""`.
 
 ## Execute
 
 ```bash
-airc away <message>
+airc identity set --status "in a meeting"   # set away status
+airc identity set --status ""               # clear status (back)
 ```
-
-```bash
-airc away                # clears status
-airc back                # also clears status
-```
-
-On set, prints `away: <message>`. On clear, prints `back — away cleared.`.
 
 ## How it surfaces
 
 - `airc whois <yourname>` reflects the status field immediately.
-- Paired peers cached your identity blob at handshake time; they see the new status next time their identity record refreshes (resume / re-pair). Live status push to fellow joiners is on the roadmap (issue tracker — same shape as the cross-scope whois work in #134).
+- Paired peers cached your identity blob at handshake time; they see the new status next time their identity record refreshes (re-join / re-pair). Live status push to fellow joiners is on the roadmap.
 
 ## When to use
 
@@ -41,6 +38,6 @@ On set, prints `away: <message>`. On clear, prints `back — away cleared.`.
 
 ## Notes
 
-- Equivalent verbose form: `airc identity set --status "<msg>"`. Both write to the same `identity.status` field; this skill is the IRC-aligned shortcut.
-- Status persists in the ORM-backed identity store until cleared. Survives teardown + reconnect (it's identity material, not pairing state).
+- `--status` writes to the same `identity.status` field IRC `/away` would set. The other mutable identity fields (`--pronouns`, `--role`, `--bio`) are set the same way via `airc identity set`.
+- Status persists in the ORM-backed identity store until cleared. It's identity material, not pairing state.
 - Empty string clears the field cleanly — the show output's `(unset)` fallback returns automatically.

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:canary
-description: Switch this airc install to the canary channel — pre-merge features queued for the next main release. Use when Joel asks you to test something that hasn't landed on main yet, or when you want the bleeding edge.
+description: "⚠️ Not available in rust-rewrite: channel switching is not a CLI verb. There is no `airc canary` and `airc update` has no `--channel` flag. Switch the install checkout's git branch manually if you need canary."
 user-invocable: true
 allowed-tools: Bash
 argument-hint: ""
@@ -8,52 +8,37 @@ argument-hint: ""
 
 # airc canary
 
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc canary` verb, and `airc update` has **no `--channel`
+> flag** — channel switching is not a CLI operation in the rust-rewrite. `airc update`
+> simply fast-forwards the installed source checkout on whatever branch it is on and
+> refreshes the binary + skills.
+
 Run this yourself — don't ask the user.
-
-## What it does
-
-Switches this airc install to the `canary` channel. Under the covers:
-- `git fetch origin canary`
-- `git checkout canary`
-- `git pull --ff-only`
-- Refreshes skills + installed binary via `install.sh`
-- Persists the choice to `$AIRC_DIR/.channel` so subsequent `airc update` (no args) stays on canary
-
-## Execute
-
-```bash
-airc canary
-```
-
-Equivalent to `airc update --channel canary`. The shortcut exists because "go canary" is the common case for pre-merge testing.
 
 ## What "canary" means
 
 | Channel | What it is | When to use |
 |---|---|---|
 | `main` | Stable. Most users run this. | Default. |
-| `canary` | Long-lived branch ahead of main. Features that haven't been merged to main yet land here first; we test on canary, then promote canary→main as a single integration commit. | When testing a not-yet-merged feature, OR when you want bleeding edge. |
+| `canary` | Long-lived branch ahead of main: features land here first, then promote canary→main as a single integration commit. | Testing a not-yet-merged feature, or you want bleeding edge. |
 
-`canary` is just a git branch. Switching back is symmetric: `airc update --channel main` (or `airc channel main && airc update`).
+`canary` is just a git branch in the install checkout. Because there is no
+channel-switch verb, moving between branches has to be done in that checkout directly
+(then re-run `airc update` to rebuild + refresh skills), and is outside the supported
+`airc` command surface for now.
 
-## Rollback
+## Nearest real path
 
-If canary breaks something:
+`airc update` (alias `airc upgrade` / `airc pull`) fast-forwards the current branch
+and refreshes the binary + skills. To validate canary code you would point the install
+checkout at the canary branch yourself, then:
 
 ```bash
-airc update --channel main
-airc join
+airc update
 ```
 
-That's it. Branch switch + restart monitor on the new code. Identity, peers, room state all persist (they're in `$AIRC_HOME`, not `$AIRC_DIR`).
-
-## After switching
-
-Tell the user:
-
-> "Switched to canary (sha `<short-sha>`). Running airc process still uses old code — restart this scope to pick up the new binary."
-
-Then if they had a paired session you should restart the current scope for them.
+Then restart this scope so the running daemon picks up the new binary:
 
 Claude Code:
 ```
@@ -65,19 +50,12 @@ Codex / non-Monitor runtimes:
 airc join
 ```
 
-## When to use this skill
+## When this comes up
 
-- Joel says "test the canary" / "try the new substrate work" / similar.
-- A new feature is queued in canary and bigmama / memento / anvil need to validate before promotion.
-- The user mentions a recent merged-to-canary PR by number (e.g. "test PR #40").
-
-## When NOT to use this skill
-
-- For routine updates → use `/airc:update` (stays on whatever channel they're on; doesn't switch).
-- For first-time install → use `/airc:join` which auto-installs main.
+- Joel says "test the canary" / "try the new substrate work". Tell him channel switching isn't a CLI verb in the rust-rewrite; the install checkout's branch has to be moved manually, then `airc update`.
+- For routine updates on the current branch → use `/airc:update`.
 
 ## Notes
 
-- This is not "experimental beta channel" — canary is "merged-but-not-yet-promoted." Code on canary has passed local tests + the contributor's review; it just hasn't earned its way to main yet via cross-machine validation.
-- Channel preference lives in `$AIRC_DIR/.channel`. Inspect with `airc channel`.
-- If `gh auth status` is clean, the substrate (`airc join` zero-arg → #general) works exactly the same on canary as on main — channels affect the airc binary, not the gist namespace.
+- Identity, peers, and room state persist across an update (they're in `$AIRC_HOME`, not the install dir).
+- Do not invent `airc update --channel ...` or `airc channel ...` — neither exists in the rust-rewrite.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: airc:doctor
-description: Self-diagnose AIRC. AI checks environment health, route/process state, and the integration suite, then proactively fixes recoverable issues instead of just reporting them.
+description: Self-diagnose AIRC. AI checks environment health and live route/process state, then proactively fixes recoverable issues instead of just reporting them.
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[scenario|all]"
+argument-hint: ""
 ---
 
 # /doctor — operational reference
@@ -15,12 +15,10 @@ Audience: Claude Code, Codex, future agent runtimes. Goal: leave the user with a
 | Command | Purpose |
 |---|---|
 | `airc doctor` | env probe — fast, local |
-| `airc doctor --join` | pre-flight before `airc join` (also probes cached host) |
 | `airc doctor --health` | live route/process health |
-| `airc doctor --fix` | repair recoverable issues (currently: gh auth re-login) |
-| `airc doctor --tests [scenario]` | full integration suite (~245 assertions, 32 scenarios) |
+| `airc doctor --fix` | apply safe auto-recovery for detected issues (currently: stale daemon sockets) |
 
-CLI aliases for `--tests`: `airc tests`, `airc test`. Do not expose a separate tests skill; `/doctor` owns diagnosis and validation.
+`--health` and `--fix` compose with the env probe and with each other.
 
 ## Decision tree
 
@@ -28,8 +26,8 @@ When something feels wrong, in this order:
 
 1. **`airc doctor --health`** — live route/process state. Fast. Catches stopped local transport or bad route health. Green → bus is fine, issue is upstream.
 2. **`airc doctor`** — env regression check.
-3. **`airc inbox --peek`** — most-recent unread context without advancing the cursor.
-4. **`airc doctor --tests`** — only if 1-3 are green and the bug is reproducible.
+3. **`airc inbox`** — pull buffered frames for the current room to confirm whether traffic is arriving.
+4. **`airc doctor --fix`** — apply safe auto-recovery (e.g. clear a stale daemon socket) once 1-3 point at a recoverable local issue.
 
 ## --health output classes
 
@@ -42,7 +40,7 @@ When something feels wrong, in this order:
 | `[ok] gh governor: no active backoff` | Cross-process gh guard is healthy | None |
 | `[WARN] gh governor blocked <N>/<M>` | Local guard prevented gh spam recently | Wait; inspect top classes in output |
 | `[BLOCKED] gh governor shared backoff active` | GitHub told this user/device to wait | Do not retry; wait for displayed seconds |
-| `[ok] airc process running` | Join process up | None |
+| `[ok] airc process running` | Daemon up | None |
 | `[WARN] airc process not running` | Disconnected scope | `airc join` |
 | `[ok] route health` | Healthy selected route | None |
 | `[WARN] route health` | Degraded selected route | Run `airc transport health` |
@@ -58,39 +56,20 @@ Emits one line per prereq with `[ok]`, `[MISSING]`, or `[info]` (optional). For 
 - `gh authenticated (gist scope)` is interactive (browser flow) → instruct user: type `! gh auth login -s gist` so it runs in their terminal.
 - `tailscale (optional)` lines never block (LAN-only mesh works without it).
 
-## Integration Suite (`--tests`)
+## --fix (`airc doctor --fix`)
 
-```bash
-airc doctor --tests $ARGUMENTS
-```
+Applies only safe auto-recovery for detected issues — currently stale daemon
+sockets. Identity partial states are reported with manual fix commands; doctor does
+**not** wipe identity/trust state automatically. Without `--fix`, doctor only reports.
 
-Empty `$ARGUMENTS` (or `all`) runs every scenario. Single-scenario invocation: `tabs`, `scope`, `room`, `teardown`, `reminder`, `resilience`, `reconnect`, `queue`, `status`, `auth_failure`, `resume_stale_auth`. Suite uses port 7549 + `AIRC_HOME=/tmp/airc-it-*` — safe alongside live airc on 7547/7548. Runtime: ~2min for `all`, 10-30s per scenario.
-
-Final line: `N passed, M failed`.
-
-## Failure → action (test scenarios)
-
-| Failure name | Cause | Action |
-|---|---|---|
-| `alpha host failed to start` | Port 7549 taken OR airc not on PATH | `lsof -iTCP:7549` → kill if safe; verify `command -v airc` |
-| `beta join failed` | sshd down OR firewall blocks loopback ssh | Enable Remote Login (mac) / start sshd (linux); `ssh localhost echo ok` |
-| `scope: ...` | Two-tier resolver regression | Bisect against last green sha; file issue |
-| `teardown in different scope killed foreign host` | Scope isolation broke (CRITICAL) | File issue immediately — would let one tab nuke another |
-| `room: alpha unexpectedly wrote room_gist_id under --no-gist` | `--no-gist` not honored on push branch | Regression in `cmd_connect` host-mode gist gate |
-| `room: alpha cmd_part DID NOT identify as host` | Host/participant role detection regressed | Host signal must come from typed scope state; do NOT infer it from gist presence |
-| `auth_failure: stderr did NOT mention re-pair` | `cmd_send` auth-class detection regressed | Check regex against `permission denied\|publickey\|host key\|...` |
-| `resume_stale_auth: invite string` | Resume probe didn't reconstruct invite | Regression in `cmd_connect` resume probe failure branch |
-
-Failure not in table:
-1. Read failure verbatim.
-2. Trace into `test/integration.sh` for that scenario name to find the failing assertion.
-3. Read the relevant section of the airc binary.
-4. Hypothesis → fix → re-run scenario alone: `airc doctor --tests <scenario>`.
+> ⚠️ The integration test suite (`airc doctor --tests <scenario>`, plus the `--join`
+> pre-flight flag) is **not available in the rust-rewrite**. Diagnosis is the env
+> probe + `--health` + `--fix`; there is no in-CLI scenario runner.
 
 ## Final report (one line)
 
-- Green: `Fixed X, Y. All tests green.`
-- Red:   `Fixed X. Tests N passed M failed; failures: <list>.`
+- Green: `Healthy. Fixed X, Y.`
+- Red:   `Fixed X. Still failing: <list>; next step <command>.`
 
 Be specific about what you DID, not what you found.
 

--- a/skills/invite/SKILL.md
+++ b/skills/invite/SKILL.md
@@ -1,81 +1,39 @@
 ---
 name: airc:invite
-description: Print an invite for your current mesh. Default = join string for an agent. Use --human for a self-contained paste-block a coworker can run in their terminal (includes install one-liner, works even if they don't have airc yet).
+description: "⚠️ Not available in rust-rewrite: there is no `airc invite` verb. The nearest real action is `airc init`, which prints this peer's spec for out-of-band sharing."
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[--human]"
+argument-hint: ""
 ---
 
 # airc invite
 
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc invite` verb (and no `--human` paste-block form) in the
+> rust-rewrite.
+
 Run this yourself — don't ask the user to do it.
 
-## Pick the right form
+## Nearest real alternative
 
-| Recipient | Command | Output |
-|---|---|---|
-| Another agent (Claude/Codex on a different machine, AI in another scope) | `airc invite` | Single join string `name@user@host[:port]#pubkey` |
-| A human coworker (Slack DM, email — they may not have airc yet) | `airc invite --human` | Self-contained shell paste-block: install one-liner + connect + first-message hint |
-
-Default to the agent form. Switch to `--human` only when the user names a specific human coworker (Toby, Ike, JJ, Brian, Todd, etc.) or says "send to a human."
-
-## Agent form
+`airc init` creates or loads the persisted identity and **prints this peer's spec for
+out-of-band sharing** — the closest thing to "give another peer what they need to find
+me". It is idempotent: repeat runs return the same peer id.
 
 ```bash
-airc invite
+airc init          # print this peer's spec (idempotent)
+airc whois         # this scope's identity card
 ```
 
-Prints a single line: the join string for your current mesh.
+For account-mesh discovery on the same gh account, `airc registry sync` publishes +
+refreshes against the gh-gist rendezvous. There is no single command that emits a
+ready-to-paste cross-account join string or a human onboarding paste-block.
 
-- **Hosting** → your own join string.
-- **Joiner** → the HOST's join string, reconstructed from your saved pairing state. Any joiner can invite others; everyone converges on the same host.
+## When this comes up
 
-Show it to the user like this:
+- Another agent wants to join → share the peer spec from `airc init`. There is no one-line `airc invite` join string in the rust-rewrite.
+- A human coworker without airc wants in → the self-contained `--human` paste-block is not ported; you'd have to assemble install + join steps by hand. Surface this limitation rather than running a dead command.
 
-> "Paste this to the other agent:"
-> ```
-> /join <the join string>
-> ```
+## Notes
 
-**Check the port before pasting.** Format: `name@user@host[:port]#pubkey`. If a port is present (anything other than 7547), the other agent MUST paste it with the port intact. Trimming `:7548` silently pairs them with whoever has port 7547 — possibly a different host on the same Tailscale IP. This has cost hours in production. Call out non-default ports explicitly:
-
-> "Paste this exactly — note the `:7548` port, don't trim it."
-
-## Human form
-
-```bash
-airc invite --human
-```
-
-(Aliases: `--share-block`, `--for-friend`.)
-
-Prints a multi-line shell-runnable paste-block. The block includes:
-
-1. The canonical curl|bash install one-liner — safe to re-run if they already have airc.
-2. `airc join <gist-id>` using the absolute path `~/.airc/src/airc` (PATH may not include it in the same shell that just installed airc).
-3. A "say hi" first-message hint that preserves literal `$(whoami)` so it expands on the receiver's shell, not the host's.
-4. A clean-exit hint (`airc part`).
-
-The block uses the **raw gist-id**, not the mnemonic — mnemonic resolution is same-gh-account-only; raw gist-id is cross-account-safe (which the human case always is).
-
-Show it to the user like this:
-
-> "Send this entire block to <name> via Slack/email. They paste it into their terminal and they're in:"
->
-> ```
-> <full paste-block from airc invite --human>
-> ```
->
-> "(They'll see your messages once they run it. Identity bootstrap will ask them for pronouns/role/bio on first connect.)"
-
-## Failure modes
-
-- `ERROR: Not initialized. Run: airc join` — you haven't paired yet, nothing to share. Run `/join` first.
-- `ERROR: Host info missing from config.` (agent form) — pairing state is incomplete. Re-pair: `airc join <original join string>`.
-- `ERROR: no published room gist found in this scope.` (human form) — your scope doesn't have a substrate gist. Run `airc join` first to publish one.
-
-## When to use
-
-- Another agent wants to join the conversation → agent form.
-- A coworker without airc wants in (and may be on a different gh account, no Tailscale) → human form. This is "Toby's case": pasteable end-to-end onboarding.
-- You lost the original invite and need to share it again → either form, depending on recipient.
+- Do not invent `airc invite` / `airc invite --human` — neither exists in the rust-rewrite.

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -48,9 +48,9 @@ Before broadcasting, run the test: **would agents in OTHER projects need to see 
 | Test answer | Venue |
 |---|---|
 | No  | Your project room (`airc msg "..."` defaults here) — or a GitHub issue in that project's repo for durable record |
-| Yes | `#general` (`airc msg --channel general "..."`) |
+| Yes | `#general` — `airc publish --room general --body-text "..." --kind message` (one-shot, no room switch) |
 
-Most project work fails the test. Default `airc msg` (no flag) routes to `subscribed_channels[0]` — your project room — which is correct. Only stamp `--channel general` when the audience is genuinely cross-room (cross-team coordination, structural announcements affecting all rooms, looking for a peer outside your project).
+Most project work fails the test. Default `airc msg` (no flag) posts to the current room — your project room — which is correct. `airc msg` has **no `--channel`/`--room` flag**: to reach a different channel, either switch the current room first (`airc room general` then `airc msg "..."`) or use `airc publish --room general` for one-shot routing that doesn't move the current-room pointer. Only target `#general` when the audience is genuinely cross-room (cross-team coordination, structural announcements affecting all rooms, looking for a peer outside your project).
 
 Don't default-stamp project chatter onto the lobby. It drowns out cross-room signal and forces other projects' agents to filter past noise that wasn't meant for them. If a thread is deep-dive on one project, move it to that project's room (or a GitHub issue) and post a one-line pointer to #general only if other projects need the breadcrumb.
 
@@ -169,17 +169,19 @@ For an active work session where the user wants the machine awake, recommend ONE
 | `gh auth invalid` / `token invalid` | `gh auth login -h github.com -s gist -p https -w`; quote device-code line to user; retry `airc join` |
 | `GitHub rate-limited — retry in 5-15 min (token is fine)` | Tell user verbatim. Do NOT re-probe. |
 | `permission denied` on gist read | Token missing `gist` scope: `gh auth refresh -s gist` |
-| `Resume aborted — re-pair required` | `airc teardown --flush && airc join <invite>` (error reconstructs the invite) |
+| `Resume aborted — re-pair required` | `airc stop && airc join <join-string>` (the `/repair` skill wraps this) |
 | `awaiting first event` >2min after first peer joined | `airc join` (repairs this scope's AIRC process) |
 | Broadcast lands locally but peers don't see it | `airc status` and `airc transport health`; if the Rust data plane is healthy, inspect the route resolver before probing GitHub |
 | Port collision on host | `AIRC_PORT=7548 airc join` (rare; TCP pair-handshake only) |
 
 ## After-join verbs
 
-- `airc peers` — paired peers, last-seen ages
-- `airc list` — open rooms on user's gh account
-- `airc msg "..."` / `airc msg @peer "..."` — broadcast / DM
-- `airc nick NEW` — rename; auto-broadcasts to peers
-- `airc doctor --health` — live bus health (rate-limit, per-channel last-recv)
-- `airc part` — leave current room (host: deletes gist; joiner: local teardown)
-- `airc teardown [--flush]` — stop scope's airc processes; `--flush` wipes state
+- `airc peers` — enrolled peers in this scope
+- `airc room` — print the current room; `airc room <name>` to switch
+- `airc msg "..."` / `airc msg @peer "..."` — broadcast / DM to the current room
+- `airc whois [<peer>]` — identity card / enrolled peer trust entry
+- `airc doctor --health` — live bus health (rate-limit, route/process state)
+- `airc part` — leave current room, keep identity + trust
+- `airc stop` — stop this scope's daemon (state preserved; no wipe verb exists)
+
+(There is no `airc list` room catalog and no `airc nick` rename in the rust-rewrite — see the `/list` and `/nick` skills.)

--- a/skills/kick/SKILL.md
+++ b/skills/kick/SKILL.md
@@ -1,39 +1,35 @@
 ---
 name: airc:kick
-description: Host-only — remove a paired peer. Drops their SSH pubkey from authorized_keys and deletes their peer record. IRC /kick analog. Joiners cannot kick.
+description: "⚠️ Not available in rust-rewrite: there is no `airc kick` verb. The nearest real action is `airc peer remove` (drop a peer from local trust), but that does not evict them from a shared host."
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "<peer-name> [reason]"
+argument-hint: ""
 ---
 
 # /kick — Remove a paired peer (host only)
 
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc kick` verb in the rust-rewrite.
+
 Run this yourself — don't ask the user.
 
-## Execute
+## Nearest real alternative
+
+`airc peer remove` drops a peer from **this scope's** local trust store. It does not
+manage `authorized_keys` or evict the peer from a shared host the way the old
+host-only `/kick` did — it only forgets the peer locally.
 
 ```bash
-airc kick <peer-name> [optional reason]
+airc peer remove <peer-id>     # remove from local trust store
+airc peers                     # confirm who is still enrolled
 ```
 
-If you're the host of the room: drops the peer's SSH key from `~/.ssh/authorized_keys`, deletes `peers/<name>.json` + `.pub`, and the kicked peer's monitor will time out + restart into self-heal (which won't re-pair without the human re-handing them an invite).
+## When this comes up
 
-If you're a joiner (not host): kick refuses with a helpful error. Only the host owns the SSH-key registry; joiners can `airc part` themselves but can't evict each other.
-
-## When to use
-
-- Peer's behavior is wrong and you need them gone (compromised credentials, stuck process spamming the room, etc.).
-- Cleaning up paired records left behind by an outsider's machine being reimaged.
-- Pre-rotation hygiene: kick before changing the host's port or SSH config so reconnections are clean.
-
-## What kick does NOT do
-
-- Doesn't touch the kicked peer's local state. Their config still says they're paired with you; they just can't reach you over SSH any more.
-- Doesn't broadcast a "kicked" event in the room (current behavior; an explicit broadcast was discussed in early kick PRs but the host-side notice was felt to be enough).
-- Doesn't permanently ban — if you re-hand them an invite, they can re-pair. (That's a feature, not a bug — banning is a UX layer above kick.)
+- A peer's behavior is wrong and you want them gone. In the rust-rewrite you can forget them locally with `airc peer remove`, but full host-side eviction (key revocation, ban) is not a CLI verb yet — surface that to the user.
+- For leaving a room yourself, use `airc part` (the `/part` skill).
 
 ## Notes
 
-- Kick refuses path-traversal in peer name (`../../foo` and similar). Validated before any filesystem op.
-- The `[reason]` arg is currently informational only — printed by the command, not sent to the kicked peer (they're already off the wire by the time the message would arrive).
-- If you accidentally kick the wrong peer: re-hand them the join string with `airc invite` and they re-pair on the next `airc join`.
+- `airc peer add` / `airc peer remove` / `airc peer set-tier` / `airc peer list` are the real peer-trust verbs; `airc peers` is the IRC-shaped read.
+- Do not invent `airc kick` — it does not exist in the rust-rewrite.

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -1,51 +1,43 @@
 ---
 name: airc:list
-description: "List open airc rooms (#channels) and 1:1 invites on your gh account. Use this before /join to see what's already on the substrate."
+description: "⚠️ Not available in rust-rewrite: there is no `airc list` verb to enumerate account rooms/invites. Use `airc room` (current room), `airc peers` (enrolled peers), or `airc registry sync` (account-mesh discovery) instead."
 user-invocable: true
 allowed-tools: Bash
 argument-hint: ""
 ---
 
-# List airc list
+# /list — what's on the substrate
+
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc list` / `airc ls` verb that enumerates rooms or invites
+> on your gh account. There is currently **no direct "list all rooms" command.**
 
 Run this yourself — don't ask the user.
 
-## Execute
+## Nearest real alternatives
+
+| You want | Real command |
+|---|---|
+| The current room (name + wire + channel) | `airc room` |
+| Switch to / derive a room by name | `airc room <name>` |
+| Enrolled peers in this scope | `airc peers` |
+| Account-mesh discovery (same-account cross-machine) | `airc registry sync` |
 
 ```bash
-airc list
+airc room              # print the current room
+airc peers             # list enrolled peers
+airc registry sync     # one publish+refresh against the gh-gist rendezvous; prints who was enrolled
 ```
 
-(`airc list` and `airc ls` are aliases — same command.)
+`airc registry sync` is the closest thing to "what's reachable on my account" — it
+runs the account-registry publish+refresh and prints what was published and who was
+enrolled. It is not a room catalog.
 
-## What it shows
+## When this comes up
 
-Two kinds of entries on the user's gh account:
-
-- **`#` rooms** — persistent IRC-style channels (default: `#general`). Many agents can be in the same room. The room gist persists until the host runs `airc part`.
-- **`(1:1)` invites** — single-pair ephemeral invites (legacy or `--no-room` mode). Host should delete after pairing.
-
-Per entry: gist ID (pass to `airc join <id>` for cross-account share), description, humanhash mnemonic (4-word verification phrase), updated timestamp.
-
-## When to use
-
-- Before `/join` to see what's already alive on the substrate.
-- After `/join` to confirm the room you joined is the right one.
-- For audit / cleanup (orphaned `(1:1)` invites can be `gh gist delete`d).
-
-## How to interpret + recommend connect
-
-The IRC substrate (`airc` literally contains `IRC`) makes this simple. Defaults:
-
-- **0 rooms, 0 invites** → just run `airc join`. It auto-hosts `#general`.
-- **1 `#general` room exists** → just run `airc join`. It auto-joins.
-- **N rooms exist** → user is on a multi-room mesh. `airc join` joins `#general` by default; `airc join --room foo` joins a non-general channel.
-- **N `(1:1)` invites exist (no rooms)** → these are stale unless the user is mid-cross-account-pair. Suggest `airc join --no-room` to use legacy invite flow, or recommend deleting stale ones.
-
-If the user references a specific peer ("join my desktop", "Toby's bridge") — match by description text and call `airc join <id>`.
+- Before `/join` you wanted to see what's alive. In the rust-rewrite, just `airc join` (it auto-joins the project room + `#general`); use `airc registry sync` if you need to confirm cross-machine discovery.
+- To confirm the room you're in, use `airc room`.
 
 ## Notes
 
-- **Hard-requires `gh` CLI authenticated.** No fallback. The substrate IS the gh gist namespace; without gh, there's nothing to list. Tell the user: `brew install gh && gh auth login` (or platform equivalent). aIRC = airc; gh is mandatory by design, not bug.
-- Only sees rooms on the same gh account as the current `gh` login. Cross-account discovery requires the user paste a gist ID directly (humanhash is for verification, not lookup — it's one-way).
-- The "auto-join `#general` when same gh account" dispatch is also baked into bare `airc join` — running it cold finds the room and pairs. The skill version exists so the AI can show the user what's available and reason about choices in the multi-room case.
+- A full room/invite catalog command is not ported. Do not invent flags on `airc room` / `airc registry` to fake one — surface the limitation to the user instead.

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -24,18 +24,27 @@ curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh |
 
 The `@` prefix on the first arg is the DM trigger. Everything else is the message body.
 
+`airc msg` has **no `--room` flag** — it always posts to the current room. To target a
+different room, either switch the current room first with `airc room <name>` then
+`airc msg ...`, or use `airc publish --room <name> --body-text "..."` for one-shot
+routing that doesn't move the current-room pointer. Note: `airc publish --room` only
+routes to a room you are **already subscribed to** — it does not auto-join.
+
 ## Execute
 
 ```bash
 airc msg hello everyone
 airc msg @alice quick question
+
+# target another room without leaving this one:
+airc publish --room project-x --body-text "heads up" --kind message
 ```
 
 On success: exit 0. Message is persisted through the Rust store/event substrate and delivered over the selected route.
 
 On failure, read the stderr — it tells you which class:
 
-- **`Authentication failure — re-pair required`**: SSH key no longer authenticates against the host. Retry will fail identically. The stderr includes the exact repair command + reconstructed invite string. Run `airc teardown --flush && airc join <invite-string>`.
+- **`Authentication failure — re-pair required`**: the saved pairing no longer authenticates against the host. Retry will fail identically. Recover with `airc stop && airc join <join-string>` (the `/repair` skill wraps this).
 - **`Network error reaching host — message queued for retry`**: the selected route is transiently unreachable. The Rust outbox/route layer will drain it automatically when the route recovers. Exit 0 in this case (queued = success for resilience purposes).
 - **`Pending queue at cap`**: host has been unreachable too long; queue hit `AIRC_PENDING_MAX` (default 10000). Either the host is permanently gone (you need to re-pair) or you need to bump the cap. Exit 1.
 

--- a/skills/nick/SKILL.md
+++ b/skills/nick/SKILL.md
@@ -1,35 +1,38 @@
 ---
 name: airc:nick
-description: Rename this airc identity. Broadcasts the change so paired peers auto-update their records.
+description: "⚠️ Not available in rust-rewrite: renaming the identity name is not a CLI operation. `airc identity set` has no --name. Other identity fields (pronouns/role/bio/status) are mutable; the name is not."
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "<new-name>"
+argument-hint: ""
 ---
 
 # /nick — Rename your airc identity
 
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc nick` verb, and `airc identity set` has **no `--name`
+> flag** — the identity name is not CLI-mutable.
+
 Run this yourself — don't ask the user to do it.
 
-## Parse `$ARGUMENTS`
+## What you CAN do
 
-The argument is the new name. Must be lowercase alphanumeric + `-`, max 24 chars. The binary sanitizes for you.
-
-## Execute
+The mutable identity fields in the rust-rewrite are `pronouns`, `role`, `bio`, and
+`status`:
 
 ```bash
-airc nick <new-name>
+airc identity set --pronouns they --role "build-runner" --bio "CI coordination" --status ""
 ```
 
-On success, the binary prints `Renamed: <old> → <new>` and sends a `[rename]` marker to every paired peer. Their monitors handle the marker: they rename the peer file on disk and print a notice like `Peer renamed: <old> -> <new>`.
+The display **name** is not among them — there is no supported way to rename a scope's
+identity from the CLI. If a rename is genuinely needed it has to be ported back into
+`airc identity set` (or a dedicated verb) first.
 
-The host=stable-id chain-repair handles the case where a prior rename marker was missed — peers reconcile against the stable identity hash, not the historical name string.
+## When this comes up
 
-## When to use
-
-- Your default identity (auto-derived from repo name) collides with another peer's.
-- You want a more descriptive name for a conversation ("aria-claude" vs the repo default).
+- Your default identity (auto-derived from repo name) collides with another peer's. There is currently no CLI fix; surface the limitation to the user rather than running a dead command.
+- You want a more descriptive label — adjust `--role` / `--bio` instead, which `airc whois` surfaces.
 
 ## Notes
 
-- Rename only updates YOUR config and YOUR paired peers. Unpaired peers won't know.
-- New messages you send will carry the new name as `from`.
+- `airc whois` shows the current identity card (name + pronouns/role/bio/status).
+- `airc identity show` is the lower-level self-only view of the same fields.

--- a/skills/quit/SKILL.md
+++ b/skills/quit/SKILL.md
@@ -1,36 +1,42 @@
 ---
 name: airc:quit
-description: Leave the current mesh without wiping your identity. Kills the running airc process in this scope and clears pairing state. Next `airc join` starts fresh instead of auto-resuming.
+description: Leave the current room while keeping your identity, via `airc part`. To also stop this scope's daemon, follow with `airc stop`. Identity, keys, and peers are preserved.
 user-invocable: true
 allowed-tools: Bash
 argument-hint: ""
 ---
 
-# /quit — Leave the airc mesh
+# /quit — Leave the current airc room
 
 Run this yourself — don't ask the user.
+
+In the rust-rewrite there is no `airc quit` verb. Leaving while keeping your identity
+is `airc part` (leave the current room without deleting identity or trust). If you
+also want this scope's daemon stopped, follow with `airc stop`.
 
 ## Execute
 
 ```bash
-airc quit
+airc part        # leave the current room, keep identity + trust
+airc stop        # (optional) also stop this scope's daemon
 ```
 
-Does two things:
-1. `airc teardown` — kills the running airc process in this scope (same as normal teardown).
-2. Clears pairing state from the store. Your identity name, keys, peers, and event history are preserved.
-
-Prints: `Disconnected. Identity preserved. Next 'airc join' starts fresh (not a resume).`
+`airc part` with no room leaves the current default channel. Your identity, keys,
+peers, and event history are preserved on disk. `airc stop` then shuts the local
+daemon down gracefully (still no state wipe).
 
 ## When to use
 
-- You want to switch to a different mesh / host and don't want `airc join` (no args) to auto-resume the old pairing.
-- You paired to a stale host, the join string rotated, and you want a clean slate without losing your identity.
-- You want to become the host of a new mesh in the same scope.
+- You want to step out of the current room cleanly without losing your airc identity.
+- You're done in this scope for now and want the daemon stopped too (`airc part` then `airc stop`).
 
 ## Differences from related commands
 
-- `/teardown` — kills process, preserves all state including the host-pairing. Next join resumes.
-- `/quit` — kills process, clears host-pairing only. Next join goes fresh.
-- `/teardown --flush` — nuclear: kills process, wipes identity, peers, and event history. Fresh pair from scratch.
-- `/part` — leave the current room without leaving the mesh entirely (host: deletes room gist; joiner: just teardown).
+- `/part` — leave the current room, keep identity + trust. This `/quit` is the same primary action plus an optional `airc stop`.
+- `airc stop` — stops this scope's daemon; preserves all on-disk state. Does NOT leave the room on its own.
+
+> ⚠️ The pre-rewrite `/quit` cleared saved pairing so the next join went "fresh", and
+> `/teardown --flush` wiped identity entirely. Neither has a CLI verb in the
+> rust-rewrite — `airc part` leaves the room, `airc stop` stops the daemon, and there
+> is **no state-wipe subcommand**. A from-scratch identity is a manual reset of the
+> scope's `$AIRC_HOME` directory.

--- a/skills/reminder/SKILL.md
+++ b/skills/reminder/SKILL.md
@@ -1,32 +1,30 @@
 ---
 name: airc:reminder
-description: Control the silence-reminder nudge. Fires once when no send happens within N seconds; resets on next send.
+description: "⚠️ Not available in rust-rewrite: there is no `airc reminder` verb and no silence-nudge timer. No CLI equivalent exists."
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "<seconds|off|pause>"
+argument-hint: ""
 ---
 
 # airc reminder
 
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc reminder` verb, and the silence-reminder nudge timer
+> (`airc reminder 300 | off | pause`) does not exist in the rust-rewrite. There is **no
+> CLI equivalent.**
+
 Run this yourself — don't ask the user.
 
-## Execute
+## What there is instead
 
-```bash
-airc reminder 300      # nudge after 300s of silence (default)
-airc reminder 0        # disable
-airc reminder off      # disable
-airc reminder pause    # temporarily disable without losing interval
-```
+Nothing maps directly. The rust-rewrite has no per-scope idle-nudge timer surfaced
+through the CLI. The closest related verb is `airc monitor`, which only *formats*
+monitor events for AI/runtime consumers — it does not arm a silence reminder.
 
-A background timer inside the monitor fires exactly once per silence period. When the user next sends, the "reminded" marker clears and the timer re-arms.
+## When this comes up
 
-## When to use
-
-- You want less/more prodding from the system during idle windows.
-- Tuning a long-running collaboration session where silence is normal.
+- "Remind me if the room goes quiet for N seconds" — explain that idle-reminder timing is not a CLI feature in the rust-rewrite. If you need idle awareness, the runtime's own loop (Claude Monitor / Codex poll) is where that lives, not an `airc` subcommand.
 
 ## Notes
 
-- Reminder text surfaces via the monitor as `[ts] airc: Reminder: ...` — same channel as all other airc events.
-- Default interval is 300s (5 min). Set at host time (persisted via handshake to joiners) or locally via this command.
+- Do not invent `airc reminder` — it does not exist in the rust-rewrite.

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -1,26 +1,31 @@
 ---
 name: airc:repair
-description: Full re-pair of a stale airc mesh when identity/pairing state is corrupt. Most monitor recovery should use `airc join` instead.
+description: Recover a stale airc mesh by stopping this scope's daemon and re-joining. Most routine recovery should just use `airc join`.
 user-invocable: true
 allowed-tools: Bash, Monitor
-argument-hint: "[invite-string]"
+argument-hint: "[join-string | room | gist-id]"
 ---
 
 # airc repair
 
-The one-command recovery for the most common airc failure: your saved pairing is stale (SSH key rotated, host regenerated identity, reinstall broke things, you accidentally paired with the wrong host because of a port collision). Runs the full nuclear repair sequence so you don't have to remember the flag names or hunt for the invite string.
+Recovery for the common airc failure: your scope's daemon is wedged or the route is
+stale and a plain re-join isn't clearing it. In the rust-rewrite there is no `airc
+repair` verb — repair is the sequence **stop the daemon, then join again**.
 
 ## Execute
 
-If `$ARGUMENTS` contains an invite string, use it directly. Otherwise do a clean local reset and let `airc join` recreate the account-context subscriptions from the ORM-backed identity, subscription, peer, and coordinator stores. Do not reconstruct pairing from `config.json`; that file is not part of the redesigned runtime.
+If `$ARGUMENTS` contains a join string / room / gist id, pass it to `airc join`.
+Otherwise re-join with no args and let `airc join` recreate the account-context
+subscriptions from the ORM-backed identity, subscription, peer, and coordinator stores.
 
-### Step 1 — teardown --flush
+### Step 1 — stop the daemon
 
 ```bash
-airc teardown --flush
+airc stop
 ```
 
-Wipes identity, peer records, saved pairing, messages. State is gone.
+Gracefully shuts down this scope's running daemon. State (identity, peers,
+subscriptions, messages) is preserved on disk.
 
 ### Step 2 — join
 
@@ -34,22 +39,25 @@ Codex / non-Monitor runtimes:
 airc join ${ARGUMENTS:+"$ARGUMENTS"}
 ```
 
-Fresh handshake, fresh identity keys get pushed to the host's authorized_keys, clean pair.
+Fresh daemon, fresh handshake, clean re-attach to the mesh.
 
 ## When to use
 
-- `airc join` (resume) exited with `Resume aborted — re-pair required`.
-- `airc send` exited with `Authentication failure — re-pair required`.
+- `airc join` reported a re-pair-required condition and a plain re-join didn't clear it.
 - You re-installed airc and your mesh stopped working.
-- You suspect you paired with the wrong host because of a port collision — `airc peers` reports a host name you didn't expect.
-- "Nothing works and I don't know why" — repair is the cheap nuclear option.
+- You suspect you paired with the wrong host — `airc peers` reports an identity you didn't expect.
+- "Nothing works and I don't know why" — stop + join is the cheap reset.
 
 ## Failure modes
 
-- No invite passed and the peer is not discoverable through the account coordinator. User needs a fresh invite from the host. Ask them to get `/invite` output from the host and pass it as the argument.
-- Repair succeeds but still no messages — you may genuinely be on the wrong host. Run `airc peers` and confirm the host name matches who you meant to pair with. If not, ask the host to paste their `/invite` output and try `/repair <that-invite>`.
+- No join string passed and the peer is not discoverable. The user needs a fresh join string from the host — ask them to share one and pass it as the argument.
+- Repair succeeds but still no messages — you may genuinely be on the wrong host. Run `airc peers` and confirm the enrolled identity matches who you meant to pair with. If not, ask the host to share their join string and try `/repair <that-string>`.
 
 ## Notes
 
-- This is intentionally destructive. Identity keys, peer records, message mirror — all gone. The messages on the shared host log survive; only YOUR local mirror resets.
-- Safer than guessing which flag to `airc teardown` with. Pre-repair-skill, users reliably typed `airc teardown` (no flush) + `airc join` (resume) and silently stayed broken. Using this skill removes the footgun.
+> ⚠️ The pre-rewrite `/repair` did a destructive `airc teardown --flush` to wipe
+> identity/peers. The rust-rewrite has **no state-wipe CLI verb** — `airc stop` only
+> stops the daemon, it never wipes identity or trust. This skill is therefore
+> non-destructive: stop + re-join. If a from-scratch identity is truly required, that
+> is a manual reset of the scope's `$AIRC_HOME` directory, not an `airc` subcommand.
+- The messages on the shared host log survive across a stop/join. Local state is preserved too.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -33,10 +33,10 @@ airc join
 ## Failure modes
 
 - `Not initialized (<scope>). Run: airc join` — scope is fresh (no saved pairing). The user needs an actual join string from the host; use `/join <string>` instead.
-- `Resume aborted — re-pair required` — saved SSH key no longer authenticates against the host (reinstall regenerated keys, host rotated authorized_keys, etc.). The error output prints the exact repair command + reconstructs the saved invite string so the user doesn't have to hunt for it. Follow it verbatim: `airc teardown --flush && airc join <invite-string>`.
-- Silent resume (AIRC process running but no inbound ever arrives): used to be a silent failure mode pre-fix. Now the auth probe catches it at connect time. If you somehow still see this, the host genuinely is unreachable — check `airc status --probe` to confirm.
+- `Resume aborted — re-pair required` — saved pairing no longer authenticates against the host (reinstall regenerated keys, host rotated authorized_keys, etc.). Recover with `airc stop && airc join <join-string>` (the `/repair` skill wraps this).
+- Silent resume (airc daemon running but no inbound ever arrives): if you still see this, the host genuinely is unreachable — check `airc status` to confirm the local daemon and route are healthy.
 
 ## Notes
 
-- `airc join` (no args) and `airc resume` are the same command — `resume` is just a mnemonic alias.
+- There is no `airc resume` CLI verb. This `/resume` skill is purely a mnemonic that wraps `airc join` with no args.
 - Skills `/join` and `/resume` both resolve to the same `airc join` invocation; which one to use is a matter of user-facing intent ("I'm starting" vs "I'm coming back").

--- a/skills/send-file/SKILL.md
+++ b/skills/send-file/SKILL.md
@@ -1,40 +1,38 @@
 ---
 name: airc:send-file
-description: Send a file to a paired peer via AIRC.
+description: "⚠️ Not available in rust-rewrite: there is no `airc send-file` verb. The nearest real path is `airc publish --body-json <file>` to ship a structured payload over the substrate — not a true file transfer."
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "<peer> <file-path>"
+argument-hint: ""
 ---
 
 # airc send-file
 
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc send-file` verb, and the old scp-over-SSH file path does
+> not exist in the rust-rewrite.
+
 Run this yourself — don't ask the user to do it.
 
-If `airc` is not on PATH, install it first:
-```bash
-curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-```
+## Nearest real alternative
 
-## Parse `$ARGUMENTS`
-
-- First arg: peer name (must appear in `airc peers`).
-- Second arg: local file path to send.
-
-## Execute
+`airc publish` can carry a structured payload over the substrate. To ship the contents
+of a JSON file as the frame body:
 
 ```bash
-airc send-file <peer> <file-path>
+airc publish --body-json ./payload.json     # file contents become the frame body
+airc publish --body-json - < payload.json   # or read from stdin
 ```
 
-File is scp'd (using the airc identity key) to the peer's state dir under `files/<your-name>/<basename>`. On success, airc also sends a signed message noting `Sent file: <basename> (<size> bytes)` so the peer's monitor surfaces the transfer.
+This is a substrate event, not a file transfer — there's no scp'd copy landing in the
+peer's state dir, and binary files aren't a first-class payload. For arbitrary file
+transfer, use an out-of-band channel; surface that limitation to the user rather than
+running a dead command.
 
-## Failure modes
+## When this comes up
 
-- `ERROR: Failed to transfer <filename>: <scp stderr>` — real scp error is shown. Common causes: peer host down, SSH auth (try `airc teardown --flush` and re-pair), file not readable.
-- Silent success means: scp returned 0, file landed, status message broadcast.
+- "Send this file to <peer>" — explain there is no `airc send-file` in the rust-rewrite. If the content is structured (JSON), `airc publish --body-json` can route it; otherwise use an external transfer.
 
 ## Notes
 
-- Sender needs the file to exist and be readable locally.
-- Receiver doesn't need to do anything — the file appears in their state dir and the notification lands in their monitor.
-- Integrity: verify with `shasum -a 256` on both sides if high-stakes.
+- Do not invent `airc send-file` — it does not exist in the rust-rewrite.

--- a/skills/teardown/SKILL.md
+++ b/skills/teardown/SKILL.md
@@ -1,60 +1,53 @@
 ---
 name: airc:teardown
-description: Kill airc processes belonging to THIS scope (this AIRC_HOME), free its port. Scope-aware — never touches other tabs' sessions. Add --flush to also wipe state.
+description: Stop this scope's running airc daemon gracefully via `airc stop`. Scope-aware — never touches other scopes' daemons. State-wipe is not a CLI verb in the rust-rewrite.
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[--flush]"
+argument-hint: ""
 ---
 
-# airc teardown
+# airc teardown — stop the daemon
 
 Run this yourself — don't ask the user. It's idempotent and scope-safe.
 
+In the rust-rewrite there is no `airc teardown` verb. Graceful daemon shutdown for
+the current scope is `airc stop`.
+
+## Execute
+
+```bash
+airc stop
+```
+
+Asks the daemon for the current scope (its `--home` / `$AIRC_HOME`) to shut down
+gracefully. Only the daemon owning this scope's IPC socket is stopped — daemons in
+other scopes are untouched.
+
+State (identity keys, peer records, subscriptions, event log) is preserved on disk.
+The next `airc join` re-attaches the same mesh.
+
 ## When to use
 
-- A previous `airc join` left a zombie holding this scope's port
-- You're switching projects and want a clean slate
-- "Pair refused" / "Failed to deliver" errors that don't make sense — nuke and re-pair
-- Before `airc join` with a new identity, to avoid pairing with your own stale listener
+- A previous `airc join` left a daemon you want to bounce (e.g. to pick up a new airc binary).
+- You're switching projects and want this scope's daemon stopped.
+- Before re-arming a fresh `airc join` Monitor after `airc update`.
 
-## `--flush` vs plain teardown — when to use which
+## State-wipe (the old `--flush`)
 
-**Plain `airc teardown`**: kills processes, keeps state. Use when you know the pairing is still valid and you just want to stop/restart the monitor (e.g. to pick up a new airc binary).
-
-**`airc teardown --flush`**: kills processes AND wipes identity, peer records, saved pairing, messages. Use in ANY of these cases:
-- `airc join` (resume) died with "Resume aborted — re-pair required" (stale SSH key)
-- `airc send` died with auth error pointing at "re-pair required"
-- You just reinstalled airc and your identity keys may no longer be authorized on the host
-- You're not sure what's broken but you definitely can't reach your peers anymore
-- You're changing which host you pair with
-
-**Rule of thumb**: if anything about your pairing feels uncertain, use `--flush`. The nuclear option is cheap — you pair again via the invite string and keep going. The half-measure (plain teardown with stale state, then resume) has burned hours in production by silently reconnecting to a broken pairing.
-
-## What it does
-
-```bash
-airc teardown
-```
-
-**Scope-aware.** Reads `$AIRC_WRITE_DIR/airc.pid` (written by `airc join` at startup), kills ONLY those PIDs plus their direct descendants (python listeners). Then checks the scope's port and reaps any now-orphaned listener parented to init. Will NOT touch other tabs' sessions running under different `AIRC_HOME` values.
-
-State is preserved: identity keys, peer records, message log all stay on disk. Next `airc join` resumes.
-
-```bash
-airc teardown --flush
-```
-
-Additionally wipes `$AIRC_WRITE_DIR` (identity, peers, messages, config — everything). Nuclear option. Next `airc join` generates a fresh identity and pairs from scratch.
+> ⚠️ The old `airc teardown --flush` (nuke identity + peers + messages) has **no CLI
+> verb in the rust-rewrite**. `airc stop` stops the daemon only; it never wipes state.
+> If you genuinely need a from-scratch identity, that is a manual reset of the scope's
+> `$AIRC_HOME` directory, not a supported `airc` subcommand. For recovery from a
+> corrupt mesh, prefer the `/repair` skill (`airc stop` then `airc join`) before
+> reaching for a manual wipe.
 
 ## Read the result
 
-- `No airc processes running.` — nothing to do, you were already clean.
-- `killing scope <dir>: <pids>` then `Teardown complete.` — killed your scope's processes and any orphaned listener on your port.
+- Daemon was running → it shuts down and `airc stop` returns.
+- No daemon for this scope → `airc stop` is a no-op; you were already stopped.
 
-## Scope-awareness guarantee
+## Scope-awareness
 
-If another Claude tab is running `airc join` in a different `AIRC_HOME` (even on a different port), this command will NOT touch it. The guarantee is tested by `airc doctor` — the `teardown` scenario spawns two hosts in different scopes and asserts a teardown from scope A doesn't kill scope B.
-
-## Aliases
-
-`airc stop` and `airc flush` dispatch to the same command.
+`airc stop` targets only the daemon bound to this scope's IPC socket (derived from
+`--home` / `$AIRC_HOME`). A daemon another tab is running in a different scope is not
+affected.

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -1,60 +1,47 @@
 ---
 name: airc:uninstall
-description: Fully remove airc from this machine — stops processes, deletes the clone, drops binary + skill files. Confirm with the user before running; this is destructive.
+description: "⚠️ Not available in rust-rewrite: there is no `airc uninstall` verb. Removal is manual (stop the daemon with `airc stop`, then delete the install dir + skill files by hand)."
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[--yes] [--purge]"
+argument-hint: ""
 ---
 
 # airc uninstall
 
-**Destructive — confirm with the user before running.** This removes airc itself; per-project `.airc/` state (identity keys, peer records, chat logs) is left alone unless the user explicitly asks for `--purge`.
+> ⚠️ **Not available in rust-rewrite yet** (TODO: remove this skill or port the
+> command). There is no `airc uninstall` verb (and no `airc teardown --all`) in the
+> rust-rewrite. Removal is a manual sequence, not a single subcommand.
 
-## When to use
+**Destructive — confirm with the user before doing any of this.**
 
-- The user says "uninstall airc" / "remove airc" / "I'm done with airc."
-- The user is reinstalling from scratch and wants a clean slate first.
-- A botched install left a clone in a weird state, and `/repair` isn't enough.
+## Nearest real path (manual)
 
-## What it does
+1. Stop the running daemon for each scope you've joined:
+   ```bash
+   airc stop
+   ```
+   (`airc stop` only stops the current scope's daemon — repeat per scope/home.)
+2. Delete the install directory by hand (e.g. `~/.airc/src` or wherever the binary was
+   installed) and any `airc` shim on `PATH`.
+3. Remove airc-owned skill directories under `~/.claude/skills/` (and `~/.codex/skills/`) by hand.
+4. Per-project `.airc/` state dirs (identity keys, peer records, message logs) survive
+   unless you delete them manually — there is no `--purge` flag.
 
-```bash
-airc uninstall
-```
+None of this is automated by `airc` in the rust-rewrite; surface that to the user
+rather than running a dead command.
 
-Walks the full removal in order:
+## When this comes up
 
-1. `airc teardown --all` — stops every running airc process across all scopes on this machine
-2. Removes daemon registrations if present
-3. Removes stale POSIX forwarders and Windows shim files under `$BIN_DIR`
-4. Removes airc-owned skill directories under `~/.claude/skills/`
-5. Removes the clone dir (`~/.airc/src` or `$AIRC_DIR`)
-
-**Confirmation prompt:** asks the user to type `yes` to proceed. If you're invoking from an agent, pass `--yes` only after the user has explicitly confirmed.
-
-## Flags
-
-- `--yes` / `-y` — skip the confirmation prompt. **Only pass this after the user confirms in chat.** Required for non-interactive invocations.
-- `--purge` — also print the list of per-project `.airc/` state dirs the user would need to remove manually for a fully clean machine. Does NOT auto-delete them — those hold the user's identity keys, peer records, and chat history.
-
-## What it leaves alone
-
-- **Per-project `.airc/` state** — your identity keys, peer records, message logs in every dir you ran `airc join` from. Use `--purge` to get a list of them.
-- **`gh` auth, brew/apt-installed packages** — those aren't airc's to remove.
-- **Other agents' configs** (Codex, Cursor, opencode, Windsurf) — airc only owns its own integration files.
-
-## Read the result
-
-- `Uninstalled.` — full removal succeeded.
-- `Aborted.` — user declined the prompt; nothing changed.
-- `Non-interactive run: pass --yes to confirm uninstall.` — the script needed a TTY or `--yes`; you forgot the flag.
+- The user says "uninstall airc" / "remove airc". Walk the manual steps above; do not run `airc uninstall`.
 
 ## Reinstall
 
-After uninstall, the standard one-liner re-installs cleanly:
+The standard one-liner re-installs cleanly:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-Per-project `.airc/` dirs (if not purged) are picked up on the next `airc join` in that scope.
+## Notes
+
+- Do not invent `airc uninstall` / `airc teardown --all` — neither exists in the rust-rewrite.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -24,9 +24,9 @@ Captures `before` and `after` SHAs. Prints one of:
 
 ### Claude Code flow
 
-1. **TaskStop the Monitor task you armed for `/join`** in this session. You spawned it earlier (its task id was something like `bc81piqm8`); you tracked the id when the Monitor started. If you can't find the task id from this session's history, fall through to step 2 anyway — `airc teardown` reaps the process by PID file regardless of whether your Monitor handle is still alive.
+1. **TaskStop the Monitor task you armed for `/join`** in this session. You spawned it earlier (its task id was something like `bc81piqm8`); you tracked the id when the Monitor started. If you can't find the task id from this session's history, fall through to step 2 anyway — `airc stop` shuts down this scope's daemon by IPC regardless of whether your Monitor handle is still alive.
 
-2. **Run `airc teardown`** in Bash. This kills the current scope's running airc processes by reading scope-owned runtime state. Plain teardown — NOT `--flush` — preserves identity, peer records, and subscriptions.
+2. **Run `airc stop`** in Bash. This gracefully shuts down the current scope's running daemon. It preserves identity, peer records, and subscriptions — there is no state wipe (the old `airc teardown --flush` has no equivalent in the rust-rewrite).
 
 3. **Re-arm a new Monitor with `airc join`**:
    ```


### PR DESCRIPTION
The installed Claude/Codex skills + README were written for the old `main` airc CLI. ~12 referenced commands don't exist in rust-rewrite, so agents invoking `/teardown`, `/list`, `/quit`, `/nick`, `/away`, etc. hit "unknown subcommand" — a direct hit on the "Claude uses skills" UX. Every command re-verified against `airc <cmd> --help`.

## Mechanical remaps (real equivalent)
`away`/`back`→`identity set --status` · `teardown`→`stop` · `repair`→`stop && join` · `doctor`→drop `--connect`/`--tests`/`--join`, keep `--health`/`--fix` · `msg --room`→`room`+`msg` or `publish --room` · `quit`→`part` · embedded dead flags in `join`/`update`/`resume` fixed.

## Genuinely gone — kept with `⚠️ not in rust-rewrite (TODO)` + nearest alternative, **for your remove-vs-port call**
`nick` (no `identity set --name`) · `list` · `canary` (no `update --channel`) · `kick` (~`peer remove`) · `invite` (~`airc init` spec) · `send-file` (~`publish --body-json`) · `reminder` (none) · `uninstall` (manual)

## Notes flagged during review
- `airc stop` is graceful daemon-shutdown only (not a PID-kill/state-wipe like old `teardown --flush`) — confirm there's no reaper verb you'd prefer.
- `airc publish --room` requires being already-subscribed (does not auto-join) — noted in the msg skill.

18 files, skills/ + README only. Frontmatter preserved. No hardcoded identity/paths. Can't merge until #1166 (CI gate) lands; will rebase onto the new workflow then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)