### PR TITLE
fix(ci): clean-install smoke uses real verbs (daemon/stop), not legacy connect/teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,46 +64,52 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           AIRC_EXPECT_BIN="$HOME/.local/bin/airc" bash "$HOME/.airc/src/test/public_installed_runtime_proof.sh"
 
-      - name: Smoke — connect --no-room --no-gist + teardown
+      - name: Smoke — daemon host loop up + stop teardown
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           export AIRC_HOME=/tmp/ci-airc/state
           export AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1
+          # Offline gate — the old smoke used `--no-gist`; AIRC_DISABLE_ACCOUNT_REGISTRY
+          # is its real equivalent (blocks the gh/gist transport), so the
+          # daemon never reaches for gh on a runner with no auth.
+          export AIRC_DISABLE_ACCOUNT_REGISTRY=1
           mkdir -p /tmp/ci-airc/state
-          # Spawn host in background. --no-gist keeps it offline.
-          airc connect --no-room --no-gist > /tmp/ci-airc/host.log 2>&1 &
-          # Wait up to 10s for airc.pid to appear (airc writes it once
-          # the host loop is up). Don't pgrep on argv — airc's actual
-          # process line is `bash /path/to/airc connect ...` and pgrep
-          # patterns are brittle across distros.
+          # Spawn the foreground host loop in the background. The env
+          # above keeps it offline (no general join, no gist, no identity
+          # prompt). `connect`/`teardown` were legacy Python verbs removed
+          # in the rust rewrite — the real verbs are `daemon` (start the
+          # host loop) and `stop` (graceful shutdown).
+          airc daemon > /tmp/ci-airc/host.log 2>&1 &
+          # Wait up to 10s for the daemon pidfile to appear (the daemon
+          # writes <home>/daemon.pid once its bind guard is up). Don't
+          # pgrep on argv — process lines are brittle across distros.
           for i in 1 2 3 4 5 6 7 8 9 10; do
-            [ -f /tmp/ci-airc/state/airc.pid ] && break
+            [ -f /tmp/ci-airc/state/daemon.pid ] && break
             sleep 1
           done
-          if [ ! -f /tmp/ci-airc/state/airc.pid ]; then
-            echo "FAIL: airc.pid never appeared — connect didn't reach host loop"
+          if [ ! -f /tmp/ci-airc/state/daemon.pid ]; then
+            echo "FAIL: daemon.pid never appeared — airc daemon didn't reach host loop"
             cat /tmp/ci-airc/host.log || true
             exit 1
           fi
-          # Verify all PIDs in airc.pid are alive.
-          for p in $(cat /tmp/ci-airc/state/airc.pid); do
+          # Verify all PIDs in daemon.pid are alive.
+          for p in $(cat /tmp/ci-airc/state/daemon.pid); do
             if ! kill -0 "$p" 2>/dev/null; then
-              echo "FAIL: PID $p in airc.pid is not alive"
+              echo "FAIL: PID $p in daemon.pid is not alive"
               cat /tmp/ci-airc/host.log || true
               exit 1
             fi
           done
-          echo "✓ airc connect stayed up (pids: $(cat /tmp/ci-airc/state/airc.pid))"
-          airc teardown
+          echo "✓ airc daemon stayed up (pids: $(cat /tmp/ci-airc/state/daemon.pid))"
+          airc stop
           sleep 1
-          # After teardown, airc.pid is removed AND no PID from it should
-          # still be alive. We saved the pids before teardown for the
-          # post-check.
-          if [ -f /tmp/ci-airc/state/airc.pid ]; then
-            echo "FAIL: airc teardown left airc.pid behind"
+          # The daemon removes daemon.pid on graceful exit (PidFileGuard
+          # Drop). If it lingers, stop didn't reach the host loop.
+          if [ -f /tmp/ci-airc/state/daemon.pid ]; then
+            echo "FAIL: airc stop left daemon.pid behind"
             exit 1
           fi
-          echo "✓ airc teardown clean"
+          echo "✓ airc stop clean"
 
   clean-install-macos:
     runs-on: macos-latest
@@ -131,37 +137,41 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           AIRC_EXPECT_BIN="$HOME/.local/bin/airc" bash "$HOME/.airc/src/test/public_installed_runtime_proof.sh"
 
-      - name: Smoke — same as linux (airc.pid based)
+      - name: Smoke — same as linux (daemon.pid based)
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           export AIRC_HOME=/tmp/ci-airc/state
           export AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1
