### PR TITLE
feat(cli): airc msg/send --room — one-shot channel addressing (seam #5, card a979e5c2)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -474,9 +474,17 @@ pub enum Command {
     /// Legacy envelope encryption helpers during Rust cutover.
     Envelope(EnvelopeArgs),
 
-    /// Send a single text Message frame to the default subscribed
-    /// room and exit. The default channel lives in the ORM store.
+    /// Send a single text Message frame to a subscribed room and
+    /// exit. With `--room`, sends to that room without mutating this
+    /// scope's default-room pointer (one-shot routing — same shape
+    /// as `airc publish --room`). Without `--room`, the default
+    /// channel lives in the ORM store.
     Send {
+        /// Channel name to route to. Must already be subscribed
+        /// (send does not auto-join). Defaults to the current room
+        /// when omitted.
+        #[arg(long)]
+        room: Option<String>,
         /// Message body.
         text: String,
     },
@@ -546,11 +554,20 @@ pub enum Command {
         socket: Option<PathBuf>,
     },
 
-    /// Send a text message to the current room via the running
-    /// daemon (fast — no per-call substrate setup).
+    /// Send a text message to a subscribed room via the running
+    /// daemon (fast — no per-call substrate setup). With `--room`,
+    /// sends to that room without mutating this scope's
+    /// default-room pointer (one-shot routing — same shape as
+    /// `airc publish --room`). Without `--room`, defaults to the
+    /// current room.
     Msg {
         #[arg(long)]
         socket: Option<PathBuf>,
+        /// Channel name to route to. Must already be subscribed
+        /// (msg does not auto-join). Defaults to the current room
+        /// when omitted.
+        #[arg(long)]
+        room: Option<String>,
         /// Message body.
         text: String,
     },

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -848,14 +848,36 @@ pub(crate) async fn attached_airc(home: &Path) -> Result<Airc, Box<dyn std::erro
 pub async fn run_send(
     home: &Path,
     peers: Vec<PeerSpec>,
+    room: Option<&str>,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = attached_airc(home).await?;
     for peer in &peers {
         airc.enrol_volatile_peer(peer)?;
     }
-    let current = airc.current_room().await?;
-    airc.say_with_headers(text, runtime_headers()?).await?;
+    // Card a979e5c2 (seam #5): `--room <name>` routes ONE message
+    // to a subscribed-but-not-current room without mutating this
+    // scope's default-room pointer. Same shape as `airc publish`.
+    // Without `--room`, the historical "current room + runtime
+    // headers" path runs unchanged.
+    let (channel_name, channel_id) = match room {
+        Some(name) => {
+            let receipt = airc
+                .publish(
+                    airc_lib::PublishTarget::RoomByName(name.to_string()),
+                    airc_protocol::FrameKind::Message,
+                    airc_core::Body::text(text),
+                    runtime_headers()?,
+                )
+                .await?;
+            (receipt.channel_name, receipt.channel_id.to_string())
+        }
+        None => {
+            let current = airc.current_room().await?;
+            airc.say_with_headers(text, runtime_headers()?).await?;
+            (current.name, current.channel.to_string())
+        }
+    };
     let peer_count = airc.peers().await?.len();
     // `Airc::say` returned Ok — the frame is signed, persisted to the
     // local store, and written to the wire. Any scope tailing this
@@ -872,13 +894,11 @@ pub async fn run_send(
     // matches what actually happened.
     if peer_count == 0 {
         println!(
-            "sent to {} ({}). 0 paired remote peers; any scope tailing this channel on this machine will receive it.",
-            current.name, current.channel
+            "sent to {channel_name} ({channel_id}). 0 paired remote peers; any scope tailing this channel on this machine will receive it."
         );
     } else {
         println!(
-            "sent to {} ({}) — {peer_count} paired peer(s) + any local scope tailing this channel.",
-            current.name, current.channel
+            "sent to {channel_name} ({channel_id}) — {peer_count} paired peer(s) + any local scope tailing this channel."
         );
     }
     Ok(())
@@ -1514,25 +1534,45 @@ pub async fn run_stop(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>>
 pub async fn run_msg(
     home: &Path,
     socket: PathBuf,
+    room: Option<&str>,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let socket = ensure_daemon_running(home, socket, Vec::new()).await?;
     sync_daemon_peers_for_current_rooms(home, socket.clone()).await?;
     let airc = Airc::attach(home, socket).await?;
-    let current = airc.current_room().await?;
-    airc.say_with_headers(text, runtime_headers()?).await?;
+    // Card a979e5c2 (seam #5): `--room <name>` routes ONE message
+    // to a subscribed-but-not-current room without mutating this
+    // scope's default-room pointer. Same shape as `airc publish`.
+    // Without `--room`, the historical "current room" path runs
+    // unchanged.
+    let (channel_name, channel_id) = match room {
+        Some(name) => {
+            let receipt = airc
+                .publish(
+                    airc_lib::PublishTarget::RoomByName(name.to_string()),
+                    airc_protocol::FrameKind::Message,
+                    airc_core::Body::text(text),
+                    runtime_headers()?,
+                )
+                .await?;
+            (receipt.channel_name, receipt.channel_id.to_string())
+        }
+        None => {
+            let current = airc.current_room().await?;
+            airc.say_with_headers(text, runtime_headers()?).await?;
+            (current.name, current.channel.to_string())
+        }
+    };
     let peer_count = airc.peers().await?.len();
     // See run_send for the rationale — same message-honesty fix
     // for the daemon-attached send path.
     if peer_count == 0 {
         println!(
-            "sent to {} ({}). 0 paired remote peers; any scope tailing this channel on this machine will receive it.",
-            current.name, current.channel
+            "sent to {channel_name} ({channel_id}). 0 paired remote peers; any scope tailing this channel on this machine will receive it."
         );
     } else {
         println!(
-            "sent to {} ({}) — {peer_count} paired peer(s) + any local scope tailing this channel.",
-            current.name, current.channel
+            "sent to {channel_name} ({channel_id}) — {peer_count} paired peer(s) + any local scope tailing this channel."
         );
     }
     Ok(())

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -855,6 +855,13 @@ pub async fn run_send(
     for peer in &peers {
         airc.enrol_volatile_peer(peer)?;
     }
+    // Card a979e5c2 reviewer NIT — symmetric with run_msg: keep the
+    // daemon's per-wire subscriber index aware of every subscribed
+    // room before the send goes out. Load-bearing in particular when
+    // `--room <name>` targets a room the daemon hasn't recently
+    // touched. Safe no-op when the index is already fresh.
+    let socket = crate::cli::default_socket_path_in(home);
+    sync_daemon_peers_for_current_rooms(home, socket).await?;
     // Card a979e5c2 (seam #5): `--room <name>` routes ONE message
     // to a subscribed-but-not-current room without mutating this
     // scope's default-room pointer. Same shape as `airc publish`.

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -344,7 +344,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             } => legacy_envelope::unwrap_stdin(&sender_pub, &identity_dir),
         },
 
-        Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,
+        Command::Send { room, text } => {
+            commands::run_send(&home, parsed.peers, room.as_deref(), &text).await
+        }
 
         Command::Listen { replay } => commands::run_listen(&home, parsed.peers, replay).await,
 
@@ -372,8 +374,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Status { socket } => commands::run_status(&home, default_or(socket, &home)).await,
         Command::Stop { socket } => commands::run_stop(default_or(socket, &home)).await,
 
-        Command::Msg { socket, text } => {
-            commands::run_msg(&home, default_or(socket, &home), &text).await
+        Command::Msg { socket, room, text } => {
+            commands::run_msg(&home, default_or(socket, &home), room.as_deref(), &text).await
         }
         Command::Publish {
             room,

--- a/crates/airc-lib/tests/publish_to_room_does_not_mutate_default.rs
+++ b/crates/airc-lib/tests/publish_to_room_does_not_mutate_default.rs
@@ -1,0 +1,74 @@
+//! Regression test for card a979e5c2 (seam #5): the `--room <name>` one-shot
+//! send must NEVER mutate this scope's default-room pointer.
+//!
+//! The CLI surface (`airc msg --room X "..."` and `airc send --room X "..."`)
+//! routes through `airc.publish(PublishTarget::RoomByName(name), ...)`. The
+//! invariant — "after a one-shot --room send, `airc room` still reports the
+//! ORIGINAL room" — is what makes cross-channel coordination work without
+//! silently flipping the user's current-room pointer.
+//!
+//! BIGMAMA's adversarial review of PR #1188 verified the impl by READING the
+//! code (no mutation in the publish path) — but a future refactor could
+//! silently reintroduce the room-drift bug with a green suite. This test pins
+//! the invariant structurally so any drift fails CI.
+
+mod common;
+
+use airc_core::Body;
+use airc_lib::PublishTarget;
+use airc_protocol::FrameKind;
+use common::Machine;
+
+#[tokio::test]
+async fn publish_to_room_by_name_does_not_change_current_room() {
+    let machine = Machine::boot().await;
+    let alice = machine.attach("alice").await;
+
+    // Alice joins TWO rooms. The first one becomes her current/default
+    // because join semantics in this fixture leave the most-recent join
+    // wired as current. Re-join the "home" room AFTER to anchor it as
+    // current — that's the room the no-mutation invariant must protect.
+    let other = alice
+        .join("other-room")
+        .await
+        .expect("alice joins other-room");
+    let home = alice
+        .join("home-room")
+        .await
+        .expect("alice joins home-room");
+    let current_before = alice
+        .current_room()
+        .await
+        .expect("read current room before");
+    assert_eq!(
+        current_before.name, home.name,
+        "test precondition: current room should be the most-recently-joined home-room"
+    );
+
+    // The act under test: one-shot publish to the OTHER room. This is the
+    // exact code path `airc msg --room other-room` exercises.
+    let receipt = alice
+        .publish(
+            PublishTarget::RoomByName(other.name.clone()),
+            FrameKind::Message,
+            Body::text("targeted at other-room, sender stays on home-room"),
+            airc_core::Headers::new(),
+        )
+        .await
+        .expect("publish to other-room");
+    assert_eq!(
+        receipt.channel_name, other.name,
+        "publish routed to the requested room (sanity)"
+    );
+
+    // The invariant: current room is UNCHANGED.
+    let current_after = alice.current_room().await.expect("read current room after");
+    assert_eq!(
+        current_after.name, current_before.name,
+        "BUG: --room publish silently mutated the default-room pointer (regression of seam #5)"
+    );
+    assert_eq!(
+        current_after.channel, current_before.channel,
+        "BUG: --room publish silently changed the channel id (regression of seam #5)"
+    );
+}

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -48,9 +48,9 @@ Before broadcasting, run the test: **would agents in OTHER projects need to see 
 | Test answer | Venue |
 |---|---|
 | No  | Your project room (`airc msg "..."` defaults here) — or a GitHub issue in that project's repo for durable record |
-| Yes | `#general` — `airc publish --room general --body-text "..." --kind message` (one-shot, no room switch) |
+| Yes | `#general` — `airc msg --room general "..."` (one-shot, no room switch) |
 
-Most project work fails the test. Default `airc msg` (no flag) posts to the current room — your project room — which is correct. `airc msg` has **no `--channel`/`--room` flag**: to reach a different channel, either switch the current room first (`airc room general` then `airc msg "..."`) or use `airc publish --room general` for one-shot routing that doesn't move the current-room pointer. Only target `#general` when the audience is genuinely cross-room (cross-team coordination, structural announcements affecting all rooms, looking for a peer outside your project).
+Most project work fails the test. Default `airc msg` (no flag) posts to the current room — your project room — which is correct. To reach a different channel without flipping the default, use `airc msg --room <name> "..."` (one-shot send, card a979e5c2 / seam #5) — `--room` only routes to a room you are already subscribed to; it does not auto-join. Equivalent for the short-lived path: `airc send --room <name> "..."`. For a structured payload: `airc publish --room <name> --body-text "..."`. Only target `#general` when the audience is genuinely cross-room (cross-team coordination, structural announcements affecting all rooms, looking for a peer outside your project).
 
 Don't default-stamp project chatter onto the lobby. It drowns out cross-room signal and forces other projects' agents to filter past noise that wasn't meant for them. If a thread is deep-dive on one project, move it to that project's room (or a GitHub issue) and post a one-line pointer to #general only if other projects need the breadcrumb.
 

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -24,11 +24,12 @@ curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh |
 
 The `@` prefix on the first arg is the DM trigger. Everything else is the message body.
 
-`airc msg` has **no `--room` flag** — it always posts to the current room. To target a
-different room, either switch the current room first with `airc room <name>` then
-`airc msg ...`, or use `airc publish --room <name> --body-text "..."` for one-shot
-routing that doesn't move the current-room pointer. Note: `airc publish --room` only
-routes to a room you are **already subscribed to** — it does not auto-join.
+`airc msg --room <name> <message>` — one-shot send to a subscribed room without
+changing the scope's current-room pointer (card a979e5c2 / seam #5). Without `--room`,
+`airc msg` defaults to the current room as before. `--room` only routes to a room
+you are **already subscribed to** — it does not auto-join. (Equivalent for the
+short-lived path: `airc send --room <name> <message>`. For a structured payload:
+`airc publish --room <name> --body-text "..."`.)
 
 ## Execute
 


### PR DESCRIPTION
## What

Both `airc msg` and `airc send` now accept `--room <name>` for one-shot routing to a subscribed channel without mutating this scope's default-room pointer. Same shape as `airc publish --room`.

Closes seam #5 of `IDENTITY-SCOPE-PEER-LIVENESS-MODEL.md` (PR #1184).

## Why

Live cross-Claude test on 2026-06-14 surfaced a real comms break: two agents on the same machine, both alive on airc, couldn't reach each other because their cwd-inferred default rooms differed (continuum cwd → general, airc cwd → cambriantech). The only ways out were `airc room <name>` (mutates default; next CLI call in the other cwd silently flips back) or `airc publish` (works, but emits a JSON receipt — wrong shape for chat). We had documented this as a seam and queued it; Joel correctly called us out for queuing a live comms break.

## How

- `airc msg --room <name> "text"` + `airc send --room <name> "text"`: when `--room` is set, routes through `PublishTarget::RoomByName` via `airc.publish(...)`, prints prose using the `PublishReceipt`'s `channel_name` + `channel_id`. Without `--room`, the historical current-room path runs unchanged.
- Identical clap-arg shape + behaviour pinned to the existing `airc publish --room` so all three commands match.
- `current.channel` (RoomId) display path also normalized to `to_string()` so the prose is uniform across all branches.

## Verified live

From cwd whose default room was `cambriantech`:

```
$ airc msg --room general "..."
sent to general (5eedf7b1-14b1-5938-b4ea-047c239c8fd4) — 25 paired peer(s) + any local scope tailing this channel.
$ airc room
room:    cambriantech                          # ← UNCHANGED
```

255 airc-cli tests pass; `cargo fmt --check` clean.

## Test plan

- [x] cargo check
- [x] cargo test --package airc-cli  → 255 passed
- [x] cargo fmt --check
- [x] live test: --room routes one-shot without mutating default
- [ ] CI green on canary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
