### PR TITLE
fix(work): cleanup handles nested `<short>/src/` worktree layout (follow-up to c9b28925)

### DIFF
--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -955,7 +955,7 @@ pub async fn run_cleanup(
         // status, that's enough to remove regardless of the kanban
         // projection's state — which often lags reality when a
         // `gh pr merge` bypasses `airc work merge`.
-        let upstream_gone = probe_upstream_gone(&path);
+        let upstream_gone = probe_upstream_gone(&effective);
 
         let disposition = classify_worktree(card_state.as_ref(), &dirty_status, upstream_gone);
 

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -936,28 +936,8 @@ pub async fn run_cleanup(
             .and_then(|c| c.pull_request.as_ref().map(|pr| pr.number));
         let repo = card.as_ref().map(|c| c.repo.to_string());
 
-        // Card 83a5624e: resolve <short>/ vs <short>/src/ BEFORE
-        // probing so the operator sees the actual git worktree path
-        // in the disposition table AND the force-remove loop targets
-        // the right directory.
-        let effective = resolve_worktree_path(&path);
-
-        // Probe for both uncommitted AND unpushed work — see
-        // `probe_dirty_status` for the WIP-outranks-hygiene contract.
-        let dirty_status = probe_dirty_status_at(&effective);
-
-        // Probe whether the worktree's branch still exists on origin.
-        // `gh pr merge --delete-branch` (the default merger path AND
-        // every manual merge that uses --delete-branch) removes the
-        // branch on origin AFTER merging the PR. That's the universal
-        // signal a worktree is dead: branch upstream is gone ⇒ either
-        // merged-and-deleted or abandoned. Combined with `Clean` dirty
-        // status, that's enough to remove regardless of the kanban
-        // projection's state — which often lags reality when a
-        // `gh pr merge` bypasses `airc work merge`.
-        let upstream_gone = probe_upstream_gone(&effective);
-
-        let disposition = classify_worktree(card_state.as_ref(), &dirty_status, upstream_gone);
+        let (effective, dirty_status, disposition) =
+            classify_worktree_path(&path, card_state.as_ref());
 
         classifications.push(WorktreeClassification {
             short,
@@ -965,7 +945,7 @@ pub async fn run_cleanup(
             card_state,
             pr_number,
             repo,
-            dirty_status: dirty_status.clone(),
+            dirty_status,
             disposition,
         });
     }
@@ -1142,6 +1122,26 @@ pub(crate) enum DirtyStatus {
 /// override an out-of-sync kanban state and remove — fixes the
 /// recurring disk-full crash where worktrees for already-merged
 /// PRs lingered because the projection hadn't observed the merge.
+/// BIGMAMA review on PR #1198: extract the per-worktree classification
+/// pipeline so the regression nets the PRODUCTION code path. Reverting
+/// `probe_upstream_gone(&effective)` → `&path` inside THIS function now
+/// makes the nested-layout test go red — which is what a regression net
+/// must actually guarantee.
+///
+/// Card 83a5624e: resolve `<short>/` vs `<short>/src/` BEFORE probing so
+/// the operator sees the actual git worktree path in the disposition
+/// table AND the force-remove loop targets the right directory.
+pub(crate) fn classify_worktree_path(
+    path: &std::path::Path,
+    card_state: Option<&CardState>,
+) -> (std::path::PathBuf, DirtyStatus, Disposition) {
+    let effective = resolve_worktree_path(path);
+    let dirty_status = probe_dirty_status_at(&effective);
+    let upstream_gone = probe_upstream_gone(&effective);
+    let disposition = classify_worktree(card_state, &dirty_status, upstream_gone);
+    (effective, dirty_status, disposition)
+}
+
 pub(crate) fn classify_worktree(
     card_state: Option<&airc_work::CardState>,
     dirty: &DirtyStatus,
@@ -2769,29 +2769,34 @@ mod tests {
 
     /// Regression test for BIGMAMA review on PR #1198: the production
     /// fix at `run_cleanup:958` was `probe_upstream_gone(&effective)`,
-    /// but ALL 269 tests pass if you revert that line back to
-    /// `probe_upstream_gone(&path)` — the regression isn't netted.
+    /// but the previous attempt at this test called probe_upstream_gone
+    /// directly with both `&effective` and `&parent` — reverting the
+    /// production line back to `&path` left the test green because
+    /// it never touched the production call site.
     ///
-    /// Net it here: build a `<parent>/src/` nested layout, delete the
-    /// tracking branch on the origin (the only condition under which
-    /// `probe_upstream_gone` returns true), and assert the probe
-    /// follows the resolve through the nested path. If a future
-    /// refactor passes the unresolved `<parent>/` again, this test
-    /// goes red because `git -C <parent>` is not a git tree.
+    /// Defense: drive through `classify_worktree_path` (the extracted
+    /// helper that wraps the same probes run_cleanup uses), feed it a
+    /// nested-layout worktree with a deleted upstream, and assert the
+    /// final disposition is `Removable`. `Removable` is only reachable
+    /// when `upstream_gone == true` — which requires the helper to
+    /// have correctly threaded the resolved `effective` path into
+    /// `probe_upstream_gone`. If a future refactor reverts the helper
+    /// to pass `&path`, the probe runs against the non-git `<parent>/`
+    /// container, returns false, and the disposition falls back to
+    /// SkipUnknownCard (no card) → this test goes red.
     #[test]
-    fn probe_upstream_gone_follows_nested_src_resolve() {
+    fn classify_worktree_path_emits_removable_on_nested_deleted_upstream() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let parent = tmp.path().join("aabbccdd");
         std::fs::create_dir_all(&parent).expect("mkdir parent");
         let nested = parent.join("src");
 
-        // Standard nested layout: real clone under <parent>/src/.
         let (real_clone, real_tmp) = git_fixture_with_upstream(true);
         std::fs::rename(&real_clone, &nested).expect("rename real clone to nested");
 
-        // Detect default branch then delete the tracking ref on the
-        // origin — `probe_upstream_gone` returns true iff the remote
-        // ref no longer exists.
+        // Delete the upstream branch on origin — the universal "PR
+        // merged / branch abandoned" signal probe_upstream_gone keys
+        // off of.
         let branch_out = std::process::Command::new("git")
             .args(["-C", nested.to_str().unwrap(), "rev-parse", "--abbrev-ref", "HEAD"])
             .output()
@@ -2814,30 +2819,21 @@ mod tests {
             String::from_utf8_lossy(&del.stderr)
         );
 
-        // The load-bearing assertion: probe_upstream_gone given the
-        // <parent>/ container MUST resolve into <parent>/src/ to see
-        // the deleted upstream. With the bug present
-        // (probe_upstream_gone takes <parent>/ unresolved) this comes
-        // back false because `git -C <parent>` fails non-fatally and
-        // the function short-circuits.
-        //
-        // We probe the EFFECTIVE (resolved) path here — the contract
-        // the production fix enforces — so the test goes red if the
-        // production code stops passing &effective.
-        let effective = resolve_worktree_path(&parent);
-        assert!(
-            probe_upstream_gone(&effective),
-            "probe_upstream_gone(&effective) on a nested layout with deleted upstream must return true; \
-             the production fix at run_cleanup:958 routes through &effective and this test \
-             nets the regression if a future refactor reverts to &path"
-        );
-        // And the bug-shaped call: probe against the unresolved
-        // parent MUST come back false — that's the dial we're
-        // protecting against.
-        assert!(
-            !probe_upstream_gone(&parent),
-            "probe_upstream_gone(&parent) on a nested layout cannot see the deleted upstream; \
-             this asserts the bug shape so the regression is two-sided"
+        // Drive through the SAME helper run_cleanup uses. The card
+        // state is None (no projection match) — `upstream_gone`
+        // short-circuits to Removable BEFORE the card-state branch is
+        // even consulted, so the disposition signal IS the probe
+        // signal. Revert the helper to use unresolved `path` and this
+        // assertion fails because probe_upstream_gone(<parent>/) is
+        // false → falls through to SkipUnknownCard.
+        let (effective, dirty, disposition) = classify_worktree_path(&parent, None);
+        assert_eq!(
+            disposition,
+            Disposition::Removable,
+            "nested layout + deleted upstream MUST classify as Removable. \
+             effective={effective:?}, dirty={dirty:?}, disposition={disposition:?}. \
+             If this fails, classify_worktree_path stopped routing &effective \
+             to probe_upstream_gone — re-check the production fix."
         );
     }
 

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -641,10 +641,16 @@ pub(crate) async fn cleanup_card_worktree(
     let short: String = card_id.to_string().chars().take(8).collect();
     let lease_root = lease::lease_root()
         .ok_or_else(|| "HOME/USERPROFILE not set; cannot resolve ~/.airc/worktrees/".to_string())?;
-    let worktree_path = lease_root.join(&short);
-    if !worktree_path.exists() {
+    let parent = lease_root.join(&short);
+    if !parent.exists() {
         return Ok(());
     }
+    // Card 83a5624e: support both the canonical `<short>/` layout
+    // and the `<short>/src/` nested layout (used by repos like
+    // continuum where `src/` is the workspace root). Without this,
+    // the merger's cleanup hook stranded nested worktrees on every
+    // merge — observed 2026-06-05 with continuum PRs #1530/#1531.
+    let worktree_path = resolve_worktree_path(&parent);
     let worktree_str = worktree_path.to_string_lossy().to_string();
 
     // WIP guard: refuse if either uncommitted/untracked OR
@@ -930,9 +936,15 @@ pub async fn run_cleanup(
             .and_then(|c| c.pull_request.as_ref().map(|pr| pr.number));
         let repo = card.as_ref().map(|c| c.repo.to_string());
 
+        // Card 83a5624e: resolve <short>/ vs <short>/src/ BEFORE
+        // probing so the operator sees the actual git worktree path
+        // in the disposition table AND the force-remove loop targets
+        // the right directory.
+        let effective = resolve_worktree_path(&path);
+
         // Probe for both uncommitted AND unpushed work — see
         // `probe_dirty_status` for the WIP-outranks-hygiene contract.
-        let dirty_status = probe_dirty_status(&path);
+        let dirty_status = probe_dirty_status_at(&effective);
 
         // Probe whether the worktree's branch still exists on origin.
         // `gh pr merge --delete-branch` (the default merger path AND
@@ -949,7 +961,7 @@ pub async fn run_cleanup(
 
         classifications.push(WorktreeClassification {
             short,
-            path: path.clone(),
+            path: effective,
             card_state,
             pr_number,
             repo,
@@ -1263,6 +1275,66 @@ pub(crate) fn parse_worktree_short_id(basename: &str) -> Option<String> {
 /// unpushed WIP would have been destroyed by `--force`. This is
 /// the WIP-outranks-hygiene contract the PR claims to enforce.
 fn probe_dirty_status(path: &std::path::Path) -> DirtyStatus {
+    let effective = resolve_worktree_path(path);
+    probe_dirty_status_at(&effective)
+}
+
+/// Resolve `<short>/` to the actual git worktree path. Some repos
+/// (continuum is the canonical case) live at `<short>/src/` because
+/// `src/` is the workspace root the operator clones into. The
+/// `airc work claim` canonical convention is `<short>/`, but
+/// `git worktree add <short>/src` is a common manual pattern that
+/// leaves the parent `<short>/` as a non-git directory containing
+/// a single `src/` worktree.
+///
+/// This helper:
+///
+///   1. If `path` IS a git worktree (a `.git` file/dir exists OR
+///      `git rev-parse --git-dir` succeeds), return `path`.
+///   2. Else if `path/src/` IS a git worktree, return `path/src/`.
+///   3. Else return `path` unchanged — downstream probes will
+///      classify it as `Unknown`/`SkipNotGit` and the operator
+///      sees the diagnostic.
+///
+/// One-level nested fallback ONLY. Arbitrary deep nesting is
+/// out-of-scope (no observed wild case); per `[[no-fallbacks-ever]]`
+/// the helper documents exactly the two layouts it accepts.
+///
+/// Card 83a5624e follow-up to c9b28925: the merger's
+/// `cleanup_card_worktree` hook (and the manual `airc work cleanup`)
+/// both probe `~/.airc/worktrees/<short>/` directly. Worktrees
+/// allocated at `<short>/src/` were stranded across merges
+/// (observed 2026-06-05 with continuum PRs #1530 / #1531). This
+/// helper closes that gap.
+fn resolve_worktree_path(path: &std::path::Path) -> std::path::PathBuf {
+    if is_git_worktree(path) {
+        return path.to_path_buf();
+    }
+    let nested = path.join("src");
+    if is_git_worktree(&nested) {
+        return nested;
+    }
+    path.to_path_buf()
+}
+
+/// Cheap heuristic: `.git` (file or dir) at the path's top level
+/// is a strong signal of a git worktree. Avoids spawning `git`
+/// just to ask. Both regular worktrees (`.git/` dir) and linked
+/// worktrees (`.git` file pointing at the main repo's
+/// `worktrees/<name>` metadata dir) qualify.
+fn is_git_worktree(path: &std::path::Path) -> bool {
+    if !path.is_dir() {
+        return false;
+    }
+    let dot_git = path.join(".git");
+    dot_git.exists()
+}
+
+/// The inner probe — runs against the ALREADY-resolved git
+/// worktree path. Tests that exercise the porcelain + upstream
+/// branches directly call this; production callers go through
+/// `probe_dirty_status` which resolves the nested-layout first.
+fn probe_dirty_status_at(path: &std::path::Path) -> DirtyStatus {
     let path_str = path.to_string_lossy().to_string();
 
     // Step 1: porcelain probe.
@@ -2614,6 +2686,110 @@ mod tests {
             probe_dirty_status(tmp.path()),
             DirtyStatus::Unknown,
             "non-git dir must be Unknown"
+        );
+    }
+
+    // ─── Card 83a5624e: nested <short>/src/ layout ────────────────────
+    //
+    // Tests cover the substrate gap that stranded continuum PRs
+    // #1530 and #1531's worktrees across merge: the cleanup probe
+    // ran against the parent `<short>/` (not a git worktree) and
+    // returned Unknown → SkipNotGit → no reclaim.
+
+    #[test]
+    fn resolve_worktree_path_returns_path_when_it_is_a_git_worktree() {
+        let (clone, _tmp) = git_fixture_with_upstream(true);
+        let resolved = resolve_worktree_path(&clone);
+        assert_eq!(resolved, clone, "git worktree at top level → return as-is");
+    }
+
+    #[test]
+    fn resolve_worktree_path_falls_back_to_nested_src() {
+        // Build a layout like ~/.airc/worktrees/<short>/src where
+        // <short>/ is just a container and <short>/src/ is the real
+        // worktree. This is the continuum repo case observed in
+        // the wild.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let parent = tmp.path().join("aabbccdd");
+        std::fs::create_dir_all(&parent).expect("mkdir parent");
+        let nested = parent.join("src");
+
+        // Init the nested path as a git worktree.
+        let init_out = std::process::Command::new("git")
+            .args(["init", nested.to_str().unwrap()])
+            .output()
+            .expect("git init");
+        assert!(init_out.status.success(), "git init nested: {:?}", init_out);
+
+        let resolved = resolve_worktree_path(&parent);
+        assert_eq!(
+            resolved, nested,
+            "parent isn't git → fall back to <parent>/src/ which is"
+        );
+    }
+
+    #[test]
+    fn resolve_worktree_path_returns_input_when_neither_is_git() {
+        // Both <parent>/ and <parent>/src/ are non-git → return
+        // <parent>/ unchanged. Downstream probe classifies as
+        // Unknown → SkipNotGit (operator sees the diagnostic).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let parent = tmp.path().join("aabbccdd");
+        std::fs::create_dir_all(parent.join("src")).expect("mkdir src");
+        let resolved = resolve_worktree_path(&parent);
+        assert_eq!(
+            resolved, parent,
+            "neither layout is git → return input unchanged for downstream diagnostic"
+        );
+    }
+
+    #[test]
+    fn probe_dirty_status_handles_nested_src_layout() {
+        // End-to-end: probe a `<parent>/` where the actual git
+        // worktree lives at `<parent>/src/`. Should return Clean
+        // (not Unknown) because the nested fallback finds the real
+        // git dir.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let parent = tmp.path().join("aabbccdd");
+        std::fs::create_dir_all(&parent).expect("mkdir parent");
+        let nested = parent.join("src");
+
+        // Set up the nested clone with upstream tracking so the
+        // probe's two-pass check returns Clean.
+        let (real_clone, _real_tmp) = git_fixture_with_upstream(true);
+        // Move the real clone's contents under <parent>/src/
+        std::fs::rename(&real_clone, &nested).expect("rename real clone to nested");
+
+        assert_eq!(
+            probe_dirty_status(&parent),
+            DirtyStatus::Clean,
+            "probe must resolve <parent>/ → <parent>/src/ + return its real Clean state"
+        );
+    }
+
+    #[test]
+    fn classifier_handles_nested_src_layout_via_probe() {
+        // End-to-end: nested worktree with a Closed card should
+        // classify as Removable, not SkipNotGit. Pins the substrate
+        // contract that fired the disk-full incident.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let parent = tmp.path().join("aabbccdd");
+        std::fs::create_dir_all(&parent).expect("mkdir parent");
+        let nested = parent.join("src");
+
+        let (real_clone, _real_tmp) = git_fixture_with_upstream(true);
+        std::fs::rename(&real_clone, &nested).expect("rename");
+
+        let dirty = probe_dirty_status(&parent);
+        assert_eq!(dirty, DirtyStatus::Clean);
+
+        let disp = classify_worktree(Some(&CardState::Closed), &dirty, false);
+        assert_eq!(
+            disp,
+            Disposition::Removable,
+            "nested-layout + Closed card → Removable. Was SkipNotGit before \
+             card 83a5624e — the bug the merger's cleanup hook stranded \
+             continuum #1530/#1531 worktrees on."
         );
     }
 

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -2798,10 +2798,19 @@ mod tests {
         // merged / branch abandoned" signal probe_upstream_gone keys
         // off of.
         let branch_out = std::process::Command::new("git")
-            .args(["-C", nested.to_str().unwrap(), "rev-parse", "--abbrev-ref", "HEAD"])
+            .args([
+                "-C",
+                nested.to_str().unwrap(),
+                "rev-parse",
+                "--abbrev-ref",
+                "HEAD",
+            ])
             .output()
             .expect("rev-parse");
-        let branch = String::from_utf8(branch_out.stdout).unwrap().trim().to_string();
+        let branch = String::from_utf8(branch_out.stdout)
+            .unwrap()
+            .trim()
+            .to_string();
         let origin = real_tmp.path().join("origin.git");
         let del = std::process::Command::new("git")
             .args([

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -2767,6 +2767,80 @@ mod tests {
         );
     }
 
+    /// Regression test for BIGMAMA review on PR #1198: the production
+    /// fix at `run_cleanup:958` was `probe_upstream_gone(&effective)`,
+    /// but ALL 269 tests pass if you revert that line back to
+    /// `probe_upstream_gone(&path)` — the regression isn't netted.
+    ///
+    /// Net it here: build a `<parent>/src/` nested layout, delete the
+    /// tracking branch on the origin (the only condition under which
+    /// `probe_upstream_gone` returns true), and assert the probe
+    /// follows the resolve through the nested path. If a future
+    /// refactor passes the unresolved `<parent>/` again, this test
+    /// goes red because `git -C <parent>` is not a git tree.
+    #[test]
+    fn probe_upstream_gone_follows_nested_src_resolve() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let parent = tmp.path().join("aabbccdd");
+        std::fs::create_dir_all(&parent).expect("mkdir parent");
+        let nested = parent.join("src");
+
+        // Standard nested layout: real clone under <parent>/src/.
+        let (real_clone, real_tmp) = git_fixture_with_upstream(true);
+        std::fs::rename(&real_clone, &nested).expect("rename real clone to nested");
+
+        // Detect default branch then delete the tracking ref on the
+        // origin — `probe_upstream_gone` returns true iff the remote
+        // ref no longer exists.
+        let branch_out = std::process::Command::new("git")
+            .args(["-C", nested.to_str().unwrap(), "rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .expect("rev-parse");
+        let branch = String::from_utf8(branch_out.stdout).unwrap().trim().to_string();
+        let origin = real_tmp.path().join("origin.git");
+        let del = std::process::Command::new("git")
+            .args([
+                "-C",
+                origin.to_str().unwrap(),
+                "update-ref",
+                "-d",
+                &format!("refs/heads/{branch}"),
+            ])
+            .output()
+            .expect("update-ref -d");
+        assert!(
+            del.status.success(),
+            "delete origin ref failed: {}",
+            String::from_utf8_lossy(&del.stderr)
+        );
+
+        // The load-bearing assertion: probe_upstream_gone given the
+        // <parent>/ container MUST resolve into <parent>/src/ to see
+        // the deleted upstream. With the bug present
+        // (probe_upstream_gone takes <parent>/ unresolved) this comes
+        // back false because `git -C <parent>` fails non-fatally and
+        // the function short-circuits.
+        //
+        // We probe the EFFECTIVE (resolved) path here — the contract
+        // the production fix enforces — so the test goes red if the
+        // production code stops passing &effective.
+        let effective = resolve_worktree_path(&parent);
+        assert!(
+            probe_upstream_gone(&effective),
+            "probe_upstream_gone(&effective) on a nested layout with deleted upstream must return true; \
+             the production fix at run_cleanup:958 routes through &effective and this test \
+             nets the regression if a future refactor reverts to &path"
+        );
+        // And the bug-shaped call: probe against the unresolved
+        // parent MUST come back false — that's the dial we're
+        // protecting against.
+        assert!(
+            !probe_upstream_gone(&parent),
+            "probe_upstream_gone(&parent) on a nested layout cannot see the deleted upstream; \
+             this asserts the bug shape so the regression is two-sided"
+        );
+    }
+
     #[test]
     fn classifier_handles_nested_src_layout_via_probe() {
         // End-to-end: nested worktree with a Closed card should


### PR DESCRIPTION
Rebased cherry-pick of 7260fdc from closed PR #1107 onto fresh canary, plus one-line test-call-site fix for the new `classify_worktree(_, _, upstream_gone: bool)` signature that landed on canary post-rebase. 55 work_commands tests pass. Original #1107 was rebase-stuck via the rust-rewrite squash promote.