### PR TITLE
feat(registry): airc registry gc — prune junk gists, cut per-convergence gh cost

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -447,6 +447,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             registry_cli::RegistryAction::Sync { allow_endpointless } => {
                 registry_commands::run_sync(&home, allow_endpointless).await
             }
+            registry_cli::RegistryAction::Gc { apply } => {
+                registry_commands::run_gc(&home, apply).await
+            }
         },
 
         Command::Transport(args) => match args.action {

--- a/crates/airc-cli/src/registry_cli.rs
+++ b/crates/airc-cli/src/registry_cli.rs
@@ -29,4 +29,22 @@ pub enum RegistryAction {
         #[arg(long)]
         allow_endpointless: bool,
     },
+
+    /// Garbage-collect junk registry gists on this account so a
+    /// converging reader fetches one gist per real machine, not a swamp
+    /// of identity-less / legacy duplicates (each extra gist is a
+    /// per-tick gh fetch).
+    ///
+    /// Deletes only the PROVABLY-junk: `<hex>-unknown-user` gists
+    /// (identity-less CI / container publishers) and legacy
+    /// pre-writer-key `airc-account-mesh-registry.json` duplicates. A
+    /// real machine's `<host>-<user>` gist is never touched.
+    ///
+    /// Dry-run by default — prints the plan. Pass `--apply` to delete.
+    Gc {
+        /// Actually delete the junk gists. Without this flag, gc only
+        /// prints what it WOULD delete (dry run).
+        #[arg(long)]
+        apply: bool,
+    },
 }

--- a/crates/airc-cli/src/registry_commands.rs
+++ b/crates/airc-cli/src/registry_commands.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 
 use airc_ipc::{DaemonClient, IpcRouteEndpoint};
 use airc_lib::{
-    machine_account_home, Airc, GateBlock, GhAccountRegistryStore, RegistryRefreshGate,
+    machine_account_home, Airc, GateBlock, GcAction, GhAccountRegistryStore, RegistryRefreshGate,
     RouteEndpoint, SyncOutcome,
 };
 use airc_store::SqliteEventStore;
@@ -145,7 +145,7 @@ pub async fn run_sync(
     // Gate FIRST (hermetic, then gh-auth): a blocked scope must hear
     // the gate's reason, not an endpoint refusal it can't act on.
     if let Some(block) = gate.block().await {
-        print_gate_skip(&block);
+        print_gate_skip("sync", &block);
         return Ok(());
     }
 
@@ -183,29 +183,81 @@ pub async fn run_sync(
         }
         // The gate re-checks inside sync_once; if it flipped between
         // our check and the tick, surface the reason the same way.
-        SyncOutcome::Skipped(block) => print_gate_skip(&block),
+        SyncOutcome::Skipped(block) => print_gate_skip("sync", &block),
     }
     Ok(())
 }
 
