### PR TITLE
feat(peer): age/TTL staleness gate on peer prune (seam #3.2 slice 3)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1880,8 +1880,13 @@ pub async fn run_peer_prune(home: &Path, apply: bool) -> Result<(), Box<dyn std:
         println!("(no enroled peers — nothing to prune)");
         return Ok(());
     }
-    let enrolled_pairs: Vec<(airc_core::PeerId, airc_lib::TrustTier)> =
-        enrolled.iter().map(|p| (p.peer_id, p.tier)).collect();
+    // Seam #3.2: carry each peer's last_seen so the classifier can apply
+    // the staleness grace window (a recently-contacted peer absent from
+    // one registry snapshot is kept, not evicted as a ghost).
+    let enrolled_triples: Vec<(airc_core::PeerId, airc_lib::TrustTier, u64)> = enrolled
+        .iter()
+        .map(|p| (p.peer_id, p.tier, p.last_seen_ms))
+        .collect();
 
     // Authoritative live set: the fresh, stale-pruned account-registry
     // document (READ-ONLY — `live_registry_peer_ids` does not enrol).
@@ -1905,7 +1910,16 @@ pub async fn run_peer_prune(home: &Path, apply: bool) -> Result<(), Box<dyn std:
         }
     };
 
-    let verdicts = airc_lib::classify_peer_prune(&enrolled_pairs, &live_ids);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let verdicts = airc_lib::classify_peer_prune(
+        &enrolled_triples,
+        &live_ids,
+        now_ms,
+        airc_lib::DEFAULT_PEER_STALE_AFTER_MS,
+    );
     let mut to_evict = Vec::new();
     for verdict in &verdicts {
         match verdict.action {
@@ -1948,7 +1962,7 @@ pub async fn run_peer_prune(home: &Path, apply: bool) -> Result<(), Box<dyn std:
         if airc
             .remove_peer(
                 *peer_id,
-                "peer-prune: untrusted + absent from fresh registry",
+                "peer-prune: untrusted + absent from fresh registry + stale past last_seen TTL",
             )
             .await?
         {

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -531,6 +531,10 @@ impl Airc {
         document: AccountRegistryDocument,
     ) -> Result<(), AircError> {
         document.validate().map_err(AircError::AccountRegistry)?;
+        // Seam #3.2 (liveness): the wall-clock instant we are importing
+        // at — the upper bound for any peer's `last_seen`. See the clamp
+        // at the touch below.
+        let now_ms = crate::time::now_ms()?;
         for peer in document.peers {
             if peer.peer_id() == self.inner.identity.peer_id {
                 continue;
@@ -545,17 +549,26 @@ impl Airc {
             // refreshed, stale-pruned registry document just published a
             // beacon — that IS fresh contact. Record it so the age-based
             // eviction classifier can tell a live peer from a stale
-            // enrolment. Use the beacon's OWN heartbeat instant (the
-            // peer's liveness assertion), not local `now_ms`: the touch
-            // is monotonic, so a clock-skewed or out-of-order beacon can
-            // only ever leave recency unchanged, never rewind it. The
-            // peer was enrolled two lines up, so this resolves to Some;
-            // we don't assert it (a best-effort liveness stamp, unlike
-            // the endpoints store below whose silent drop was a real bug).
+            // enrolment.
+            //
+            // SECURITY CLAMP (sentinel BLOCK on #1195): `last_seen` means
+            // "when WE last had contact" — we cannot have had contact in
+            // the future. `heartbeat_at_ms` is the peer's OWN self-asserted
+            // timestamp, fully attacker-controlled; the store applies it
+            // monotonically with no upper bound. Without `.min(now_ms)` an
+            // untrusted peer (or a replayed/skewed beacon) could pin its
+            // own `last_seen` arbitrarily far ahead, and the age-based
+            // prune gate (peers.rs: keep when `now - last_seen < TTL`)
+            // would then NEVER evict it — the ghost-GC this whole spine
+            // exists for, defeated by a value the peer controls. Clamping
+            // to `now_ms` makes the most we'll ever record "received now",
+            // while the store's monotonic max still ignores stale/older
+            // beacons (no rewind). The peer was enrolled two lines up, so
+            // this resolves to Some; best-effort stamp, not asserted.
             airc_trust::touch_last_seen(
                 &self.inner.wire_root,
                 peer.peer_spec.peer_id,
-                peer.presence.heartbeat_at_ms,
+                peer.presence.heartbeat_at_ms.min(now_ms),
             )
             .await?;
             // Card 625abe6d slice 1: persist the beacon's endpoints on
@@ -833,15 +846,24 @@ mod tests {
         );
     }
 
-    /// what this catches: seam #3.2 touch wiring. A peer present in a
-    /// freshly refreshed registry document just published a beacon, so
-    /// `import_account_registry_document` must `touch_last_seen` with
-    /// the beacon's OWN heartbeat instant — AND monotonically, so a
-    /// later out-of-order/stale beacon cannot rewind recency. Without
-    /// the wiring `last_seen` would never advance past enrolment and
-    /// the age-based eviction classifier would have nothing to read.
+    /// what this catches: seam #3.2 touch wiring + the SECURITY CLAMP
+    /// (sentinel BLOCK on #1195). `import_account_registry_document`
+    /// stamps `last_seen` from the beacon — but `heartbeat_at_ms` is the
+    /// peer's OWN self-asserted, attacker-controlled value, and the store
+    /// applies it monotonically with no upper bound. Without
+    /// `.min(now_ms)` an untrusted peer could publish a FUTURE heartbeat,
+    /// pin its `last_seen` arbitrarily ahead, and the age-based prune gate
+    /// (`keep when now - last_seen < TTL`) would NEVER evict it — the
+    /// ghost-GC defeated by a value the peer controls.
+    ///
+    /// This test imports a year-2286 beacon and asserts: (1) the stored
+    /// `last_seen` is clamped to the import instant (never the future
+    /// value), and (2) end-to-end, the peer still EVICTS once `TTL` has
+    /// elapsed since import. If the clamp regresses, `last_seen` would be
+    /// the future value and the same `classify_peer_prune` call would
+    /// `Keep` it forever — so this assertion is the regression net.
     #[tokio::test]
-    async fn import_registry_touches_last_seen_from_beacon_heartbeat() {
+    async fn import_clamps_future_heartbeat_keeping_peer_evictable() {
         let dir = tempdir().unwrap();
         let machine_b = dir.path().join("machine-b/.airc");
         std::fs::create_dir_all(&machine_b).unwrap();
@@ -849,11 +871,6 @@ mod tests {
 
         let peer_id = PeerId::new();
         let spec = peer_spec(peer_id);
-        // Heartbeat in the far future (year ~2286) so it is
-        // unambiguously newer than the real-clock enrolment `added_at`
-        // that `add` seeds — proving the touch ADVANCED last_seen to the
-        // beacon value, not the no-op monotonic floor.
-        let fresh_hb = 9_999_999_999_999u64;
         let doc = |hb: u64| {
             AccountRegistryDocument::new(
                 mesh(),
@@ -873,30 +890,67 @@ mod tests {
             )
         };
 
-        airc.import_account_registry_document(doc(fresh_hb))
+        // Attacker-controlled heartbeat far in the future (year ~2286).
+        let future_hb = 9_999_999_999_999u64;
+        let before = crate::time::now_ms().unwrap();
+        airc.import_account_registry_document(doc(future_hb))
             .await
             .unwrap();
-        let after_fresh = airc_trust::load(&airc.inner.wire_root).await.unwrap();
-        let p = after_fresh
-            .iter()
+        let after = crate::time::now_ms().unwrap();
+
+        let p = airc_trust::load(&airc.inner.wire_root)
+            .await
+            .unwrap()
+            .into_iter()
             .find(|p| p.peer_id == spec.peer_id)
             .expect("peer enrolled on import");
-        assert_eq!(
-            p.last_seen_ms, fresh_hb,
-            "import must touch last_seen with the beacon heartbeat"
+        // CLAMP: never the future value; bounded by the import instant;
+        // still a recent stamp (proves the touch fired, not left at 0).
+        assert_ne!(
+            p.last_seen_ms, future_hb,
+            "a self-asserted future heartbeat must never be stored verbatim"
+        );
+        assert!(
+            p.last_seen_ms <= after,
+            "last_seen ({}) must be clamped to the import instant ({after})",
+            p.last_seen_ms
+        );
+        assert!(
+            p.last_seen_ms >= before,
+            "import must still stamp a recent last_seen ({} < {before})",
+            p.last_seen_ms
         );
 
-        // A later import carrying an OLDER heartbeat must NOT rewind.
+        // END-TO-END: once TTL has elapsed since import, the absent peer
+        // must EVICT. With the future value stored (clamp removed) the
+        // age would saturate to 0 and this would Keep forever.
+        let ttl = crate::DEFAULT_PEER_STALE_AFTER_MS;
+        let prune_now = after + ttl + 1;
+        let verdicts = crate::classify_peer_prune(
+            &[(spec.peer_id, crate::TrustTier::Untrusted, p.last_seen_ms)],
+            &std::collections::HashSet::new(),
+            prune_now,
+            ttl,
+        );
+        assert_eq!(
+            verdicts[0].action,
+            crate::PeerPruneAction::Evict,
+            "clamped peer must age out; an unclamped future stamp would Keep forever: {}",
+            verdicts[0].reason
+        );
+
+        // A later OLDER beacon must NOT rewind the clamped recency.
         airc.import_account_registry_document(doc(1_000))
             .await
             .unwrap();
-        let after_stale = airc_trust::load(&airc.inner.wire_root).await.unwrap();
-        let p2 = after_stale
-            .iter()
+        let p2 = airc_trust::load(&airc.inner.wire_root)
+            .await
+            .unwrap()
+            .into_iter()
             .find(|p| p.peer_id == spec.peer_id)
             .expect("peer still enrolled");
         assert_eq!(
-            p2.last_seen_ms, fresh_hb,
+            p2.last_seen_ms, p.last_seen_ms,
             "monotonic: an older/out-of-order beacon must not rewind recency"
         );
     }

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -147,7 +147,10 @@ pub use mesh_identity::{
     resolve_with as resolve_mesh_identity_with, CachedIdentity, MeshIdentityError,
     Source as MeshIdentitySource, DEFAULT_TTL_MS as MESH_IDENTITY_TTL_MS,
 };
-pub use peers::{classify_peer_prune, EnrolledPeer, PeerPruneAction, PeerPruneVerdict};
+pub use peers::{
+    classify_peer_prune, EnrolledPeer, PeerPruneAction, PeerPruneVerdict,
+    DEFAULT_PEER_STALE_AFTER_MS,
+};
 pub use publish::{PublishReceipt, PublishTarget};
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use registry_refresh::{

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -33,37 +33,50 @@ pub struct PeerPruneVerdict {
     pub reason: String,
 }
 
+/// Default staleness grace for [`classify_peer_prune`] — 1 hour. An
+/// Untrusted peer that is absent from the fresh registry but whose
+/// `last_seen_ms` is within this window is KEPT (recently-contacted;
+/// the registry snapshot may merely lag the last beacon we imported).
+/// A dead Docker-ghost peer never refreshes its beacon, so its
+/// `last_seen` stays at enrolment and it ages past this window quickly
+/// — generous enough to survive snapshot lag, short enough that ghosts
+/// don't linger. Seam #3.2 (the `last_seen_ms` column enables this).
+pub const DEFAULT_PEER_STALE_AFTER_MS: u64 = 3_600_000;
+
 /// Pure classification for `airc peer prune`: which enrolled peers are
-/// dead trust-store entries. Evicts ONLY peers that are BOTH
-/// [`TrustTier::Untrusted`] AND **absent from `live_ids`** (the peer_ids
-/// present in the current fresh, stale-pruned account registry).
+/// dead trust-store entries. Evicts ONLY peers that are ALL of
+/// [`TrustTier::Untrusted`], **absent from `live_ids`** (the peer_ids in
+/// the current fresh, stale-pruned account registry), AND **stale** —
+/// `now_ms - last_seen_ms >= stale_after_ms`.
 ///
 /// The tier guard is LOAD-BEARING: a trusted peer — e.g. a cross-grid
 /// friend who publishes to THEIR account and is therefore absent from
 /// yours — must NEVER be auto-evicted on absence alone. A live peer
 /// (present in the fresh registry) is always kept regardless of tier.
-/// This is the peer-store analog of `classify_registry_gc`; the trust
-/// store has no `last_seen`/TTL, so dead enrolments (the `172.18.0.x`
-/// Docker-ghost peers) never expire without this. Side-effect-free →
+///
+/// Seam #3.2 adds the staleness gate: before this, the trust store had
+/// no `last_seen`/TTL, so an Untrusted+absent peer was evicted the
+/// instant it dropped out of a registry snapshot — even one we'd
+/// imported a beacon from seconds earlier (snapshot lag looked like
+/// death). The `last_seen_ms` column closes that: a peer seen within
+/// `stale_after_ms` gets a grace window. Future `last_seen` (clock skew)
+/// reads as age 0 via saturating subtraction → kept. Side-effect-free →
 /// unit-testable without touching the store.
 pub fn classify_peer_prune(
-    enrolled: &[(PeerId, TrustTier)],
+    enrolled: &[(PeerId, TrustTier, u64)],
     live_ids: &HashSet<PeerId>,
+    now_ms: u64,
+    stale_after_ms: u64,
 ) -> Vec<PeerPruneVerdict> {
     enrolled
         .iter()
-        .map(|(peer_id, tier)| {
+        .map(|(peer_id, tier, last_seen_ms)| {
             let (action, reason) = if live_ids.contains(peer_id) {
                 (
                     PeerPruneAction::Keep,
                     "live in the fresh account registry".to_string(),
                 )
-            } else if *tier == TrustTier::Untrusted {
-                (
-                    PeerPruneAction::Evict,
-                    "untrusted + absent from fresh registry (dead enrolment)".to_string(),
-                )
-            } else {
+            } else if *tier != TrustTier::Untrusted {
                 (
                     PeerPruneAction::Keep,
                     format!(
@@ -71,6 +84,28 @@ pub fn classify_peer_prune(
                         tier.as_wire_str()
                     ),
                 )
+            } else {
+                // Untrusted + absent: evict only if ALSO stale past the
+                // grace window. `saturating_sub` makes a future last_seen
+                // (clock skew / not-yet-imported) read as age 0 → kept.
+                let age_ms = now_ms.saturating_sub(*last_seen_ms);
+                if age_ms >= stale_after_ms {
+                    (
+                        PeerPruneAction::Evict,
+                        format!(
+                            "untrusted + absent + last seen {age_ms}ms ago \
+                             (>= {stale_after_ms}ms TTL) — dead enrolment"
+                        ),
+                    )
+                } else {
+                    (
+                        PeerPruneAction::Keep,
+                        format!(
+                            "untrusted + absent but seen {age_ms}ms ago \
+                             (within {stale_after_ms}ms grace)"
+                        ),
+                    )
+                }
             };
             PeerPruneVerdict {
                 peer_id: *peer_id,
@@ -244,37 +279,41 @@ mod tests {
     use tempfile::tempdir;
 
     // what this catches: `peer prune` must evict ONLY peers that are
-    // Untrusted AND absent from the fresh registry, and must NEVER evict
-    // a trusted peer (a cross-grid Friend publishes to THEIR account so
-    // is absent from ours) or a live peer. Mutation check: dropping the
-    // tier guard evicts the Friend; dropping the live-set check evicts
-    // the live untrusted peer — both fail an assert.
+    // Untrusted AND absent from the fresh registry AND stale past the
+    // grace window; and must NEVER evict a trusted peer (a cross-grid
+    // Friend publishes to THEIR account so is absent from ours) or a
+    // live peer. Mutation check: dropping the tier guard evicts the
+    // Friend; dropping the live-set check evicts the live untrusted
+    // peer — both fail an assert. (Stale `last_seen` here so the
+    // staleness gate is satisfied; the grace window has its own test.)
     #[test]
     fn classify_peer_prune_evicts_only_untrusted_absent() {
-        use super::{classify_peer_prune, PeerPruneAction};
+        use super::{classify_peer_prune, PeerPruneAction, DEFAULT_PEER_STALE_AFTER_MS};
         use crate::TrustTier;
         use airc_core::PeerId;
         use std::collections::HashSet;
 
-        let ghost = PeerId::new(); // untrusted + absent  → Evict
+        let ghost = PeerId::new(); // untrusted + absent + stale → Evict
         let live_untrusted = PeerId::new(); // untrusted but LIVE → Keep
         let friend_absent = PeerId::new(); // trusted Friend + absent → Keep (cross-grid)
 
+        let now = 10_000_000_000u64;
+        // last_seen far in the past → past the grace window for all.
         let enrolled = vec![
-            (live_untrusted, TrustTier::Untrusted),
-            (ghost, TrustTier::Untrusted),
-            (friend_absent, TrustTier::Friend),
+            (live_untrusted, TrustTier::Untrusted, 0),
+            (ghost, TrustTier::Untrusted, 0),
+            (friend_absent, TrustTier::Friend, 0),
         ];
         let mut live_ids = HashSet::new();
         live_ids.insert(live_untrusted);
 
-        let verdicts = classify_peer_prune(&enrolled, &live_ids);
+        let verdicts = classify_peer_prune(&enrolled, &live_ids, now, DEFAULT_PEER_STALE_AFTER_MS);
         let action_of = |id: PeerId| verdicts.iter().find(|v| v.peer_id == id).unwrap().action;
 
         assert_eq!(
             action_of(ghost),
             PeerPruneAction::Evict,
-            "untrusted + absent = dead enrolment"
+            "untrusted + absent + stale = dead enrolment"
         );
         assert_eq!(
             action_of(live_untrusted),
@@ -292,6 +331,52 @@ mod tests {
                 .filter(|v| v.action == PeerPruneAction::Evict)
                 .count(),
             1
+        );
+    }
+
+    // what this catches (seam #3.2): the staleness grace window. An
+    // Untrusted, absent peer whose last_seen is WITHIN the TTL must be
+    // KEPT — it was recently contacted and its absence from one registry
+    // snapshot is likely lag, not death. The SAME peer once it ages past
+    // the TTL must Evict. A future last_seen (clock skew) reads as age 0
+    // → kept (no panic on saturating_sub).
+    #[test]
+    fn classify_peer_prune_grace_window_keeps_recently_seen() {
+        use super::{classify_peer_prune, PeerPruneAction};
+        use crate::TrustTier;
+        use airc_core::PeerId;
+        use std::collections::HashSet;
+
+        let recent = PeerId::new();
+        let skewed = PeerId::new();
+        let now = 1_000_000u64;
+        let ttl = 100_000u64;
+        let live_ids = HashSet::new(); // both absent
+
+        // recent: seen 50k ago (< 100k TTL) → Keep; skewed: last_seen in
+        // the future → age saturates to 0 → Keep.
+        let within = vec![
+            (recent, TrustTier::Untrusted, now - 50_000),
+            (skewed, TrustTier::Untrusted, now + 500_000),
+        ];
+        let verdicts = classify_peer_prune(&within, &live_ids, now, ttl);
+        for v in &verdicts {
+            assert_eq!(
+                v.action,
+                PeerPruneAction::Keep,
+                "within grace / future last_seen must be kept: {}",
+                v.reason
+            );
+        }
+
+        // Same recent peer, now aged past the TTL → Evict.
+        let aged = vec![(recent, TrustTier::Untrusted, now - 200_000)];
+        let verdicts = classify_peer_prune(&aged, &live_ids, now, ttl);
+        assert_eq!(
+            verdicts[0].action,
+            PeerPruneAction::Evict,
+            "untrusted + absent + aged past TTL must evict: {}",
+            verdicts[0].reason
         );
     }
 


### PR DESCRIPTION
## Seam #3.2 slice 3 — the payoff

**Stacked on #1194 → #1192.** ⚠️ Retarget base down the chain as each merges (→ #1194's branch, then `canary`), before any base branch is deleted (the #1191 auto-close lesson).

This is what the `last_seen_ms` column (#1192) and the beacon-import touch (#1194) were built **for**. `classify_peer_prune`'s own doc said *"the trust store has no last_seen/TTL, so dead enrolments never expire without this"* — this PR is the *this*.

### Behavior change (strictly safer)
**Before:** an Untrusted peer absent from one registry snapshot was evicted *immediately* — even one we'd imported a beacon from seconds earlier (snapshot lag looked like death).

**Now:** eviction requires Untrusted **AND** absent **AND** stale (`now_ms - last_seen_ms >= TTL`). A recently-contacted peer gets a grace window (`DEFAULT_PEER_STALE_AFTER_MS` = 1h). A dead Docker-ghost never refreshes its beacon, so it ages past the window and still evicts. Fewer evictions, more correct.

- `classify_peer_prune` signature: `enrolled` is now `(PeerId, TrustTier, last_seen_ms)` triples + `now_ms` + `stale_after_ms`. `saturating_sub` makes a future `last_seen` (clock skew) read as age 0 → kept (no panic).
- `run_peer_prune` passes `p.last_seen_ms` + wall-clock now + the default TTL; forensic remove reason notes the staleness gate.

### Tests
- existing `classify_peer_prune_evicts_only_untrusted_absent` updated (stale `last_seen` so the gate is satisfied — proves the tier + live-set guards still hold).
- new `classify_peer_prune_grace_window_keeps_recently_seen` — keep-within-TTL, keep-on-future-`last_seen`, evict-once-aged.

### Completes seam #3.2
Slices: 1 (#1192 column) → 2 (#1194 touch wiring) → **3 (this, the eviction gate)**. The liveness spine is now end-to-end: enrol seeds recency → fresh beacons advance it monotonically → prune ages out the truly-silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)