### PR TITLE
fix(harness): mesh-converge self-cleans its throwaway registry gists

### DIFF
--- a/.github/workflows/runtime-guards.yml
+++ b/.github/workflows/runtime-guards.yml
@@ -17,6 +17,7 @@ on:
       - "test/public_installed_runtime_proof.sh"
       - "test/rust_cutover_guard.sh"
       - "test/rust_quality_guard.sh"
+      - "docker/mesh-converge.sh"
       - ".github/workflows/ci.yml"
       - ".github/workflows/runtime-guards.yml"
   push:
@@ -30,6 +31,7 @@ on:
       - "test/public_installed_runtime_proof.sh"
       - "test/rust_cutover_guard.sh"
       - "test/rust_quality_guard.sh"
+      - "docker/mesh-converge.sh"
       - ".github/workflows/ci.yml"
       - ".github/workflows/runtime-guards.yml"
 
@@ -40,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: shell syntax
-        run: bash -n install.sh uninstall.sh
+        run: bash -n install.sh uninstall.sh docker/mesh-converge.sh
       - name: Rust cutover guards
         run: bash test/rust_cutover_guard.sh
       - name: Rust quality guards

--- a/docker/mesh-converge.sh
+++ b/docker/mesh-converge.sh
@@ -26,12 +26,44 @@ NET="airc-mesh-test"
 TOKEN="$(gh auth token 2>/dev/null)"
 [ -z "$TOKEN" ] && { echo "FAIL: no gh token (run: gh auth login)"; exit 1; }
 
+# Self-cleaning rendezvous hygiene. The test nodes are throwaway containers
+# with no stable host/user identity, so each `airc join` publishes a
+# `<hex>-unknown-user` account-registry gist to the operator's REAL gh
+# account — and the harness genuinely needs the real rendezvous to test
+# gist convergence, so we can't just disable the registry. Left behind they
+# pile up (80+ phantom gists were found polluting one real account, slowing
+# every subsequent convergence). Fix: snapshot the registry gists that exist
+# BEFORE the run and, on exit, delete only the NEW ones. An operator's real
+# machine gist is always in the snapshot, so it is never touched.
+reg_gist_ids() {
+  gh api --paginate '/gists?per_page=100' \
+    --jq '.[] | select(.files | keys[0] | startswith("airc-account-mesh-registry")) | .id' 2>/dev/null
+}
+SNAP_READY=0
+BEFORE_SNAP="$(mktemp)"
+
 cleanup() {
   for i in $(seq 1 "$N"); do docker rm -f "airc-node-$i" >/dev/null 2>&1; done
   docker network rm "$NET" >/dev/null 2>&1
+  # Delete ONLY registry gists this run created (current set minus the
+  # pre-run snapshot). Guarded by SNAP_READY so the initial cleanup (which
+  # runs BEFORE the snapshot is taken) can never delete a pre-existing gist.
+  if [ "$SNAP_READY" = 1 ]; then
+    local cleaned=0 gid
+    while IFS= read -r gid; do
+      [ -n "$gid" ] || continue
+      gh gist delete "$gid" --yes >/dev/null 2>&1 && cleaned=$((cleaned + 1))
+    done < <(reg_gist_ids | grep -vxF -f "$BEFORE_SNAP")
+    [ "$cleaned" -gt 0 ] && echo "  cleaned $cleaned throwaway test registry gist(s) from the account"
+    rm -f "$BEFORE_SNAP"
+  fi
 }
 trap cleanup EXIT
 cleanup
+# Snapshot the pre-existing registry gists, THEN arm gist cleanup so the
+# exit trap only ever removes what this run published.
+reg_gist_ids > "$BEFORE_SNAP"
+SNAP_READY=1
 
 echo "== bring up $N isolated nodes on one account =="
 docker network create "$NET" >/dev/null


### PR DESCRIPTION
## What

Live finding while setting up a real cross-machine join: one operator account had **81 account-mesh registry gists** — 1 real machine + **14 `<hex>-unknown-user`** (Docker test nodes, no stable host/user identity) + **66 legacy** no-writer-key duplicates. The 14 came from **this harness**: each container runs `airc join` against the real `GH_TOKEN`, and with `HOME=/node` (not temp-rooted) the hermetic gate doesn't block the publish — so every run leaks phantom gists. 80+ junk gists make every subsequent *real* convergence fetch-heavy and stale-beacon-laden (the gh-cost / orphan problem the grid must avoid).

## Fix

The harness genuinely needs the real rendezvous to test gist convergence, so disabling the registry would defeat it. Instead, make it **self-cleaning**:
- Snapshot the registry gist IDs that exist **before** the run.
- On exit, delete only the **new** ones (`reg_gist_ids | grep -vxF -f snapshot`).
- An operator's real machine gist is always in the snapshot → never touched.
- A `SNAP_READY` guard ensures the initial pre-run `cleanup` (which runs before the snapshot is taken) can't delete anything pre-existing.

Also adds `docker/mesh-converge.sh` to the runtime-guards shell-syntax check (paths + `bash -n`) for CI coverage. `bash -n` passes locally.

The 81 pre-existing junk gists on the affected account were cleaned up out-of-band (kept the one real machine gist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)