-fn print_gate_skip(block: &GateBlock) {
+fn print_gate_skip(verb: &str, block: &GateBlock) {
     match block {
         // HERMETIC GATE (card d793c242): this scope must not touch the
         // gh account rendezvous — say exactly why, loudly. The manual
         // verb honors the same gate as the daemon loop; there is no
         // CLI path around it (the gh store enforces it again inside).
         GateBlock::Hermetic(reason) => {
-            println!("registry sync REFUSED (hermetic gate): {reason}");
+            println!("registry {verb} REFUSED (hermetic gate): {reason}");
         }
         GateBlock::GhNotReady => {
             println!(
-                "registry sync skipped: `gh` is not authenticated. The account-mesh \
+                "registry {verb} skipped: `gh` is not authenticated. The account-mesh \
                  rendezvous is the same-account gist transport — sign in with `gh auth \
                  login` to enable zero-touch cross-machine discovery. (This is optional, \
                  like every airc transport; LAN/relay/Reticulum paths are unaffected.)"
             );
         }
     }
+}
+
+/// `airc registry gc` — prune junk registry gists on this account.
+/// Dry-run by default; `--apply` deletes. Cuts the per-convergence gh
+/// fetch cost back down to one gist per real machine.
+pub async fn run_gc(home: &Path, apply: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let db_path = machine_account_home(home).join("events.sqlite");
+    let event_store = Arc::new(SqliteEventStore::open_path(&db_path).await?);
+    let store = GhAccountRegistryStore::new(event_store, home);
+    let gate = RegistryRefreshGate::GhAuth {
+        gh_bin: crate::commands::gh_bin_override(),
+        scope_home: home.to_path_buf(),
+        token_override: None,
+    };
+    if let Some(block) = gate.block().await {
+        print_gate_skip("gc", &block);
+        return Ok(());
+    }
+
+    let report = store.gc(apply).await?;
+    for verdict in &report.verdicts {
+        let tag = match verdict.action {
+            GcAction::Delete => "DELETE",
+            GcAction::Keep => "keep  ",
+        };
+        let short = &verdict.id[..verdict.id.len().min(8)];
+        println!("  {tag}  {short}  {} — {}", verdict.filename, verdict.reason);
+    }
+    if report.applied {
+        println!(
+            "registry gc: deleted {} junk gist(s), kept {} real gist(s).",
+            report.deleted, report.kept
+        );
+        if report.deleted < report.to_delete {
+            println!(
+                "  ({} delete(s) failed — see errors above; re-run to retry.)",
+                report.to_delete - report.deleted
+            );
+        }
+    } else if report.to_delete == 0 {
+        println!(
+            "registry gc: clean — {} real gist(s), nothing to delete.",
+            report.kept
+        );
+    } else {
+        println!(
+            "registry gc (dry run): would delete {} junk gist(s), keep {} real gist(s). \
+             Re-run with --apply to delete.",
+            report.to_delete, report.kept
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/airc-cli/src/registry_commands.rs
+++ b/crates/airc-cli/src/registry_commands.rs
@@ -232,7 +232,10 @@ pub async fn run_gc(home: &Path, apply: bool) -> Result<(), Box<dyn std::error::
             GcAction::Keep => "keep  ",
         };
         let short = &verdict.id[..verdict.id.len().min(8)];
-        println!("  {tag}  {short}  {} — {}", verdict.filename, verdict.reason);
+        println!(
+            "  {tag}  {short}  {} — {}",
+            verdict.filename, verdict.reason
+        );
     }
     if report.applied {
         println!(

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -700,7 +700,10 @@ impl GhAccountRegistryStore {
     /// Delete one gist by id via `gh api --method DELETE /gists/<id>`.
     async fn delete_gist(&self, id: &str) -> Result<(), AccountRegistryError> {
         let (ok, _stdout, stderr) = self
-            .gh_run(&["api", "--method", "DELETE", &format!("/gists/{id}")], None)
+            .gh_run(
+                &["api", "--method", "DELETE", &format!("/gists/{id}")],
+                None,
+            )
             .await?;
         if ok {
             Ok(())
@@ -1158,9 +1161,18 @@ mod tests {
     #[test]
     fn classify_registry_gc_deletes_only_provable_junk() {
         let gists = vec![
-            ("real".to_string(), "airc-account-mesh-registry.bigmama-joelt.json".to_string()),
-            ("ci".to_string(), "airc-account-mesh-registry.05c0fc93ce40-unknown-user.json".to_string()),
-            ("legacy".to_string(), "airc-account-mesh-registry.json".to_string()),
+            (
+                "real".to_string(),
+                "airc-account-mesh-registry.bigmama-joelt.json".to_string(),
+            ),
+            (
+                "ci".to_string(),
+                "airc-account-mesh-registry.05c0fc93ce40-unknown-user.json".to_string(),
+            ),
+            (
+                "legacy".to_string(),
+                "airc-account-mesh-registry.json".to_string(),
+            ),
             ("weird".to_string(), "something-else.json".to_string()),
         ];
         let verdicts = classify_registry_gc(&gists);
@@ -1174,13 +1186,20 @@ mod tests {
         };
         assert_eq!(action_of("real"), GcAction::Keep, "real machine gist kept");
         assert_eq!(action_of("ci"), GcAction::Delete, "unknown-user is junk");
-        assert_eq!(action_of("legacy"), GcAction::Delete, "legacy unnamed is junk");
+        assert_eq!(
+            action_of("legacy"),
+            GcAction::Delete,
+            "legacy unnamed is junk"
+        );
         assert_eq!(
             action_of("weird"),
             GcAction::Keep,
             "unrecognized filename must NOT be deleted"
         );
-        let to_delete = verdicts.iter().filter(|v| v.action == GcAction::Delete).count();
+        let to_delete = verdicts
+            .iter()
+            .filter(|v| v.action == GcAction::Delete)
+            .count();
         assert_eq!(to_delete, 2);
     }
 

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -186,6 +186,114 @@ pub fn writer_filename() -> String {
     format!("airc-account-mesh-registry.{}.json", writer_key())
 }
 
+/// What [`classify_registry_gc`] decided for one own-account gist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GcAction {
+    /// A real machine's gist (or an unrecognized file) — never deleted.
+    Keep,
+    /// Provable junk — safe to delete.
+    Delete,
+}
+
+/// One gist's gc verdict: id + filename + action + a human-readable reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcVerdict {
+    pub id: String,
+    pub filename: String,
+    pub action: GcAction,
+    pub reason: String,
+}
+
+/// Outcome of [`GhAccountRegistryStore::gc`]: every gist's verdict plus
+/// counts. `deleted` is what was actually removed (0 in a dry run);
+/// `applied` says whether deletions were performed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcReport {
+    pub verdicts: Vec<GcVerdict>,
+    pub kept: usize,
+    /// Number marked for deletion (the plan size, dry-run or not).
+    pub to_delete: usize,
+    /// Number actually deleted (== to_delete on a clean apply, 0 on dry run).
+    pub deleted: usize,
+    pub applied: bool,
+}
+
+/// Shape of a registry gist's first filename.
+enum RegistryFilename {
+    /// Legacy `airc-account-mesh-registry.json` (pre-writer-key).
+    Legacy,
+    /// `airc-account-mesh-registry.<key>.json` — `<key>` is `<host>-<user>`.
+    Keyed(String),
+    /// Anything else — not a recognized registry filename.
+    Other,
+}
+
+fn parse_registry_filename(filename: &str) -> RegistryFilename {
+    if filename == "airc-account-mesh-registry.json" {
+        return RegistryFilename::Legacy;
+    }
+    if let Some(stem) = filename.strip_suffix(".json") {
+        if let Some(key) = stem.strip_prefix("airc-account-mesh-registry.") {
+            if !key.is_empty() {
+                return RegistryFilename::Keyed(key.to_string());
+            }
+        }
+    }
+    RegistryFilename::Other
+}
+
+/// Pure, reader-side classification of own-account registry gists into
+/// keep vs delete. The conservative v1 policy deletes only the two
+/// PROVABLY-junk categories and keeps every real machine's gist:
+///
+/// - `airc-account-mesh-registry.<hex>-unknown-user.json` — an
+///   identity-less publisher (a CI runner or throwaway container with
+///   no resolvable host/user; cf the mesh-converge harness). A real
+///   desktop resolves a `<host>-<user>` key, so an `unknown-user` gist
+///   is never a real machine.
+/// - `airc-account-mesh-registry.json` — a LEGACY, pre-writer-key gist.
+///   The find-or-update scheme (card d793c242) keys gists by machine,
+///   so these unnamed ones are superseded duplicates; any live machine
+///   republishes under its `<host>-<user>` filename.
+/// - `airc-account-mesh-registry.<host>-<user>.json` — a real machine's
+///   gist. KEPT. (Deduping multiple gists for the SAME real key, and
+///   pruning gists whose beacons are all stale, are future opt-in
+///   passes — v1 never touches a real writer-keyed gist.)
+/// - anything unrecognized — KEPT (never delete a file we don't model).
+///
+/// Filename-only and side-effect-free, so the policy is unit-testable
+/// and mutation-verifiable without any gh I/O.
+pub fn classify_registry_gc(gists: &[(String, String)]) -> Vec<GcVerdict> {
+    gists
+        .iter()
+        .map(|(id, filename)| {
+            let (action, reason) = match parse_registry_filename(filename) {
+                RegistryFilename::Legacy => (
+                    GcAction::Delete,
+                    "legacy pre-writer-key gist (superseded duplicate)".to_string(),
+                ),
+                RegistryFilename::Keyed(key) if key.ends_with("-unknown-user") => (
+                    GcAction::Delete,
+                    format!("identity-less publisher ({key}) — never a real machine"),
+                ),
+                RegistryFilename::Keyed(key) => {
+                    (GcAction::Keep, format!("real machine gist ({key})"))
+                }
+                RegistryFilename::Other => (
+                    GcAction::Keep,
+                    "unrecognized filename — left untouched".to_string(),
+                ),
+            };
+            GcVerdict {
+                id: id.clone(),
+                filename: filename.clone(),
+                action,
+                reason,
+            }
+        })
+        .collect()
+}
+
 fn first_nonempty_env(names: &[&str]) -> Option<String> {
     names
         .iter()
@@ -530,6 +638,61 @@ impl GhAccountRegistryStore {
             return Ok(None);
         }
         Ok(serde_json::from_str(content.trim()).ok())
+    }
+
+    /// Garbage-collect this account's registry gists: delete the
+    /// provably-junk ones ([`classify_registry_gc`]) so a converging
+    /// reader fetches one gist per real machine instead of a swamp of
+    /// identity-less / legacy duplicates (each extra gist is a per-tick
+    /// gh fetch). Dry-run when `apply == false`: classify + report, no
+    /// deletes. Honors the hermetic gate — a hermetic scope must not
+    /// mutate the production rendezvous.
+    pub async fn gc(&self, apply: bool) -> Result<GcReport, AccountRegistryError> {
+        if let Some(block) = account_registry_block(&self.scope_home) {
+            return Err(AccountRegistryError::Adapter(format!(
+                "HERMETIC GATE: refusing account-registry gc — {block}"
+            )));
+        }
+        let entries = self.list_registry_gists().await?;
+        let pairs: Vec<(String, String)> = entries
+            .iter()
+            .map(|e| (e.id.clone(), e.filename.clone()))
+            .collect();
+        let verdicts = classify_registry_gc(&pairs);
+        let kept = verdicts
+            .iter()
+            .filter(|v| v.action == GcAction::Keep)
+            .count();
+        let to_delete = verdicts.len() - kept;
+        let mut deleted = 0usize;
+        if apply {
+            for verdict in verdicts.iter().filter(|v| v.action == GcAction::Delete) {
+                if self.delete_gist(&verdict.id).await.is_ok() {
+                    deleted += 1;
+                }
+            }
+        }
+        Ok(GcReport {
+            verdicts,
+            kept,
+            to_delete,
+            deleted,
+            applied: apply,
+        })
+    }
+
+    /// Delete one gist by id via `gh api --method DELETE /gists/<id>`.
+    async fn delete_gist(&self, id: &str) -> Result<(), AccountRegistryError> {
+        let (ok, _stdout, stderr) = self
+            .gh_run(&["api", "--method", "DELETE", &format!("/gists/{id}")], None)
+            .await?;
+        if ok {
+            Ok(())
+        } else {
+            Err(AccountRegistryError::Adapter(format!(
+                "gh api DELETE /gists/{id} failed: {stderr}"
+            )))
+        }
     }
 
     /// Probe the sentinel-recorded gist: `Found(filename)` when it
@@ -971,6 +1134,40 @@ mod tests {
         assert_eq!(filename, writer_filename());
     }
 
+    // what this catches: registry gc must delete ONLY the two provably-
+    // junk categories (identity-less `unknown-user` publishers + legacy
+    // pre-writer-key duplicates) and never a real machine's gist — the
+    // exact policy that cleaned 80 phantom gists off a real account.
+    // Mutation check: flipping any Keep<->Delete arm fails an assert.
+    #[test]
+    fn classify_registry_gc_deletes_only_provable_junk() {
+        let gists = vec![
+            ("real".to_string(), "airc-account-mesh-registry.bigmama-joelt.json".to_string()),
+            ("ci".to_string(), "airc-account-mesh-registry.05c0fc93ce40-unknown-user.json".to_string()),
+            ("legacy".to_string(), "airc-account-mesh-registry.json".to_string()),
+            ("weird".to_string(), "something-else.json".to_string()),
+        ];
+        let verdicts = classify_registry_gc(&gists);
+        let action_of = |id: &str| {
+            verdicts
+                .iter()
+                .find(|v| v.id == id)
+                .unwrap_or_else(|| panic!("missing verdict for {id}"))
+                .action
+                .clone()
+        };
+        assert_eq!(action_of("real"), GcAction::Keep, "real machine gist kept");
+        assert_eq!(action_of("ci"), GcAction::Delete, "unknown-user is junk");
+        assert_eq!(action_of("legacy"), GcAction::Delete, "legacy unnamed is junk");
+        assert_eq!(
+            action_of("weird"),
+            GcAction::Keep,
+            "unrecognized filename must NOT be deleted"
+        );
+        let to_delete = verdicts.iter().filter(|v| v.action == GcAction::Delete).count();
+        assert_eq!(to_delete, 2);
+    }
+
     // Hermetic gate inputs (env-set arm is pinned by the CLI
     // subprocess tests in crates/airc-cli/tests/registry_hermetic.rs,
     // where the env can be set without racing parallel tests).
@@ -1052,7 +1249,18 @@ case "$1" in
     fi
     ;;
   api)
-    path="$2"
+    # Two arg shapes: `api <path> [--jq expr]` (GET) and
+    # `api --method DELETE <path>` (delete).
+    if [ "$2" = "--method" ] || [ "$2" = "-X" ]; then
+      method="$3"; path="$4"
+    else
+      method="GET"; path="$2"
+    fi
+    if [ "$method" = "DELETE" ]; then
+      id="${path#/gists/}"
+      rm -f "$S/$id.filename" "$S/$id.content"
+      exit 0
+    fi
     if [ "$path" = "/gists?per_page=100" ]; then
       for f in "$S"/*.filename; do
         [ -e "$f" ] || continue
@@ -1193,6 +1401,55 @@ exit 0
             peers: Vec<AccountPeerBeacon>,
         ) -> AccountRegistryDocument {
             AccountRegistryDocument::new(mesh(), generated_at_ms, Vec::new(), peers)
+        }
+
+        // what this catches: `gc` dry-run reports the junk plan without
+        // deleting; `gc --apply` removes ONLY the junk (unknown-user +
+        // legacy) and leaves the real machine gist — the first-class
+        // version of the manual cleanup that cleared 80 phantom gists off
+        // a real account. Mutation check: dropping the apply delete-loop
+        // leaves all 3 gists and `deleted` == 0.
+        #[tokio::test]
+        async fn gc_deletes_only_junk_on_apply_not_dry_run() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+            let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
+
+            stub.seed_gist(
+                "real",
+                "airc-account-mesh-registry.bigmama-joelt.json",
+                &document(1, vec![]),
+            );
+            stub.seed_gist(
+                "ci",
+                "airc-account-mesh-registry.05c0fc93ce40-unknown-user.json",
+                &document(1, vec![]),
+            );
+            stub.seed_gist(
+                "legacy",
+                "airc-account-mesh-registry.json",
+                &document(1, vec![]),
+            );
+
+            // Dry run: plan only, nothing deleted, all 3 still present.
+            let dry = store.gc(false).await.unwrap();
+            assert_eq!(dry.to_delete, 2, "two junk gists planned for deletion");
+            assert_eq!(dry.kept, 1, "the real machine gist is kept");
+            assert_eq!(dry.deleted, 0, "dry run deletes nothing");
+            assert!(!dry.applied);
+            assert_eq!(store.list_registry_gists().await.unwrap().len(), 3);
+
+            // Apply: junk gone, real machine gist survives.
+            let applied = store.gc(true).await.unwrap();
+            assert_eq!(applied.deleted, 2);
+            assert_eq!(applied.kept, 1);
+            assert!(applied.applied);
+            let remaining = store.list_registry_gists().await.unwrap();
+            assert_eq!(remaining.len(), 1, "only the real machine gist remains");
+            assert_eq!(
+                remaining[0].filename,
+                "airc-account-mesh-registry.bigmama-joelt.json"
+            );
         }
 
         // Production-shaped home + env unset → publish goes through

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -658,7 +658,23 @@ impl GhAccountRegistryStore {
             .iter()
             .map(|e| (e.id.clone(), e.filename.clone()))
             .collect();
-        let verdicts = classify_registry_gc(&pairs);
+        // Self-guard: never delete THIS machine's own current gist,
+        // whatever its key shape. The classifier deletes
+        // `*-unknown-user` gists, and a real machine with every identity
+        // env (USER/LOGNAME/USERNAME) unset would publish exactly such a
+        // key — so force-Keep our own writer filename before any delete.
+        let self_filename = writer_filename();
+        let verdicts: Vec<GcVerdict> = classify_registry_gc(&pairs)
+            .into_iter()
+            .map(|mut verdict| {
+                if verdict.action == GcAction::Delete && verdict.filename == self_filename {
+                    verdict.action = GcAction::Keep;
+                    verdict.reason =
+                        "this machine's own current gist (never self-delete)".to_string();
+                }
+                verdict
+            })
+            .collect();
         let kept = verdicts
             .iter()
             .filter(|v| v.action == GcAction::Keep)

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -127,9 +127,10 @@ pub use external_identity::{
     HEADER_BRIDGE_HANDLE, HEADER_BRIDGE_SOURCE,
 };
 pub use gh::account_registry::{
-    account_registry_block, gh_auth_ready, gh_auth_ready_with_token, re_resolve_gh_token,
-    writer_filename, writer_key, AccountRegistryBlock, GhAccountRegistryStore, GhTokenOverride,
-    AIRC_DISABLE_ACCOUNT_REGISTRY_ENV, GH_AUTH_READY_TIMEOUT,
+    account_registry_block, classify_registry_gc, gh_auth_ready, gh_auth_ready_with_token,
+    re_resolve_gh_token, writer_filename, writer_key, AccountRegistryBlock, GcAction, GcReport,
+    GcVerdict, GhAccountRegistryStore, GhTokenOverride, AIRC_DISABLE_ACCOUNT_REGISTRY_ENV,
+    GH_AUTH_READY_TIMEOUT,
 };
 pub use gh::client::{
     parse_pr_url, parse_pr_view, GhCheck, GhClient, GhError, MergeReceipt, PrCreateArgs, PrCreated,


### PR DESCRIPTION
## What

The scale unblock. Per-convergence gh cost is **`1 list + N fetch` calls every 120s**, where N = registry gist count. The real-world N-blowup is gist proliferation: one account had **81 gists** (1 real + 14 `unknown-user` CI/container publishers + 66 legacy duplicates), so every convergence fetched all 81. `airc registry gc` is the first-class **"healing"** prune that takes N back to one gist per real machine — replacing the manual `gh gist delete` sweep with an attributable, **dry-run-by-default** command.

## How

- **`classify_registry_gc`** — pure, filename-only, unit-testable. Deletes ONLY the two provably-junk categories:
  - `airc-account-mesh-registry.<hex>-unknown-user.json` — identity-less publishers (CI / throwaway containers); never a real machine.
  - `airc-account-mesh-registry.json` — legacy pre-writer-key duplicates.
  - A real `<host>-<user>` gist, or any unrecognized filename, is **KEPT**. (Same-key dedup + stale-beacon pruning are deferred opt-in passes; v1 never touches a real writer-keyed gist.)
- **`GhAccountRegistryStore::gc(apply)`** — honors the hermetic gate, lists + classifies, deletes junk only on `apply`, returns `GcReport`.
- **`airc registry gc [--apply]`** — dry-run by default (prints the plan); `--apply` deletes.

## Validation

- Pure classifier unit test (cross-platform, mutation-noted).
- `gh_stub` I/O test: dry-run plans without deleting; apply removes only junk + keeps the real gist (`gh api --method DELETE` handled by the stub).
- **Real dry-run** in a Linux container against the live account → correctly kept both real machines (`bigmama-joelt` + `macbookpro-lan-joel`), reported *"clean — 2 real gist(s), nothing to delete."*
- `clippy -D warnings` clean (all-features, all-targets).

Follow-ups (noted in code): same-key dedup pass, `--stale` pass (prune gists whose beacons are all older than the freshness TTL), and ETag-conditional fetches for the genuinely-many-real-machines case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)