### PR TITLE
fix(update): record install source so airc update works for dev checkouts

### DIFF
--- a/bootstrap-airc.sh
+++ b/bootstrap-airc.sh
@@ -72,6 +72,35 @@ if ! git config --global --get-all credential.https://github.com.helper 2>/dev/n
   gh auth setup-git 2>/dev/null && ok "gh token wired into git credential helper" || true
 fi
 
+# 3b. Git author identity. install.sh sets this too, but on the bootstrap
+# path install.sh runs BEFORE gh auth (non-TTY curl|bash), so its
+# identity block is skipped — and without this the first agent commit
+# dies with "Author identity unknown". Derive from the authenticated gh
+# account when unset; never clobber an identity the user already set.
+# Public email, else the <id>+<login> noreply alias. No hardcoded values.
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  _need_name=0; _need_email=0
+  if [ -z "$(git config --global user.name 2>/dev/null || true)" ]; then _need_name=1; fi
+  if [ -z "$(git config --global user.email 2>/dev/null || true)" ]; then _need_email=1; fi
+  if [ "$_need_name" = 1 ] || [ "$_need_email" = 1 ]; then
+    _gh_login="$(gh api user --jq '.login' 2>/dev/null || true)"
+    _gh_name="$(gh api user --jq '.name // .login' 2>/dev/null || true)"
+    _gh_id="$(gh api user --jq '.id' 2>/dev/null || true)"
+    _gh_email="$(gh api user --jq '.email // empty' 2>/dev/null || true)"
+    if [ -z "$_gh_email" ] && [ -n "$_gh_id" ] && [ -n "$_gh_login" ]; then
+      _gh_email="${_gh_id}+${_gh_login}@users.noreply.github.com"
+    fi
+    if [ "$_need_name" = 1 ] && [ -n "$_gh_name" ]; then
+      git config --global user.name "$_gh_name"
+      ok "git user.name set from gh: $_gh_name"
+    fi
+    if [ "$_need_email" = 1 ] && [ -n "$_gh_email" ]; then
+      git config --global user.email "$_gh_email"
+      ok "git user.email set from gh: $_gh_email"
+    fi
+  fi
+fi
+
 # 4. join the room
 if [ -n "$MNEMONIC" ]; then
   step "Joining room via mnemonic / gist-id: $MNEMONIC"

--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -156,8 +156,33 @@ pub(crate) fn install_source_dir() -> Result<PathBuf, Box<dyn std::error::Error>
     }
     let home = env::var_os("HOME")
         .or_else(|| env::var_os("USERPROFILE"))
