### PR TITLE
test(sibling-scope): investigation pin for intra-machine routing gap (card 326000a5)

### DIFF
--- a/crates/airc-lib/tests/sibling_scope_intra_machine_msg.rs
+++ b/crates/airc-lib/tests/sibling_scope_intra_machine_msg.rs
@@ -1,0 +1,127 @@
+//! Regression baseline + investigation pin: sibling scopes on one machine.
+//!
+//! Card 326000a5. Field repro on canary 80a407b0aaa1 (Intel Mac):
+//!   1. Main scope: `/Users/joel/Development/continuum/.airc`, peer 9bb24964, room #general
+//!   2. Sibling scope: `AIRC_HOME=/tmp/airc-b airc init` + `airc room general`, peer 671e7e28
+//!   3. Cross-enrol via `airc peer add` both directions
+//!   4. Sibling: `airc msg "..."` reports 'sent to general — 1 paired peer(s) + any local scope tailing this channel.'
+//!   5. Main scope's `airc events list --kind message` does NOT contain the message.
+//!
+//! ## What these tests pin
+//!
+//! Both tests below CURRENTLY PASS on canary. That's the investigation pin:
+//! the substrate library delivers correctly through both the shared-mesh-root
+//! convergence path AND through independent wire roots attached to one
+//! daemon, as long as the test wires the scopes to the same `DaemonFixture`
+//! socket directly. So the field-repro bug is NOT in the SDK send/route/
+//! subscribe layer — it lies somewhere in the CLI plumbing that operators
+//! actually hit:
+//!
+//!   - socket-path resolution per cwd / per `AIRC_HOME` (do two `airc`
+//!     invocations from different homes end up at the SAME daemon socket,
+//!     or do they each spin up their own?)
+//!   - `ensure_daemon_running` lifecycle when `AIRC_HOME` overrides
+//!   - `airc events list` reading from a per-home transcript store that the
+//!     sibling's send never landed in, even though the broker fan-out
+//!     succeeded
+//!
+//! Field-symptom diff to look for in the daemon log: scope-b's send fires the
+//! broker, but scope-a is registered against a different daemon process /
+//! different db path, so the fan-out has no peer-local subscriber to deliver
+//! to.
+//!
+//! Treat these tests as the lower-bound proof — when a fix lands for the
+//! CLI-side resolution, an end-to-end CLI test in `airc-cli/tests/` should
+//! pair off these to lock in the fix at both layers.
+
+mod common;
+
+use std::time::Duration;
+
+use airc_lib::Airc;
+use common::{trust, DaemonFixture, Machine};
+use tempfile::TempDir;
+
+/// Baseline: with the shared-mesh-root convergence path (the test fixture's
+/// canonical "two tabs under one $HOME" shape), intra-machine sibling-scope
+/// delivery works. Passes on canary today.
+#[tokio::test]
+async fn shared_mesh_root_two_scopes_deliver() {
+    let machine = Machine::boot().await;
+    let (alice, bob) = machine.pair_in("sibling-scope-routing-shared").await;
+
+    let body = "sibling-scope-routing-326000a5-shared";
+    alice.say(body).await.expect("alice sends");
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let bob_events = bob.page_recent(50).await.expect("bob reads transcript");
+    let found = bob_events.iter().any(|ev| {
+        ev.body
+            .as_ref()
+            .and_then(|b| b.as_text())
+            .map(|t| t.contains(body))
+            .unwrap_or(false)
+    });
+    assert!(
+        found,
+        "shared-mesh-root convergence regressed: bob did not receive alice's message"
+    );
+}
+
+/// Field repro: two scopes whose AIRC_HOME values live OUTSIDE a shared mesh
+/// root (`AIRC_HOME=/tmp/airc-b airc init` next to `~/.airc/`). They each
+/// resolve their own wire root, independent identity keypairs, but attach to
+/// the SAME daemon socket — exactly what happens in production when an
+/// operator runs `AIRC_HOME=/tmp/airc-b airc join` alongside `airc join` in
+/// their main home.
+///
+/// On canary 80a407b0aaa1 the operator observes:
+/// > sent to general (5eedf7b1-...) — 1 paired peer(s) + any local scope
+/// > tailing this channel.
+///
+/// …yet the sibling scope's `page_recent` / `events list` does NOT see the
+/// message. This test reproduces that field gap inside the SDK.
+#[tokio::test]
+async fn independent_wire_roots_two_scopes_share_one_daemon() {
+    let daemon = DaemonFixture::start().await;
+
+    let root_a = TempDir::new().expect("root a");
+    let root_b = TempDir::new().expect("root b");
+    let home_a = root_a.path().join("alice");
+    let home_b = root_b.path().join("bob");
+
+    let alice =
+        Airc::attach_with_wire_root_for_test(home_a, root_a.path().to_path_buf(), &daemon.socket)
+            .await
+            .expect("alice attaches to shared daemon");
+
+    let bob =
+        Airc::attach_with_wire_root_for_test(home_b, root_b.path().to_path_buf(), &daemon.socket)
+            .await
+            .expect("bob attaches to shared daemon");
+
+    trust(&alice, &bob).await;
+
+    let room = "sibling-scope-routing-independent";
+    alice.join(room).await.expect("alice joins");
+    bob.join(room).await.expect("bob joins");
+
+    let body = "sibling-scope-routing-326000a5-independent";
+    alice.say(body).await.expect("alice sends");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let bob_events = bob.page_recent(50).await.expect("bob reads transcript");
+    let found = bob_events.iter().any(|ev| {
+        ev.body
+            .as_ref()
+            .and_then(|b| b.as_text())
+            .map(|t| t.contains(body))
+            .unwrap_or(false)
+    });
+
+    assert!(
+        found,
+        "sibling-scope routing gap (card 326000a5): two scopes with independent wire roots, sharing one daemon socket, mutually trusted, both joined to the SAME room name — bob received {} events; none matched body={body:?}. Field repro: AIRC_HOME=/tmp/airc-b airc msg ... reports 'sent + 1 paired peer' but the main scope's events list never sees it.",
+        bob_events.len()
+    );
+}


