### PR TITLE
docs: replace dead airc teardown/--flush verbs with real airc stop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ proceed. Atomic claim is the only arbiter; everything else is open.
 The agent stops only when:
 
 1. **Genuine completion** — the recipe / parent card is done.
-2. **Teardown** — `airc teardown`, session end, explicit instruction
+2. **Stop** — `airc stop`, session end, explicit instruction
    to stop.
 
 Things that are **not** stopping conditions:

--- a/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
+++ b/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
@@ -116,7 +116,7 @@ two fresh project scopes run public airc join
 both scopes subscribe #general and their inferred project channel
 both scopes derive the same identity-namespaced #general RoomId
 both scopes use the same account-home #general wire
-airc teardown cleans the scope processes
+airc stop cleans the scope processes
 ```
 
 For AI agents specifically, a passing install is not enough. Claude must be

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -37,13 +37,13 @@ airc daemon install       # via Bash; launchd (mac) / systemd-user (linux)
 | `/doctor [scenario]` | Environment health check (gh + sshd + ports) + integration suite + auto-fix |
 | `/tests [scenario]` | Pure test runner (alias for the test path of /doctor) |
 | `/teardown [--flush]` | Kill THIS scope's airc processes (add `--flush` to also wipe state) |
-| `/repair [invite]` | **Nuclear re-pair** — `teardown --flush` + reconnect. Use when sends mysteriously don't reach anyone. |
+| `/repair [invite]` | **Re-pair** — `airc stop` then re-join. Use when sends mysteriously don't reach anyone. |
 | `/status [--probe]` | Liveness view: monitor, queue, last send/recv, `--probe` does a fast auth check |
 | `/canary` | Switch to canary release channel (opt-in pre-merge testing) |
 
 ## Common failure + fix
 
-If your mesh mysteriously goes quiet (no messages from peers, your sends seem to succeed but nobody responds), 90% of the time the cause is stale auth or port collision with another host on the same machine. Run `/repair` (optionally with a fresh invite string from the host). Don't iterate through `/teardown` + `/connect` — that sequence without `--flush` is specifically the path that silently leaves you broken.
+If your mesh mysteriously goes quiet (no messages from peers, your sends seem to succeed but nobody responds), 90% of the time the cause is stale auth or port collision with another host on the same machine. Run `/repair` (optionally with a fresh invite string from the host) — it stops this scope's daemon and re-joins cleanly. Don't hand-iterate stop/join yourself.
 
 ## Manual Bash usage
 
@@ -56,4 +56,4 @@ Bash("airc msg @peerName 'message here'")
 
 ## Scope isolation
 
-Multiple Claude tabs can each run `/connect` in different `AIRC_HOME` dirs — `airc teardown` only kills its own scope's processes. Validated by `/doctor`.
+Multiple Claude tabs can each run `/join` in different `AIRC_HOME` dirs — `airc stop` only kills its own scope's daemon. Validated by `/doctor`.

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -37,7 +37,7 @@ gh account).
 
 Error handling:
 - Every send is mirrored locally first — never silent loss.
-- "Authentication failure" → run `airc teardown --flush && airc join <gist-id>`.
+- "Authentication failure" → run `airc stop && airc join <gist-id>`.
 - "Queued for retry" → host transient; monitor drains when it returns.
 - Host died (laptop sleep without daemon, etc.) → next `airc join` cold takes
   over hosting #general. Existing peers' monitors auto-recover after ~9 min.

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -37,7 +37,7 @@ gh account).
 
 Error classes (read stderr):
 - "Authentication failure — re-pair required" → exit 1. Run
-  `airc teardown --flush && airc join <gist-id>`. Don't retry.
+  `airc stop && airc join <gist-id>`. Don't retry.
 - "Network error reaching host — message queued for retry" → exit 0.
   Queued in pending.jsonl; monitor's flush loop drains on reconnect.
 - "Pending queue at cap" → exit 1. Host gone too long; re-pair or bump

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -36,7 +36,7 @@ gh account). CLI surface:
   airc part                      leave current room
 
 If a send fails, read stderr. Auth failures need re-pair
-(`airc teardown --flush && airc join <gist-id>`); network failures
+(`airc stop && airc join <gist-id>`); network failures
 queue automatically. If the host died (sleep without daemon), the next
 `airc join` cold takes over #general; existing peers self-recover
 after ~9 min. Wrong-host suspicion: check `airc peers` + `airc list`.


### PR DESCRIPTION
Follow-up to #1178 (executable refs in ci.yml/doctor.rs/uninstall.sh). Cleans the remaining **user/agent-facing docs** that still tell readers to run `airc teardown` / `airc teardown --flush` — legacy Python-era verbs removed in the rust rewrite. Mirrors the already-reconciled skills: graceful shutdown is `airc stop`; recovery is `airc stop` then re-join (no state-wipe verb exists).

**Fixed:** `AGENTS.md`, `integrations/{claude-code,cursor,opencode,windsurf}/README.md`, `docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md`.

**Deliberately left:** `README.md:335` (a *correct* "these don't exist" dead-command list); `docs/PHASE-3.5-MIGRATION.md` (point-in-time migration doc, part of the broader docs-consolidation backlog).

Docs-only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)