+          # Offline gate — the old smoke used `--no-gist`; AIRC_DISABLE_ACCOUNT_REGISTRY
+          # is its real equivalent (blocks the gh/gist transport), so the
+          # daemon never reaches for gh on a runner with no auth.
+          export AIRC_DISABLE_ACCOUNT_REGISTRY=1
           mkdir -p /tmp/ci-airc/state
-          airc connect --no-room --no-gist > /tmp/ci-airc/host.log 2>&1 &
+          airc daemon > /tmp/ci-airc/host.log 2>&1 &
           for i in 1 2 3 4 5 6 7 8 9 10; do
-            [ -f /tmp/ci-airc/state/airc.pid ] && break
+            [ -f /tmp/ci-airc/state/daemon.pid ] && break
             sleep 1
           done
-          if [ ! -f /tmp/ci-airc/state/airc.pid ]; then
-            echo "FAIL: airc.pid never appeared — connect didn't reach host loop"
+          if [ ! -f /tmp/ci-airc/state/daemon.pid ]; then
+            echo "FAIL: daemon.pid never appeared — airc daemon didn't reach host loop"
             cat /tmp/ci-airc/host.log || true
             exit 1
           fi
-          for p in $(cat /tmp/ci-airc/state/airc.pid); do
+          for p in $(cat /tmp/ci-airc/state/daemon.pid); do
             if ! kill -0 "$p" 2>/dev/null; then
-              echo "FAIL: PID $p in airc.pid is not alive"
+              echo "FAIL: PID $p in daemon.pid is not alive"
               cat /tmp/ci-airc/host.log || true
               exit 1
             fi
           done
-          echo "✓ airc connect stayed up (pids: $(cat /tmp/ci-airc/state/airc.pid))"
-          airc teardown
+          echo "✓ airc daemon stayed up (pids: $(cat /tmp/ci-airc/state/daemon.pid))"
+          airc stop
           sleep 1
-          if [ -f /tmp/ci-airc/state/airc.pid ]; then
-            echo "FAIL: airc teardown left airc.pid behind"
+          if [ -f /tmp/ci-airc/state/daemon.pid ]; then
+            echo "FAIL: airc stop left daemon.pid behind"
             exit 1
           fi
-          echo "✓ airc teardown clean"
+          echo "✓ airc stop clean"
 
   clean-install-windows:
     runs-on: windows-latest

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -514,7 +514,14 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].status, Status::Blocked);
         let fix = findings[0].fix.as_ref().unwrap();
-        assert!(fix.contains("teardown --flush"));
+        // what this catches: the fix must name a REAL recovery path —
+        // wipe the orphan key, then regenerate — using verbs that exist
+        // in the rust rewrite. `teardown`/`--flush` were legacy Python
+        // verbs removed in the cutover; recommending them hands the user
+        // a broken command (regression guard for that dead-verb drift).
+        assert!(fix.contains("airc join"), "fix must point at the regenerate step: {fix}");
+        assert!(fix.contains("rm "), "fix must name the wipe step: {fix}");
+        assert!(!fix.contains("teardown"), "must not recommend the removed teardown verb: {fix}");
     }
 
     #[tokio::test]

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -519,9 +519,15 @@ mod tests {
         // in the rust rewrite. `teardown`/`--flush` were legacy Python
         // verbs removed in the cutover; recommending them hands the user
         // a broken command (regression guard for that dead-verb drift).
-        assert!(fix.contains("airc join"), "fix must point at the regenerate step: {fix}");
+        assert!(
+            fix.contains("airc join"),
+            "fix must point at the regenerate step: {fix}"
+        );
         assert!(fix.contains("rm "), "fix must name the wipe step: {fix}");
-        assert!(!fix.contains("teardown"), "must not recommend the removed teardown verb: {fix}");
+        assert!(
+            !fix.contains("teardown"),
+            "must not recommend the removed teardown verb: {fix}"
+        );
     }
 
     #[tokio::test]

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -175,7 +175,7 @@ async fn check_identity(home: &Path) -> Vec<Finding> {
             return vec![Finding::blocked(
                 "identity store",
                 format!("can't open events.sqlite: {error}"),
-                "check disk/permissions; if corrupted, `airc teardown --flush` and re-join (loses scope state)",
+                "check disk/permissions; if corrupted, `airc stop` then `rm <home>/events.sqlite` and `airc join` to rebuild (loses scope state)",
             )];
         }
     };
