### PR TITLE
feat(peer): airc peer prune — evict dead trust-store enrolments

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -1280,6 +1280,22 @@ pub enum PeerAction {
         #[arg(long)]
         json: bool,
     },
+    /// Evict DEAD trust-store enrolments — peers that are `untrusted`
+    /// AND absent from the current fresh account registry (e.g. the
+    /// `172.18.0.x` Docker-container ghosts that leak failed dials). The
+    /// peer-store analog of `registry gc`.
+    ///
+    /// NEVER touches trusted peers (a cross-grid Friend publishes to
+    /// THEIR account, so is absent from yours) or live peers. Dry-run by
+    /// default — prints the plan; pass `--apply` to evict. If a fresh
+    /// live set can't be established (gh unauth / unreachable / empty
+    /// registry), it prunes nothing rather than risk a live peer.
+    Prune {
+        /// Actually evict the dead enrolments. Without this flag, prune
+        /// only prints what it WOULD evict (dry run).
+        #[arg(long)]
+        apply: bool,
+    },
 }
 
 /// CLI mirror of `airc_store::TrustTier`. Kept distinct so clap's

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1816,6 +1816,104 @@ pub async fn run_peer_remove(
     Ok(())
 }
 
+/// `peer prune` — evict DEAD trust-store enrolments (the peer-store
+/// analog of `registry gc`). Removes peers that are `Untrusted` AND
+/// absent from the current fresh account registry; trusted peers (incl.
+/// cross-grid Friends) and live peers are never touched. Dry-run by
+/// default; `--apply` performs the eviction with a forensic reason on
+/// the `PeerDeparted` event.
+///
+/// SAFETY: if a trustworthy fresh live-peer set cannot be established (gh
+/// unauthenticated, hermetic scope, unreachable rendezvous, or an empty
+/// registry), this prunes NOTHING — pruning against an unknown/empty live
+/// set would wrongly evict live peers.
+pub async fn run_peer_prune(home: &Path, apply: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let enrolled = airc_trust::load(home).await?;
+    if enrolled.is_empty() {
+        println!("(no enroled peers — nothing to prune)");
+        return Ok(());
+    }
+    let enrolled_pairs: Vec<(airc_core::PeerId, airc_lib::TrustTier)> =
+        enrolled.iter().map(|p| (p.peer_id, p.tier)).collect();
+
+    // Authoritative live set: the fresh, stale-pruned account-registry
+    // document (READ-ONLY — `live_registry_peer_ids` does not enrol).
+    let db_path = airc_lib::machine_account_home(home).join("events.sqlite");
+    let event_store = Arc::new(SqliteEventStore::open_path(&db_path).await?);
+    let store = match resolve_gh_bin() {
+        Some(bin) => {
+            airc_lib::GhAccountRegistryStore::new(event_store, home).with_bin(bin)
+        }
+        None => airc_lib::GhAccountRegistryStore::new(event_store, home),
+    };
+    let airc = Airc::open(home).await?;
+    let live_ids = match airc.live_registry_peer_ids(&store).await {
+        Ok(Some(ids)) if !ids.is_empty() => ids,
+        _ => {
+            println!(
+                "peer prune: could not establish a fresh live-peer set (gh not authenticated, \
+                 hermetic scope, unreachable rendezvous, or empty registry). Pruning NOTHING — \
+                 prune needs a trustworthy live set so it never evicts a live peer. Run `gh auth \
+                 login`, ensure the account rendezvous is reachable, then retry."
+            );
+            return Ok(());
+        }
+    };
+
+    let verdicts = airc_lib::classify_peer_prune(&enrolled_pairs, &live_ids);
+    let mut to_evict = Vec::new();
+    for verdict in &verdicts {
+        match verdict.action {
+            airc_lib::PeerPruneAction::Evict => {
+                println!(
+                    "  EVICT  {}  tier={}  — {}",
+                    verdict.peer_id,
+                    verdict.tier.as_wire_str(),
+                    verdict.reason
+                );
+                to_evict.push(verdict.peer_id);
+            }
+            airc_lib::PeerPruneAction::Keep => {
+                println!(
+                    "  keep   {}  tier={}  — {}",
+                    verdict.peer_id,
+                    verdict.tier.as_wire_str(),
+                    verdict.reason
+                );
+            }
+        }
+    }
+    let kept = verdicts.len() - to_evict.len();
+
+    if !apply {
+        if to_evict.is_empty() {
+            println!("peer prune: clean — {kept} live/trusted peer(s), no dead enrolments.");
+        } else {
+            println!(
+                "peer prune (dry run): would evict {} dead enrolment(s), keep {kept}. \
+                 Re-run with --apply to evict.",
+                to_evict.len()
+            );
+        }
+        return Ok(());
+    }
+
+    let mut evicted = 0usize;
+    for peer_id in &to_evict {
+        if airc
+            .remove_peer(
+                *peer_id,
+                "peer-prune: untrusted + absent from fresh registry",
+            )
+            .await?
+        {
+            evicted += 1;
+        }
+    }
+    println!("peer prune: evicted {evicted} dead enrolment(s), kept {kept}.");
+    Ok(())
+}
+
 /// Card 34942ec1 Sub-C: update an enrolled peer's tier without
 /// touching key material. Refuses for unknown peers (no implicit
 /// add — the operator should `peer add <spec> --tier=…` instead).

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1841,9 +1841,7 @@ pub async fn run_peer_prune(home: &Path, apply: bool) -> Result<(), Box<dyn std:
     let db_path = airc_lib::machine_account_home(home).join("events.sqlite");
     let event_store = Arc::new(SqliteEventStore::open_path(&db_path).await?);
     let store = match resolve_gh_bin() {
-        Some(bin) => {
-            airc_lib::GhAccountRegistryStore::new(event_store, home).with_bin(bin)
-        }
+        Some(bin) => airc_lib::GhAccountRegistryStore::new(event_store, home).with_bin(bin),
         None => airc_lib::GhAccountRegistryStore::new(event_store, home),
     };
     let airc = Airc::open(home).await?;

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -429,6 +429,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     .await
             }
             PeerAction::List { json } => commands::run_peer_list(&home, json).await,