-        .ok_or("HOME is not set; cannot resolve ~/.airc/src")?;
-    Ok(PathBuf::from(home).join(".airc").join("src"))
+        .ok_or("HOME is not set; cannot resolve the airc install source")?;
+    let home = PathBuf::from(home);
+    // install.sh / install.ps1 record the dir they actually installed
+    // FROM in this marker. install.sh's _default_clone_dir installs from a
+    // dev checkout (e.g. ~/work/airc) when run inside one — and
+    // rust-rewrite currently ships ONLY as a dev checkout (no release
+    // channel yet) — so the source is frequently NOT ~/.airc/src. Without
+    // the marker, `airc update` died with "No git checkout at
+    // ~/.airc/src" for every dev-checkout install (caught live
+    // 2026-06-13). Honor the marker before falling back to the default.
+    if let Some(recorded) = read_install_source_marker(&home) {
+        return Ok(recorded);
+    }
+    Ok(home.join(".airc").join("src"))
+}
+
+/// Read the path recorded in `~/.airc/install-source`, if present and
+/// non-empty. Returns `None` on any read error or blank content so the
+/// caller falls back to the default location.
+fn read_install_source_marker(home: &Path) -> Option<PathBuf> {
+    let marker = home.join(".airc").join("install-source");
+    let contents = std::fs::read_to_string(&marker).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
 }
 
 fn validate_source_checkout(source: &Path) -> Result<(), Box<dyn std::error::Error>> {
@@ -259,6 +284,75 @@ mod tests {
                 assert_eq!(
                     install_source_dir().unwrap(),
                     PathBuf::from("/tmp/home/.airc/src")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn install_source_reads_marker_when_no_env() {
+        // what this catches: airc update finding a dev-checkout install
+        // source recorded by install.sh, instead of dying on ~/.airc/src
+        // (regression for the 2026-06-13 "No git checkout" dev-install bug).
+        let temp = tempfile::TempDir::new().unwrap();
+        let airc = temp.path().join(".airc");
+        std::fs::create_dir_all(&airc).unwrap();
+        std::fs::write(airc.join("install-source"), "/opt/dev/airc\n").unwrap();
+        temp_env::with_vars(
+            [
+                ("AIRC_DIR", None::<&str>),
+                ("HOME", Some(temp.path().to_str().unwrap())),
+                ("USERPROFILE", None::<&str>),
+            ],
+            || {
+                assert_eq!(
+                    install_source_dir().unwrap(),
+                    PathBuf::from("/opt/dev/airc")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn install_source_airc_dir_beats_marker() {
+        // what this catches: explicit AIRC_DIR must still win over a
+        // recorded marker (precedence order regression).
+        let temp = tempfile::TempDir::new().unwrap();
+        let airc = temp.path().join(".airc");
+        std::fs::create_dir_all(&airc).unwrap();
+        std::fs::write(airc.join("install-source"), "/opt/dev/airc\n").unwrap();
+        temp_env::with_vars(
+            [
+                ("AIRC_DIR", Some("/explicit/override")),
+                ("HOME", Some(temp.path().to_str().unwrap())),
+            ],
+            || {
+                assert_eq!(
+                    install_source_dir().unwrap(),
+                    PathBuf::from("/explicit/override")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn install_source_blank_marker_falls_back_to_default() {
+        // what this catches: a blank/whitespace marker must not resolve to
+        // an empty path; fall through to ~/.airc/src.
+        let temp = tempfile::TempDir::new().unwrap();
+        let airc = temp.path().join(".airc");
+        std::fs::create_dir_all(&airc).unwrap();
+        std::fs::write(airc.join("install-source"), "  \n").unwrap();
+        temp_env::with_vars(
+            [
+                ("AIRC_DIR", None::<&str>),
+                ("HOME", Some(temp.path().to_str().unwrap())),
+                ("USERPROFILE", None::<&str>),
+            ],
+            || {
+                assert_eq!(
+                    install_source_dir().unwrap(),
+                    temp.path().join(".airc").join("src")
                 );
             },
         );

--- a/install.ps1
+++ b/install.ps1
@@ -293,6 +293,15 @@ if (-not (Test-Path $channelFile) -or (Get-Content $channelFile -Raw -ErrorActio
     Set-Content -Path $channelFile -Value $DEFAULT_CHANNEL -NoNewline
 }
 
+# Record the install source so `airc update` can find it even when it's a
+# dev checkout outside ~/.airc/src (parity with install.sh; the Rust
+# update command reads ~/.airc/install-source). $CLONE_DIR is already a
+# native Windows path here, which is what the native binary needs.
+$aircHome = Join-Path $env:USERPROFILE '.airc'
+New-Item -ItemType Directory -Force -Path $aircHome | Out-Null
+Set-Content -Path (Join-Path $aircHome 'install-source') -Value $CLONE_DIR
+Write-Ok "Recorded install source for 'airc update': $CLONE_DIR"
+
 # -- Build + install the Rust airc binary -------------------------------
 # Mirrors install.sh's `_install_airc_binary`: PR #864 demolished the bash
 # wrapper, airc IS the Rust binary now. On Windows that's

--- a/install.sh
+++ b/install.sh
@@ -756,6 +756,23 @@ _install_airc_binary() {
 
 _install_airc_binary
 
+# ── Record the install source for `airc update` ────────────────────────
+# install.sh's _default_clone_dir installs FROM a dev checkout (the cwd)
+# when run inside one, and rust-rewrite currently ships ONLY as a dev
+# checkout (no release channel yet) — so the source is frequently NOT
+# ~/.airc/src. The Rust `airc update` reads this marker to find the
+# source; without it, update died with "No git checkout at ~/.airc/src"
+# for every dev-checkout install (caught live 2026-06-13). The native
+# (non-MSYS) path form is REQUIRED: the airc binary is native and its
+# std::fs / git -C cannot resolve a `/c/...` MSYS path on Windows.
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) _install_source="$(_to_win_path "$CLONE_DIR")" ;;
+  *)                    _install_source="$CLONE_DIR" ;;
+esac
+mkdir -p "$HOME/.airc"
+printf '%s\n' "$_install_source" > "$HOME/.airc/install-source"
+ok "Recorded install source for 'airc update': $_install_source"
+
 # ── Skills into agent skill dirs (Claude Code + Codex) ─────────────────
 #
 # Both Claude Code and OpenAI Codex use the same on-disk skill format:


### PR DESCRIPTION
## Problem (found by running the real update path)
`airc update` resolves the source as `$AIRC_DIR` or hardcoded `~/.airc/src` (`update_commands.rs::install_source_dir`). But install.sh's `_default_clone_dir` installs FROM a dev checkout (the cwd) when run inside one — and **rust-rewrite currently ships ONLY as a dev checkout** (no release channel has the rewrite yet). So on every dev-checkout install, `airc update` dies with **"No git checkout at ~/.airc/src."** Since all current operators (incl. the other agents) are on rust-rewrite dev checkouts, this blocked the whole team from pulling fixes via `airc update`.

## Fix
- install.sh + install.ps1 record the dir they installed from in `~/.airc/install-source`.
- `install_source_dir()` resolution: `$AIRC_DIR` env → marker → `~/.airc/src` default.
- **Native path requirement:** the binary's `std::fs`/`git -C` can't resolve an MSYS `/c/...` path on Windows, so install.sh converts via `_to_win_path` on MINGW/MSYS/CYGWIN only (Unix written as-is); install.ps1's `$CLONE_DIR` is already native.

## Validation
- 3 new tests (marker honored / `$AIRC_DIR` wins / blank marker → default) + existing 4 pass.
- `cargo fmt` + `clippy` (incl. production no-unwrap gate) clean locally; CI's real legs run (Rust-path PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)