### PR DESCRIPTION
## Summary

Investigation pin for card `326000a5` — the sibling-scope intra-machine routing gap surfaced via cross-Claude dogfood-over-airc on the 2026-06-14 canary build (`80a407b0aaa1`).

Two regression-baseline tests prove that the **airc-lib SDK delivers correctly** between sibling scopes attached to one daemon, both with shared mesh root AND with independent wire roots. Both tests pass on canary. That's the investigation pin: the field-repro bug is **not in the SDK layer**, so the search narrows to CLI plumbing.

## Field repro (canary `80a407b0aaa1`, Intel Mac)

1. Main scope: `/Users/joel/Development/continuum/.airc`, peer `9bb24964`, room `#general`
2. Sibling scope: `AIRC_HOME=/tmp/airc-b airc init` + `airc room general`, peer `671e7e28`
3. Cross-enrol via `airc peer add` both directions (daemon reports "in-memory registry updated")
4. Sibling: `airc msg "..."` reports `sent to general (5eedf7b1-...) — 1 paired peer(s) + any local scope tailing this channel.`
5. Main scope's `airc events list --kind message` does **NOT** contain the message.

## Where the bug ISN'T (this PR proves)

The new tests in `crates/airc-lib/tests/sibling_scope_intra_machine_msg.rs`:

- `shared_mesh_root_two_scopes_deliver` — canonical "two tabs under one `$HOME`" via `Machine::pair_in`. **Passes**, baseline.
- `independent_wire_roots_two_scopes_share_one_daemon` — two scopes with independent `TempDir` wire roots attaching to the same `DaemonFixture` socket. **Passes**, narrows the search.

So `Airc::say()` → daemon broker → fan-out → subscriber `page_recent()` all work correctly when wired through the SDK. The bug is somewhere between the operator typing `airc msg` and the SDK call.

## Where the bug LIKELY IS (next pass)

Candidates surfaced by reading `airc-cli/src/commands.rs::run_msg` + the daemon-lifecycle wrappers:

1. **Socket-path resolution per `AIRC_HOME`** — does `default_or(socket, &home)` route both scopes to the same socket? Or does one scope spawn its own daemon thinking the other's socket is dead?
2. **`ensure_daemon_running` lifecycle** under `AIRC_HOME` override — does the second `airc` invocation discover the first scope's daemon, or start a new one?
3. **`airc events list` reading a per-home transcript store** — even if the broker fans out, if scope-a's `airc events list` reads from a per-home SQLite that the sibling's send never landed in (because the daemon wrote to scope-b's home-keyed store), the operator-observable result is the same.

A follow-up `crates/airc-cli/tests/` end-to-end test that drives `airc msg` from two distinct `AIRC_HOME` values and asserts the receiver scope's `events list` sees it would lock in the eventual fix at the operator-facing layer.

## Cross-cutting find (noted, not fixed here)

The pre-commit hook `integrations/git-hooks/airc-fetch-base.sh` carries two bugs that hit me filing this PR:

- It auto-detects `rust-rewrite` as the base on a fresh branch even though `origin/rust-rewrite` is gone post-PR-#1173 promotion (local tracking ref persists).
- Line 167's `$YEL` un-braced variable interpolation crashes under `set -u` on macOS bash 3.2 + multibyte locale (`YEL�: unbound variable`).

Worked around with `AIRC_HOOK_BASE=canary` for this commit. Worth a separate sub-card.

## Test plan

- [x] `cargo test --package airc-lib --test sibling_scope_intra_machine_msg` — both tests pass on canary `80a407b0aaa1`.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -p airc-lib --tests -- -D warnings` clean.
- [ ] Follow-up: end-to-end CLI test in `airc-cli/tests/` once the CLI-plumbing seam is identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