+            PeerAction::Prune { apply } => commands::run_peer_prune(&home, apply).await,
         },
 
         Command::Peers => commands::run_peer_list(&home, false).await,

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -508,6 +508,24 @@ impl Airc {
         Ok(Some(document))
     }
 
+    /// The peer_ids of LIVE peers in the current fresh account registry
+    /// (the merged, stale-pruned document). **READ-ONLY** — unlike
+    /// [`Self::refresh_account_registry`], this does NOT enrol/import, so
+    /// it is safe to call from a dry run. Returns `None` when no registry
+    /// document is available (empty account, gh gate, or no mesh match).
+    /// Used by `airc peer prune` as the authoritative "who is alive" set:
+    /// an enrolled peer absent from it is a dead-route candidate.
+    pub async fn live_registry_peer_ids(
+        &self,
+        store: &dyn AccountRegistryStore,
+    ) -> Result<Option<std::collections::HashSet<airc_core::PeerId>>, AircError> {
+        let identity = self.mesh_identity().await?;
+        let Some(document) = store.refresh(&identity).await? else {
+            return Ok(None);
+        };
+        Ok(Some(document.peers.iter().map(|p| p.peer_id()).collect()))
+    }
+
     pub async fn import_account_registry_document(
         &self,
         document: AccountRegistryDocument,

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -147,7 +147,7 @@ pub use mesh_identity::{
     resolve_with as resolve_mesh_identity_with, CachedIdentity, MeshIdentityError,
     Source as MeshIdentitySource, DEFAULT_TTL_MS as MESH_IDENTITY_TTL_MS,
 };
-pub use peers::EnrolledPeer;
+pub use peers::{classify_peer_prune, EnrolledPeer, PeerPruneAction, PeerPruneVerdict};
 pub use publish::{PublishReceipt, PublishTarget};
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use registry_refresh::{

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -269,8 +269,7 @@ mod tests {
         live_ids.insert(live_untrusted);
 
         let verdicts = classify_peer_prune(&enrolled, &live_ids);
-        let action_of =
-            |id: PeerId| verdicts.iter().find(|v| v.peer_id == id).unwrap().action;
+        let action_of = |id: PeerId| verdicts.iter().find(|v| v.peer_id == id).unwrap().action;
 
         assert_eq!(
             action_of(ghost),

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -1,9 +1,11 @@
+use std::collections::HashSet;
+
 use airc_core::PeerId;
 use airc_trust as peers_store;
 
 use crate::error::AircError;
 use crate::registry::PeerSpec;
-use crate::Airc;
+use crate::{Airc, TrustTier};
 
 /// One row in `Airc::peers`. Mirrors the daemon's `PeerEntry`
 /// without forcing consumers to pull the daemon crate.
@@ -11,6 +13,73 @@ use crate::Airc;
 pub struct EnrolledPeer {
     pub peer_id: PeerId,
     pub pubkey_b64: String,
+}
+
+/// What [`classify_peer_prune`] decided for one enrolled peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerPruneAction {
+    /// A real / trusted / live peer — never evicted.
+    Keep,
+    /// A dead enrolment — safe to remove from the trust store.
+    Evict,
+}
+
+/// One enrolled peer's prune verdict: id + tier + action + reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerPruneVerdict {
+    pub peer_id: PeerId,
+    pub tier: TrustTier,
+    pub action: PeerPruneAction,
+    pub reason: String,
+}
+
+/// Pure classification for `airc peer prune`: which enrolled peers are
+/// dead trust-store entries. Evicts ONLY peers that are BOTH
+/// [`TrustTier::Untrusted`] AND **absent from `live_ids`** (the peer_ids
+/// present in the current fresh, stale-pruned account registry).
+///
+/// The tier guard is LOAD-BEARING: a trusted peer — e.g. a cross-grid
+/// friend who publishes to THEIR account and is therefore absent from
+/// yours — must NEVER be auto-evicted on absence alone. A live peer
+/// (present in the fresh registry) is always kept regardless of tier.
+/// This is the peer-store analog of `classify_registry_gc`; the trust
+/// store has no `last_seen`/TTL, so dead enrolments (the `172.18.0.x`
+/// Docker-ghost peers) never expire without this. Side-effect-free →
+/// unit-testable without touching the store.
+pub fn classify_peer_prune(
+    enrolled: &[(PeerId, TrustTier)],
+    live_ids: &HashSet<PeerId>,
+) -> Vec<PeerPruneVerdict> {
+    enrolled
+        .iter()
+        .map(|(peer_id, tier)| {
+            let (action, reason) = if live_ids.contains(peer_id) {
+                (
+                    PeerPruneAction::Keep,
+                    "live in the fresh account registry".to_string(),
+                )
+            } else if *tier == TrustTier::Untrusted {
+                (
+                    PeerPruneAction::Evict,
+                    "untrusted + absent from fresh registry (dead enrolment)".to_string(),
+                )
+            } else {
+                (
+                    PeerPruneAction::Keep,
+                    format!(
+                        "trusted ({}) — never auto-evicted on absence",
+                        tier.as_wire_str()
+                    ),
+                )
+            };
+            PeerPruneVerdict {
+                peer_id: *peer_id,
+                tier: *tier,
+                action,
+                reason,
+            }
+        })
+        .collect()
 }
 
 impl Airc {
@@ -173,6 +242,59 @@ impl Airc {
 mod tests {
     use crate::Airc;
     use tempfile::tempdir;
+
+    // what this catches: `peer prune` must evict ONLY peers that are
+    // Untrusted AND absent from the fresh registry, and must NEVER evict
+    // a trusted peer (a cross-grid Friend publishes to THEIR account so
+    // is absent from ours) or a live peer. Mutation check: dropping the
+    // tier guard evicts the Friend; dropping the live-set check evicts
+    // the live untrusted peer — both fail an assert.
+    #[test]
+    fn classify_peer_prune_evicts_only_untrusted_absent() {
+        use super::{classify_peer_prune, PeerPruneAction};
+        use crate::TrustTier;
+        use airc_core::PeerId;
+        use std::collections::HashSet;
+
+        let ghost = PeerId::new(); // untrusted + absent  → Evict
+        let live_untrusted = PeerId::new(); // untrusted but LIVE → Keep
+        let friend_absent = PeerId::new(); // trusted Friend + absent → Keep (cross-grid)
+
+        let enrolled = vec![
+            (live_untrusted, TrustTier::Untrusted),
+            (ghost, TrustTier::Untrusted),
+            (friend_absent, TrustTier::Friend),
+        ];
+        let mut live_ids = HashSet::new();
+        live_ids.insert(live_untrusted);
+
+        let verdicts = classify_peer_prune(&enrolled, &live_ids);
+        let action_of =
+            |id: PeerId| verdicts.iter().find(|v| v.peer_id == id).unwrap().action;
+
+        assert_eq!(
+            action_of(ghost),
+            PeerPruneAction::Evict,
+            "untrusted + absent = dead enrolment"
+        );
+        assert_eq!(
+            action_of(live_untrusted),
+            PeerPruneAction::Keep,
+            "a LIVE peer is kept even if untrusted"
+        );
+        assert_eq!(
+            action_of(friend_absent),
+            PeerPruneAction::Keep,
+            "a trusted Friend is NEVER auto-evicted on absence (cross-grid protection)"
+        );
+        assert_eq!(
+            verdicts
+                .iter()
+                .filter(|v| v.action == PeerPruneAction::Evict)
+                .count(),
+            1
+        );
+    }
 
     /// Regression for the account-registry auto-discovery keystone
     /// (card a134b370): the daemon's registry-refresh loop opens its


### PR DESCRIPTION
## What

Phase-1 reliability fix from the substrate-solidification plan (doc PR #1184, seam **#3**). The trust store is **enrol-only** — no `last_seen`/TTL — so dead enrolments never expire. Confirmed on canary by the Intel-Mac node: **14 dead `172.18.0.x` Docker-ghost peers** (old #1175 harness runs) leaking failed dials = **42s wasted per transport healthcheck**.

`airc peer prune` is the peer-store analog of `registry gc`.

## Safety design (this is destructive)

- **Classifier** (`classify_peer_prune`, pure + unit-tested): evict ONLY peers that are `Untrusted` **AND** absent from the fresh, stale-pruned account registry.
  - The **tier guard is load-bearing**: a trusted cross-grid **Friend** publishes to *their* account, so is absent from yours — must NEVER be auto-evicted on absence. Live peers always kept.
- **No-live-set guard**: if a trustworthy fresh live set can't be established (gh unauth / hermetic / unreachable / **empty** registry), prune **NOTHING** — pruning against an unknown/empty live set would evict live peers.
- **Dry-run by default**; `--apply` evicts via `Airc::remove_peer` with a forensic reason (`PeerDeparted` records *why*).
- `live_registry_peer_ids` is **read-only** (does not enrol/import), so dry-run truly mutates nothing.

## Validation

- Classifier unit test — 4 cases incl. **trusted-Friend-absent → Keep**.
- Linux container against the **live account**: (a) enrolled untrusted ghost absent from the real registry → **EVICT**; (b) **SAFETY** — enrolled ghost + hermetic (no live set) → *"Pruning NOTHING"*, ghost stays enrolled.
- `clippy -D warnings` clean.

Follow-up (plan Phase 3): enrolment `last_seen` for age-based eviction, so this becomes a manual escape hatch rather than the only cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)