### PR TITLE
feat(peer): airc peer prune --stale-after-hours (operator override)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -1349,6 +1349,14 @@ pub enum PeerAction {
         /// only prints what it WOULD evict (dry run).
         #[arg(long)]
         apply: bool,
+        /// Staleness grace window, in hours: an untrusted peer absent
+        /// from the fresh registry is evicted only once its last_seen is
+        /// older than this. Recently-contacted peers inside the window
+        /// are kept (a momentary registry-snapshot lag is not death).
+        /// Omit for the 1-hour default; `0` evicts every absent untrusted
+        /// peer immediately (no grace).
+        #[arg(long)]
+        stale_after_hours: Option<u64>,
     },
 }
 

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1874,7 +1874,25 @@ pub async fn run_peer_remove(
 /// unauthenticated, hermetic scope, unreachable rendezvous, or an empty
 /// registry), this prunes NOTHING — pruning against an unknown/empty live
 /// set would wrongly evict live peers.
-pub async fn run_peer_prune(home: &Path, apply: bool) -> Result<(), Box<dyn std::error::Error>> {
+/// Seam #3.2 operator override for the peer-prune staleness grace
+/// window. Omit (`None`) → the 1h substrate default; an explicit value
+/// (incl. `0` = no grace, evict every absent untrusted peer) tunes how
+/// long an absent untrusted peer is kept before it ages out. A CLI flag,
+/// not an env var — substrate thresholds are explicit, not ambiently
+/// tuned. `saturating_mul` so an absurd hour count can't overflow.
+fn resolve_stale_after_ms(stale_after_hours: Option<u64>) -> u64 {
+    match stale_after_hours {
+        Some(hours) => hours.saturating_mul(3_600_000),
+        None => airc_lib::DEFAULT_PEER_STALE_AFTER_MS,
+    }
+}
+
+pub async fn run_peer_prune(
+    home: &Path,
+    apply: bool,
+    stale_after_hours: Option<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let stale_after_ms = resolve_stale_after_ms(stale_after_hours);
     let enrolled = airc_trust::load(home).await?;
     if enrolled.is_empty() {
         println!("(no enroled peers — nothing to prune)");
@@ -1914,12 +1932,17 @@ pub async fn run_peer_prune(home: &Path, apply: bool) -> Result<(), Box<dyn std:
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0);
-    let verdicts = airc_lib::classify_peer_prune(
-        &enrolled_triples,
-        &live_ids,
-        now_ms,
-        airc_lib::DEFAULT_PEER_STALE_AFTER_MS,
+    println!(
+        "peer prune: staleness grace = {} hour(s){}",
+        stale_after_ms / 3_600_000,
+        if stale_after_hours.is_some() {
+            " (operator override)"
+        } else {
+            " (default)"
+        }
     );
+    let verdicts =
+        airc_lib::classify_peer_prune(&enrolled_triples, &live_ids, now_ms, stale_after_ms);
     let mut to_evict = Vec::new();
     for verdict in &verdicts {
         match verdict.action {
@@ -2298,6 +2321,31 @@ mod tests {
         assert!(
             lines.contains("1 peer(s) enroled"),
             "count reflects the trust store only, not the legacy file: {lines}"
+        );
+    }
+
+    /// what this catches: the peer-prune staleness override math.
+    /// `None` must resolve to the substrate default (not 0 — which would
+    /// silently disable the grace window); an explicit hour count must
+    /// convert to ms; `0` must mean no grace; and an absurd value must
+    /// saturate rather than overflow-panic.
+    #[test]
+    fn resolve_stale_after_ms_maps_override_hours() {
+        assert_eq!(
+            resolve_stale_after_ms(None),
+            airc_lib::DEFAULT_PEER_STALE_AFTER_MS,
+            "omitting the flag uses the substrate default"
+        );
+        assert_eq!(resolve_stale_after_ms(Some(2)), 7_200_000, "2h → ms");
+        assert_eq!(
+            resolve_stale_after_ms(Some(0)),
+            0,
+            "0 hours = no grace (evict every absent untrusted peer)"
+        );
+        assert_eq!(
+            resolve_stale_after_ms(Some(u64::MAX)),
+            u64::MAX,
+            "absurd hour count saturates, never overflow-panics"
         );
     }
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -431,7 +431,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     .await
             }
             PeerAction::List { json } => commands::run_peer_list(&home, json).await,
-            PeerAction::Prune { apply } => commands::run_peer_prune(&home, apply).await,
+            PeerAction::Prune {
+                apply,
+                stale_after_hours,
+            } => commands::run_peer_prune(&home, apply, stale_after_hours).await,
         },
 
         Command::Peers => commands::run_peer_list(&home, false).await,


### PR DESCRIPTION
## Seam #3.2 follow-up — operator override for the prune staleness window

Closes the review nit from #1195: `DEFAULT_PEER_STALE_AFTER_MS` (1h grace) was hardcoded with no operator override. Adds `--stale-after-hours <N>` to `airc peer prune`:

- **omit** → 1h substrate default (behavior unchanged)
- **`N`** → grace window of N hours
- **`0`** → no grace (evict every absent untrusted peer immediately)

A **CLI flag, not an env var** — substrate thresholds stay explicit, not ambiently tuned (per the concurrency style guide). The active window prints in the plan (`staleness grace = N hour(s) (default|operator override)`) so the operator sees what gate was applied.

Resolution extracted into a pure `resolve_stale_after_ms` helper + unit test: `None`→default, `Some(2)`→7_200_000, `Some(0)`→0, `Some(MAX)` saturates (no overflow panic).

### Validation
`cargo check/test/clippy/fmt -p airc-cli` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)