### PR TITLE
fix(cli): collaboration peers → view over canonical trust store (seam #2)

### DIFF
--- a/crates/airc-cli/src/collaboration_peers.rs
+++ b/crates/airc-cli/src/collaboration_peers.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -15,15 +15,20 @@ struct PeerRecord {
     stem: String,
 }
 
-pub fn run_peers(default_home: &Path, args: CollaborationScopeArgs) -> Result<(), Box<dyn Error>> {
+pub async fn run_peers(
+    default_home: &Path,
+    args: CollaborationScopeArgs,
+) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
-    let peers = peer_records(home);
-    if peers.is_empty() {
-        println!("  No peers yet.");
-        return Ok(());
-    }
-    print_peer_records(home, &peers);
-    Ok(())
+    // Seam #2 (solidification doc): the airc_trust store is the CANONICAL
+    // peer truth (peer_id + tier + endpoints). `collaboration peers` is
+    // now a VIEW over it via the shared `peer list` renderer — NOT the
+    // legacy file-based name/host/paired records under
+    // `<home>/peers/*.json`. Those files persist only as handshake
+    // pairing metadata; fully retiring them + migrating the handshake
+    // flow onto the trust store (and dropping `prune-peers`) is the
+    // remaining #2 work, tracked. One peer truth, one place.
+    crate::commands::run_peer_list(home, false).await
 }
 
 pub fn run_prune_peers(
@@ -107,21 +112,6 @@ fn peer_record_from_path(path: &Path) -> Option<PeerRecord> {
             .to_string(),
         stem,
     })
-}
-
-fn print_peer_records(home: &Path, peers: &[PeerRecord]) {
-    let room = fs::read_to_string(home.join("room_name"))
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "(?)".to_string());
-    let mut seen_keys = BTreeSet::new();
-    for peer in peers {
-        if !seen_keys.insert((peer.name.clone(), peer.host.clone())) {
-            continue;
-        }
-        println!("  {} -> {}   [#{}]", peer.name, peer.host, room,);
-    }
 }
 
 fn remove_peer_file(peers_dir: &Path, stem: &str, extension: &str) {

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -220,7 +220,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             CollaborationAction::SendWarning(args) => {
                 collaboration_commands::run_send_warning(&home, args).await
             }
-            CollaborationAction::Peers(args) => collaboration_peers::run_peers(&home, args),
+            CollaborationAction::Peers(args) => collaboration_peers::run_peers(&home, args).await,
             CollaborationAction::PrunePeers(args) => {
                 collaboration_peers::run_prune_peers(&home, args)
             }


### PR DESCRIPTION
Solidification seam #2. `collaboration peers` rendered legacy file-based name/host/paired records; canonical truth is the airc_trust store. Make it a VIEW over the canonical store (shared `peer list` renderer) — one peer truth, one place. Remaining: retire the legacy `<home>/peers/*.json` (handshake metadata) + migrate handshake + drop `prune-peers` (superseded by `airc peer prune`) — follow-up. **Stacked on #1190** (seam #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)