@@ -212,12 +212,12 @@ async fn check_identity(home: &Path) -> Vec<Finding> {
         (true, false, false) => vec![Finding::blocked(
             "identity",
             "key present but no ORM row and no legacy json — orphan key, no recovery without backup",
-            "`airc teardown --flush` to wipe (loses peer_id), then `airc join` to regenerate",
+            "`airc stop` then `rm <home>/identity.key` (loses peer_id), then `airc join` to regenerate",
         )],
         (false, true, _) => vec![Finding::blocked(
             "identity",
             "ORM row present but key file missing — can't sign without the secret",
-            "restore <home>/identity.key from backup, OR `airc teardown --flush` and re-join (loses peer_id)",
+            "restore <home>/identity.key from backup, OR `airc stop` + `rm -rf <home>` then `airc join` (loses peer_id)",
         )],
     }
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,7 +7,7 @@
 # Via the verb:    airc uninstall            (preferred; just exec's this script)
 #
 # What it removes:
-#   - running airc processes (via airc teardown --all, if airc is on PATH)
+#   - the running airc daemon (via airc stop, if airc is on PATH)
 #   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
 #   - stale POSIX forwarders and Windows shim files under $BIN_DIR
 #   - airc-owned skill directories under ~/.claude/skills/ and ~/.codex/skills/
@@ -62,7 +62,7 @@ This will remove airc from this machine:
   skill dirs        $SKILLS_TARGET/<airc-skills>/ + ~/.codex/skills/<airc-skills>/ (if Codex installed)
   install dir       $CLONE_DIR
   daemon            launchd / systemd-user / Task Scheduler unit (if installed)
-  running processes airc teardown --all (if airc is on PATH)
+  running daemon    airc stop (if airc is on PATH)
 
 It will NOT remove:
   per-project .airc/ state in every dir you ran 'airc join' from
@@ -84,11 +84,12 @@ if [ "$ASSUME_YES" != "1" ]; then
   fi
 fi
 
-# 1. Stop running processes. airc teardown --all walks every airc.pid file
-# under $HOME and reaps the processes; idempotent if nothing is running.
+# 1. Stop the running daemon. `airc stop` asks the default-home daemon to
+# shut down gracefully (removes its daemon.pid on exit); idempotent — a
+# no-op exit is consumed by the `if`, so it never aborts the uninstall.
 if command -v airc >/dev/null 2>&1; then
-  if airc teardown --all >/dev/null 2>&1; then
-    ok "Stopped running airc processes (airc teardown --all)"
+  if airc stop >/dev/null 2>&1; then
+    ok "Stopped the running airc daemon (airc stop)"
   fi
   # 2. Uninstall daemon. No-op if not installed; we don't gate on a status
   # check because `airc daemon uninstall` already handles the absent case.


### PR DESCRIPTION
## What

The clean-install smoke (`ci.yml`, linux + macos) ran `airc connect --no-room --no-gist` and `airc teardown` — **legacy Python-era verbs removed in the rust rewrite**. clap rejects `connect` with *"unrecognized subcommand"*, so **clean-install failed on every PR** and nobody got a real fresh-install smoke signal. (Commit 1884603 reconciled the skills/docs to the rewrite surface but missed the CI script and shipped code.)

## Mapping (verified against the CLI)

| Legacy | Real verb | Evidence |
|---|---|---|
| `airc connect --no-room --no-gist` | `airc daemon` | foreground host loop; writes `<home>/daemon.pid` via `PidFileGuard` (`server.rs:291`), removed on Drop |
| `airc teardown` | `airc stop` | graceful shutdown; daemon removes `daemon.pid` |
| pidfile `airc.pid` | `daemon.pid` | the daemon's actual pidfile |
| `--no-gist` (offline) | `AIRC_DISABLE_ACCOUNT_REGISTRY=1` | hermetic gate blocking the gh/gist transport, so the daemon never reaches for gh on an unauthenticated runner |

`--no-room` / `--no-gist` / `--flush` flags don't exist in the rewrite.

## Validation

Built `airc-cli` in a Linux container (the unix path the Windows dev host can't run) and ran the smoke logic directly:

```
=== airc daemon (background) ===
daemon.pid: 8998
PID 8998 alive
=== airc stop ===
daemon: stop requested.
RESULT: PASS — daemon wrote daemon.pid, stop removed it
```

## Also: shipped-code drift (handed users broken recovery commands)

- **`doctor.rs`** — 3 fix-hints recommended `airc teardown --flush` (no flush verb exists). Replaced with the real `airc stop` + `rm <home>/<file>` + `airc join` idiom already used elsewhere in `doctor`.
- **`uninstall.sh`** — `airc teardown --all` (verb *and* flag both nonexistent) → best-effort `airc stop`.

Remaining `teardown` mentions are in historical migration docs / integration READMEs (non-executable, lower priority) — left for a docs sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)