### PR TITLE
fix(install.ps1): run git-hook composer from a temp file, not bash -c (fixes stock-Windows install)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -471,7 +471,22 @@ for phase in pre-commit pre-push; do
   echo "  + Git hook installed: $phase"
 done
 '@
-        & $bashExe --noprofile --norc -c $composer 'airc-githooks' $cloneForBash 2>&1 | ForEach-Object { Write-Host "  $_" }
+        # PS 5.1's native-arg passing shreds a multi-line string handed to
+        # `bash -c` (embedded newlines / `()` get mangled, so bash receives
+        # a truncated script → "unexpected EOF while looking for matching
+        # `)'"), which broke fresh installs on STOCK Windows (PowerShell 5.1
+        # is the default shell). PS 7 tolerated the -c form; 5.1 does not.
+        # Robust path: write the composer to a temp .sh (LF endings, no BOM)
+        # and run the FILE — the only argument bash gets is a clean path,
+        # which PS quotes correctly. `$1` is the clone dir (no $0 placeholder
+        # needed in file form: bash sets $0=<file>, $1=<first arg>).
+        $composerFile = Join-Path $env:TEMP ("airc-githooks-{0}.sh" -f ([System.Guid]::NewGuid().ToString('N')))
+        [System.IO.File]::WriteAllText($composerFile, ($composer -replace "`r`n", "`n"), (New-Object System.Text.UTF8Encoding($false)))
+        try {
+            & $bashExe --noprofile --norc $composerFile $cloneForBash 2>&1 | ForEach-Object { Write-Host "  $_" }
+        } finally {
+            Remove-Item -Force $composerFile -ErrorAction SilentlyContinue
+        }
         Write-Ok 'Git fetch-before-commit/push staleness guard wired'
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -502,35 +502,47 @@ done
 $ghAvail  = Get-Command gh  -ErrorAction SilentlyContinue
 $gitAvail = Get-Command git -ErrorAction SilentlyContinue
 if ($ghAvail -and $gitAvail) {
-    & gh auth status 2>$null | Out-Null
-    if ($LASTEXITCODE -eq 0) {
-        $ghHelper = & git config --global --get-all credential.https://github.com.helper 2>$null
-        # Join to a scalar before -notmatch: --get-all can return multiple
-        # helper values (array), and PS -notmatch on an array filters rather
-        # than returning a strict boolean. Scalar form is correct.
-        if ((@($ghHelper) -join "`n") -notmatch 'gh auth git-credential') {
-            & gh auth setup-git 2>$null
-            if ($LASTEXITCODE -eq 0) { Write-Ok 'gh token wired into git credential helper' }
+    # PS 5.1 converts a native command's REDIRECTED stderr into a terminating
+    # NativeCommandError under $ErrorActionPreference='Stop' (PS 7 does not).
+    # gh/git here legitimately write to stderr on a fresh box — `gh auth
+    # status` with no login prints "You are not logged in" — which we already
+    # handle via $LASTEXITCODE. Relax EAP for this probe block so those benign
+    # stderr lines don't abort the whole install (the ps5 clean-install bug).
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    try {
+        & gh auth status 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            $ghHelper = & git config --global --get-all credential.https://github.com.helper 2>$null
+            # Join to a scalar before -notmatch: --get-all can return multiple
+            # helper values (array), and PS -notmatch on an array filters rather
+            # than returning a strict boolean. Scalar form is correct.
+            if ((@($ghHelper) -join "`n") -notmatch 'gh auth git-credential') {
+                & gh auth setup-git 2>$null
+                if ($LASTEXITCODE -eq 0) { Write-Ok 'gh token wired into git credential helper' }
+            }
+            $gitName  = (& git config --global user.name)  2>$null
+            $gitEmail = (& git config --global user.email) 2>$null
+            if (-not $gitName -or -not $gitEmail) {
+                $ghLogin = (& gh api user --jq '.login') 2>$null
+                $ghName  = (& gh api user --jq '.name // .login') 2>$null
+                $ghId    = (& gh api user --jq '.id') 2>$null
+                $ghEmail = (& gh api user --jq '.email // empty') 2>$null
+                if (-not $ghEmail -and $ghId -and $ghLogin) {
+                    $ghEmail = "$ghId+$ghLogin@users.noreply.github.com"
+                }
+                if (-not $gitName -and $ghName) {
+                    & git config --global user.name $ghName
+                    Write-Ok "git user.name set from gh: $ghName"
+                }
+                if (-not $gitEmail -and $ghEmail) {
+                    & git config --global user.email $ghEmail
+                    Write-Ok "git user.email set from gh: $ghEmail"
+                }
+            }
         }
-        $gitName  = (& git config --global user.name)  2>$null
-        $gitEmail = (& git config --global user.email) 2>$null
-        if (-not $gitName -or -not $gitEmail) {
-            $ghLogin = (& gh api user --jq '.login') 2>$null
-            $ghName  = (& gh api user --jq '.name // .login') 2>$null
-            $ghId    = (& gh api user --jq '.id') 2>$null
-            $ghEmail = (& gh api user --jq '.email // empty') 2>$null
-            if (-not $ghEmail -and $ghId -and $ghLogin) {
-                $ghEmail = "$ghId+$ghLogin@users.noreply.github.com"
-            }
-            if (-not $gitName -and $ghName) {
-                & git config --global user.name $ghName
-                Write-Ok "git user.name set from gh: $ghName"
-            }
-            if (-not $gitEmail -and $ghEmail) {
-                & git config --global user.email $ghEmail
-                Write-Ok "git user.email set from gh: $ghEmail"
-            }
-        }
+    } finally {
+        $ErrorActionPreference = $prevEAP
     }
 }
 


### PR DESCRIPTION
## What

`clean-install-windows-ps5` failed on **every PR**. Under **Windows PowerShell 5.1 — the stock default shell on Windows** — `install.ps1:474` did:

```powershell
& $bashExe --noprofile --norc -c $composer 'airc-githooks' $cloneForBash
```

PS 5.1's native-argument passing shreds the multi-line `$composer` string (embedded newlines and `()` get mangled), so bash receives a **truncated** script and dies:

```
-C: -c: line 6: unexpected EOF while looking for matching `)'
```

PowerShell 7 tolerated the `-c` form, which is why only the ps5 lane broke. This meant fresh installs were broken on the most common Windows config.

## Root cause, reproduced locally (PS 5.1.26100)

```
=== via -c (current install.ps1 path) ===
  hi: -c: line 4: unexpected EOF while looking for matching `)'   # bash $0 mangled to a script fragment
=== via temp file (the fix) ===
  abs /tmp/x
  done /tmp/x
exitcode=0
```

## Fix

Write `$composer` to `$env:TEMP\airc-githooks-<guid>.sh` (LF endings, no BOM) and run the **file** — the only argument bash gets is a clean path, which PS quotes correctly. Clean up in `finally`. In file form bash sets `$0=<file>`, `$1=<first arg>`, so the old `'airc-githooks'` `$0`-placeholder arg is dropped and `$1` stays the clone dir (unchanged contract).

## Validation (all under PS 5.1, locally)

- The **real** composer (`printf %q`, `$$`, `case` globs, nested quotes) run via the temp file against a throwaway git repo → **exit 0**, installs `pre-commit` + `pre-push` with the `AIRC-FETCH-HOOK` marker.
- `install.ps1` **parses clean** under PS 5.1.
- It was the only `bash -c <multiline>` call in either PS script (`bootstrap-airc.ps1`'s here-string just pipes to `Write-Host`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)