### PR TITLE
fix(account-registry): prune stale peer beacons before enrol

### DIFF
--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -56,6 +56,11 @@ pub enum DiagnosticCode {
     /// temp-rooted (phantom hermetic-test peers in polluted documents).
     /// Carries the count, not the dump.
     AccountRegistryTempBeaconsIgnored,
+    /// Reader-merge pruned peers whose freshest beacon is older than the
+    /// freshness TTL — dead daemons whose only surviving gist beacon is
+    /// days old. Enrolling them would dial dead routes (the stale-route
+    /// orphan path). Carries the count, not the dump.
+    AccountRegistryStaleBeaconsPruned,
     WireLostEmitFailed,
     MalformedReplayFrameSkipped,
     UnverifiableReplayFrameSkipped,

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -156,6 +156,39 @@ pub fn merge_registry_documents(
     }
 }
 
+/// Default freshness horizon for reader-side beacon pruning: 10 minutes.
+///
+/// Deliberately MUCH longer than the local coordinator's 60s heartbeat
+/// TTL ([`crate::coordinator::DEFAULT_HEARTBEAT_TTL_MS`]). A peer's
+/// beacon reaches another machine only after a publish→gist→fetch hop,
+/// and the production registry-refresh loop runs on a ~120s cadence, so
+/// a perfectly live peer's freshest visible beacon is routinely a couple
+/// of minutes old purely from transport latency. The local TTL would
+/// false-drop those. This horizon is sized to prune only beacons whose
+/// publisher is genuinely gone (process dead for many minutes / the gist
+/// is days stale) while never evicting a live-but-laggy peer.
+pub const DEFAULT_PEER_FRESHNESS_TTL_MS: u64 = 600_000;
+
+/// Drop peers whose freshest beacon is staler than `ttl_ms` relative to
+/// `now_ms`, in place. Returns the number pruned.
+///
+/// This is the reader-side counterpart to the local coordinator's
+/// [`crate::coordinator::drain_stale_store`]: [`merge_registry_documents`]
+/// already keeps only the FRESHEST beacon per peer, but a peer whose
+/// freshest beacon is itself ancient (the publisher died and its gist
+/// never got cleaned) would still be enrolled and then dialed — the
+/// stale-route orphan path. Pruning here means the enrol set never
+/// contains a route we already know is dead.
+///
+/// Reuses [`PresenceBeacon::is_fresh`] so the freshness decision lives in
+/// exactly one place (saturating-sub guards future-dated clocks → a
+/// future-dated beacon is treated as fresh, never pruned).
+pub fn prune_stale_peers(peers: &mut Vec<AccountPeerBeacon>, now_ms: u64, ttl_ms: u64) -> usize {
+    let before = peers.len();
+    peers.retain(|peer| peer.presence.is_fresh(now_ms, ttl_ms));
+    before - peers.len()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountRegistryDocument {
     pub schema_version: u16,
@@ -986,6 +1019,39 @@ mod tests {
         );
         let outcome = merge_registry_documents(vec![foreign], &mesh());
         assert!(outcome.document.is_none());
+    }
+
+    // what this catches: a dead daemon whose freshest surviving gist
+    // beacon is days old must be PRUNED from the enrol set, not dialed
+    // (the stale-route orphan path the merge alone never closed — it
+    // keeps freshest-per-peer but a peer's freshest can still be
+    // ancient). The user-flagged "make sure those aren't just old ones".
+    // Mutation check: dropping the `is_fresh` filter keeps the stale
+    // peer and returns 0 — both asserts fail.
+    #[test]
+    fn prune_drops_only_peers_staler_than_ttl() {
+        let now_ms = 1_000_000;
+        let ttl = DEFAULT_PEER_FRESHNESS_TTL_MS; // 600_000
+        let fresh = PeerId::new();
+        let stale = PeerId::new();
+        let future = PeerId::new();
+        let mut peers = vec![
+            // 100s old — well within the 10min horizon.
+            beacon_at(fresh, "/machine/a/.airc", now_ms - 100_000),
+            // 900s old — a dead publisher's lingering gist beacon.
+            beacon_at(stale, "/machine/b/.airc", now_ms - 900_000),
+            // future-dated clock skew — saturating-sub treats as fresh,
+            // never pruned (we don't punish a peer for our clock).
+            beacon_at(future, "/machine/c/.airc", now_ms + 50_000),
+        ];
+
+        let pruned = prune_stale_peers(&mut peers, now_ms, ttl);
+
+        assert_eq!(pruned, 1, "exactly the stale peer is pruned");
+        let kept: Vec<_> = peers.iter().map(|p| p.peer_id()).collect();
+        assert!(kept.contains(&fresh), "live-but-laggy peer kept");
+        assert!(kept.contains(&future), "future-dated peer kept");
+        assert!(!kept.contains(&stale), "dead-route peer dropped");
     }
 
     // Two SEPARATE machine accounts, same gh identity, bridged ONLY

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -189,6 +189,9 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::AccountRegistryTempBeaconsIgnored => {
             "account_registry_temp_beacons_ignored"
         }
+        DiagnosticCode::AccountRegistryStaleBeaconsPruned => {
+            "account_registry_stale_beacons_pruned"
+        }
         DiagnosticCode::WireLostEmitFailed => "wire_lost_emit_failed",
         DiagnosticCode::MalformedReplayFrameSkipped => "malformed_replay_frame_skipped",
         DiagnosticCode::UnverifiableReplayFrameSkipped => "unverifiable_replay_frame_skipped",

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -73,8 +73,9 @@ use airc_diagnostics::{
 use airc_store::{SqliteEventStore, StoredAccountRegistryGistSentinel};
 
 use crate::account_registry::{
-    merge_registry_documents, scope_home_is_temp_rooted, AccountRegistryDocument,
-    AccountRegistryError, AccountRegistryStore,
+    merge_registry_documents, prune_stale_peers, scope_home_is_temp_rooted,
+    AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
+    DEFAULT_PEER_FRESHNESS_TTL_MS,
 };
 use crate::subscriptions::MeshIdentity;
 use crate::time;
@@ -739,7 +740,31 @@ impl AccountRegistryStore for GhAccountRegistryStore {
                 .with_field("ignored_count", outcome.ignored_temp_beacons),
             );
         }
-        Ok(outcome.document)
+        // Freshness pass: even the freshest beacon per peer can be
+        // ancient (its publisher died; the gist was never cleaned).
+        // Prune those before enrol so we never dial a route we already
+        // know is dead — the stale-route orphan path.
+        let Some(mut document) = outcome.document else {
+            return Ok(None);
+        };
+        let now_ms = time::now_ms().map_err(|error| {
+            AccountRegistryError::Adapter(format!("system clock before unix epoch: {error}"))
+        })?;
+        let pruned =
+            prune_stale_peers(&mut document.peers, now_ms, DEFAULT_PEER_FRESHNESS_TTL_MS);
+        if pruned > 0 {
+            StderrJsonDiagnosticSink.emit(
+                DiagnosticEvent::warn(
+                    DiagnosticComponent::Daemon,
+                    DiagnosticCode::AccountRegistryStaleBeaconsPruned,
+                    "account-registry reader-merge pruned stale peer beacon(s): the freshest \
+                     beacon for each was older than the freshness TTL — dead routes, never enrolled",
+                )
+                .with_field("pruned_count", pruned)
+                .with_field("ttl_ms", DEFAULT_PEER_FRESHNESS_TTL_MS),
+            );
+        }
+        Ok(Some(document))
     }
 }
 

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -750,8 +750,7 @@ impl AccountRegistryStore for GhAccountRegistryStore {
         let now_ms = time::now_ms().map_err(|error| {
             AccountRegistryError::Adapter(format!("system clock before unix epoch: {error}"))
         })?;
-        let pruned =
-            prune_stale_peers(&mut document.peers, now_ms, DEFAULT_PEER_FRESHNESS_TTL_MS);
+        let pruned = prune_stale_peers(&mut document.peers, now_ms, DEFAULT_PEER_FRESHNESS_TTL_MS);
         if pruned > 0 {
             StderrJsonDiagnosticSink.emit(
                 DiagnosticEvent::warn(

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -1149,6 +1149,15 @@ exit 0
             MeshIdentity::new("joelteply")
         }
 
+        /// Real wall-clock now, in ms. `refresh` prunes peers whose
+        /// freshest beacon is older than `DEFAULT_PEER_FRESHNESS_TTL_MS`
+        /// against this clock, so a beacon that must SURVIVE a refresh
+        /// has to carry a near-now heartbeat (a live peer). Tests anchor
+        /// surviving beacons at `now() - small_offset`.
+        fn now() -> u64 {
+            crate::time::now_ms().expect("system clock available in test")
+        }
+
         fn beacon(scope_home: &str, heartbeat_ms: u64, relay: &str) -> AccountPeerBeacon {
             let peer_id = PeerId::new();
             beacon_for(peer_id, scope_home, heartbeat_ms, relay)
@@ -1314,18 +1323,24 @@ exit 0
             let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
 
             let shared = PeerId::new();
+            // Both heartbeats are near-now (live peer): refresh prunes
+            // beacons older than the freshness TTL, so the peer must be
+            // fresh to survive — `fresh` is more recent than `stale` so
+            // the freshest-wins dedup is still exercised.
             let stale = beacon_for(
                 shared,
                 "/machine/a/.airc",
-                1_000,
+                now() - 5_000,
                 "https://stale.example.test",
             );
             let fresh = beacon_for(
                 shared,
                 "/machine/a/.airc",
-                5_000,
+                now() - 1_000,
                 "https://fresh.example.test",
             );
+            // Phantom is temp-scoped → dropped by the merge temp filter
+            // before prune, so its heartbeat is irrelevant.
             let phantom = beacon(
                 r"C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc",
                 9_000,
@@ -1377,16 +1392,19 @@ exit 0
             let stub = StubGh::install(dir.path());
             let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
 
+            // Both live (near-now heartbeats) so neither is pruned by
+            // the refresh freshness pass — the test is about the UNION
+            // across writer gists, not freshness.
             let peer_a = beacon_for(
                 PeerId::new(),
                 "/machine/a/.airc",
-                1_000,
+                now() - 5_000,
                 "https://machine-a.example.test",
             );
             let peer_b = beacon_for(
                 PeerId::new(),
                 "/machine/b/.airc",
-                5_000,
+                now() - 1_000,
                 "https://machine-b.example.test",
             );
 
@@ -1422,6 +1440,57 @@ exit 0
             assert_eq!(
                 merged_a.endpoints, peer_a.endpoints,
                 "peer A's dialable endpoints must survive the merge"
+            );
+        }
+
+        // what this catches: refresh PRUNES a peer whose freshest
+        // surviving gist beacon is older than the freshness TTL (a dead
+        // publisher whose gist was never cleaned) while keeping a live
+        // peer — the stale-route orphan path. Mutation check: removing
+        // the prune wiring in `refresh` keeps the dead peer and the
+        // len/identity asserts fail.
+        #[tokio::test]
+        async fn refresh_prunes_stale_peer_keeping_live_one() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+            let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
+
+            let live = beacon_for(
+                PeerId::new(),
+                "/machine/live/.airc",
+                now() - 30_000, // 30s old — well inside the TTL
+                "https://live.example.test",
+            );
+            let dead = beacon_for(
+                PeerId::new(),
+                "/machine/dead/.airc",
+                // Older than DEFAULT_PEER_FRESHNESS_TTL_MS (10min) — a
+                // publisher that has been gone for an hour.
+                now() - (DEFAULT_PEER_FRESHNESS_TTL_MS + 3_600_000),
+                "https://dead.example.test",
+            );
+            stub.seed_gist(
+                "live-writer",
+                "airc-account-mesh-registry.live.json",
+                &document(2_000, vec![live.clone()]),
+            );
+            stub.seed_gist(
+                "dead-writer",
+                "airc-account-mesh-registry.dead.json",
+                &document(2_000, vec![dead.clone()]),
+            );
+
+            let merged = store
+                .refresh(&mesh())
+                .await
+                .unwrap()
+                .expect("documents must merge");
+
+            assert_eq!(merged.peers.len(), 1, "the dead-route peer is pruned");
+            assert_eq!(
+                merged.peers[0].peer_id(),
+                live.peer_id(),
+                "only the live peer is enrolled"
             );
         }
 

--- a/crates/airc-lib/src/gh/governor.rs
+++ b/crates/airc-lib/src/gh/governor.rs
@@ -150,8 +150,8 @@ impl GhBudget {
 
         // Primary limiter: persist the live remaining/reset and throttle
         // at the floor (keep headroom) instead of waiting for 0.
-        let remaining = header_value(&body, "x-ratelimit-remaining")
-            .and_then(|v| v.trim().parse::<u64>().ok());
+        let remaining =
+            header_value(&body, "x-ratelimit-remaining").and_then(|v| v.trim().parse::<u64>().ok());
         let reset =
             header_value(&body, "x-ratelimit-reset").and_then(|v| v.trim().parse::<f64>().ok());
         if let (Some(remaining), Some(reset)) = (remaining, reset) {

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -79,9 +79,9 @@ pub mod work_roster;
 pub mod work_subscription;
 
 pub use account_registry::{
-    merge_registry_documents, scope_home_is_temp_rooted, AccountPeerBeacon,
+    merge_registry_documents, prune_stale_peers, scope_home_is_temp_rooted, AccountPeerBeacon,
     AccountRegistryDocument, AccountRegistryError, AccountRegistryStore, RegistryMergeOutcome,
-    SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION,
+    SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION, DEFAULT_PEER_FRESHNESS_TTL_MS,
 };
 pub use agent_heartbeat::{
     AgentHeartbeat, AgentLiveness, CoordinationSignal, HeartbeatKind, HeartbeatTask,


### PR DESCRIPTION
## What

`merge_registry_documents` keeps the **freshest beacon per peer**, but never asks whether that freshest beacon is *itself* old enough to be dead. A peer whose publisher died and whose lingering gist beacon is days old was still enrolled — and then dialed. That's the **stale-route orphan path** Joel kept flagging: *"make sure those aren't just old ones."*

The convergence harness (`docker/mesh-converge.sh`) surfaced it concretely: both isolated nodes enrolled **11–12 peers when only 1 was live**.

## Fix

A reader-side freshness pass — the counterpart to the local coordinator's `drain_stale_store`:

- **`prune_stale_peers(peers, now_ms, ttl_ms) -> usize`** — pure, in-place. Reuses `PresenceBeacon::is_fresh` so the freshness decision lives in **one place** (compression principle). Saturating-sub keeps future-dated clock-skew peers — we never punish a peer for our clock.
- **`DEFAULT_PEER_FRESHNESS_TTL_MS = 600_000` (10 min)** — deliberately **>> the 60s local heartbeat TTL**. A live peer's beacon reaches another machine only after a `publish→gist→fetch` hop on the ~120s refresh cadence, so a couple-minutes-old beacon is normal transport latency, not death. Sized to drop only genuinely-dead publishers.
- Wired into **`GhAccountRegistryStore::refresh`** — the single production enrol chokepoint — and surfaced via a counted `AccountRegistryStaleBeaconsPruned` diagnostic, symmetric with the existing temp-beacon counter (count, not dump).

## Why additive (not a `merge_registry_documents` signature change)

`merge` has no clock and 4 mechanics tests that build tiny synthetic timestamps and assert retention. Threading `now_ms` through it would force noisy edits to tests that don't care about freshness. The freshness policy is an *enrol* concern, and there is exactly one production enrol path — so the filter lives there, beside where temp-rooted beacons are already dropped.

## Validation

- Unit test `prune_drops_only_peers_staler_than_ttl`: only the over-TTL peer drops; live-but-laggy and future-dated peers kept. Mutation-documented (drop the `is_fresh` filter → both asserts fail).
- `cargo clippy -p airc-lib -p airc-cli -p airc-diagnostics --all-targets -- -D warnings` clean.
- Lib tests green: account_registry **20**, gh **29**, diagnostics **5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)