### PR TITLE
feat(monitor): airc monitor attach reconnects on stream drop (receive-resilience)

### DIFF
--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -30,6 +30,23 @@ enum MonitorFrame {
     },
 }
 
+/// Receive-resilience (2026-06-14 disconnect): the first re-attach after
+/// a healthy stream drops waits this long. Short so a transient IPC blip
+/// or a fast daemon restart recovers near-instantly.
+const RECONNECT_INITIAL_BACKOFF_MS: u64 = 250;
+
+/// Cap on the reconnect backoff: a daemon that stays down is retried at
+/// most this often, so the monitor neither hammers a dead socket nor
+/// goes permanently dark.
+const RECONNECT_MAX_BACKOFF_MS: u64 = 5_000;
+
+/// One exponential-backoff step for the attach reconnect loop: double,
+/// capped at [`RECONNECT_MAX_BACKOFF_MS`]. `saturating_mul` so a runaway
+/// value can never overflow-panic.
+fn next_reconnect_backoff_ms(current: u64) -> u64 {
+    current.saturating_mul(2).min(RECONNECT_MAX_BACKOFF_MS)
+}
+
 pub(crate) async fn run(
     home: &Path,
     _my_name: &str,
@@ -64,34 +81,66 @@ pub(crate) async fn run(
         let tx = tx.clone();
         tokio::spawn(async move {
             let client = DaemonClient::new(socket);
-            let mut request = AttachRequest::new(channel, start);
-            if coalesce_backlog {
-                request = request.with_coalesced_backlog();
-            }
-            let mut stream = match client.attach(request).await {
-                Ok(stream) => stream,
-                Err(_) => return,
-            };
-            while let Ok(Some(response)) = read_frame::<_, Response>(&mut stream).await {
-                match response {
-                    Response::Event { envelope } => match decode_wire_event(envelope) {
-                        Ok(event) => {
-                            if tx.send(MonitorFrame::Event(Box::new(event))).await.is_err() {
+            // Receive-resilience (2026-06-14 disconnect): re-attach when the
+            // stream drops instead of giving up. The original was a single
+            // attach that died PERMANENTLY when its daemon was killed/
+            // restarted (cargo/test churn, idle self-exit), taking the whole
+            // live tail dark with no recovery. We now reconnect with bounded
+            // backoff and only stop when the consumer (the merge channel) is
+            // gone — then there is nothing left to feed. On reconnect we
+            // resume the LIVE tail; events that occurred during the gap are
+            // not replayed (cursor-resume is a follow-up). Same-scope daemon
+            // restarts reuse the deterministic socket path, so the re-attach
+            // lands on the respawned daemon; a cross-SCOPE flip is seam #1's
+            // domain, out of scope here.
+            let mut backoff_ms = RECONNECT_INITIAL_BACKOFF_MS;
+            loop {
+                let mut request = AttachRequest::new(channel, start);
+                if coalesce_backlog {
+                    request = request.with_coalesced_backlog();
+                }
+                if let Ok(mut stream) = client.attach(request).await {
+                    // A healthy attach resets the backoff so the next
+                    // transient blip recovers fast.
+                    backoff_ms = RECONNECT_INITIAL_BACKOFF_MS;
+                    while let Ok(Some(response)) = read_frame::<_, Response>(&mut stream).await {
+                        match response {
+                            Response::Event { envelope } => match decode_wire_event(envelope) {
+                                Ok(event) => {
+                                    if tx.send(MonitorFrame::Event(Box::new(event))).await.is_err()
+                                    {
+                                        return;
+                                    }
+                                }
+                                // A single undecodable frame must not kill
+                                // the tail — drop the stream and re-attach.
+                                Err(_) => break,
+                            },
+                            Response::AttachCursorAdvanced { skipped, .. }
+                                if tx
+                                    .send(MonitorFrame::CatchUpSummary { channel, skipped })
+                                    .await
+                                    .is_err() =>
+                            {
                                 return;
                             }
+                            _ => {}
                         }
-                        Err(_) => return,
-                    },
-                    Response::AttachCursorAdvanced { skipped, .. }
-                        if tx
-                            .send(MonitorFrame::CatchUpSummary { channel, skipped })
-                            .await
-                            .is_err() =>
-                    {
-                        return;
                     }
-                    _ => {}
+                    // Stream ended (EOF / read error) — fall through to
+                    // reconnect.
                 }
+                // Consumer gone → nothing to feed → stop. Otherwise back off
+                // and re-attach (covers both attach-failed and stream-dropped).
+                if tx.is_closed() {
+                    return;
+                }
+                eprintln!(
+                    "airc: event stream for channel {} dropped — reconnecting in {}ms",
+                    channel.0, backoff_ms
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                backoff_ms = next_reconnect_backoff_ms(backoff_ms);
             }
         });
     }
@@ -201,6 +250,29 @@ mod tests {
     use airc_core::{Body, ClientId, EventId, Headers, PeerId, RoomId, TranscriptEvent};
 
     use super::*;
+
+    /// what this catches: the reconnect backoff must double from the
+    /// initial step and saturate at the cap — never overflow-panic and
+    /// never exceed the cap (which would let a dead daemon go un-retried
+    /// for an unbounded time, the exact "permanent dark" this card ends).
+    #[test]
+    fn reconnect_backoff_doubles_then_caps() {
+        assert_eq!(next_reconnect_backoff_ms(RECONNECT_INITIAL_BACKOFF_MS), 500);
+        assert_eq!(next_reconnect_backoff_ms(500), 1_000);
+        assert_eq!(next_reconnect_backoff_ms(2_000), 4_000);
+        // 4_000 * 2 = 8_000, capped to the 5_000 max.
+        assert_eq!(next_reconnect_backoff_ms(4_000), RECONNECT_MAX_BACKOFF_MS);
+        // At/above the cap it stays pinned.
+        assert_eq!(
+            next_reconnect_backoff_ms(RECONNECT_MAX_BACKOFF_MS),
+            RECONNECT_MAX_BACKOFF_MS
+        );
+        // Saturating: an absurd value can't overflow-panic.
+        assert_eq!(
+            next_reconnect_backoff_ms(u64::MAX),
+            RECONNECT_MAX_BACKOFF_MS
+        );
+    }
 
     #[test]
     fn body_text_reads_plain_chat_shape() {

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -94,19 +94,29 @@ pub(crate) async fn run(
             // lands on the respawned daemon; a cross-SCOPE flip is seam #1's
             // domain, out of scope here.
             let mut backoff_ms = RECONNECT_INITIAL_BACKOFF_MS;
+            // The configured `start` (Live or FromTranscriptStart) applies to
+            // the FIRST attach only. After we've attached once, reconnects
+            // resume LIVE — re-requesting the full transcript on every
+            // reconnect would re-flood it event-by-event, and (combined with
+            // the decode-error drop below) a single poisoned historical frame
+            // would wedge the loop into a permanent re-replay that never
+            // advances (sentinel BLOCK on #1203). Trade-off: a first attach
+            // that drops mid-backlog forfeits the un-replayed remainder rather
+            // than re-flooding; per-attach cursor-resume (replay only the gap)
+            // is the follow-up.
+            let mut attach_start = start;
             loop {
-                let mut request = AttachRequest::new(channel, start);
+                let mut request = AttachRequest::new(channel, attach_start);
                 if coalesce_backlog {
                     request = request.with_coalesced_backlog();
                 }
                 if let Ok(mut stream) = client.attach(request).await {
-                    // A healthy attach resets the backoff so the next
-                    // transient blip recovers fast.
-                    backoff_ms = RECONNECT_INITIAL_BACKOFF_MS;
+                    let mut got_frame = false;
                     while let Ok(Some(response)) = read_frame::<_, Response>(&mut stream).await {
                         match response {
                             Response::Event { envelope } => match decode_wire_event(envelope) {
                                 Ok(event) => {
+                                    got_frame = true;
                                     if tx.send(MonitorFrame::Event(Box::new(event))).await.is_err()
                                     {
                                         return;
@@ -116,17 +126,27 @@ pub(crate) async fn run(
                                 // the tail — drop the stream and re-attach.
                                 Err(_) => break,
                             },
-                            Response::AttachCursorAdvanced { skipped, .. }
+                            Response::AttachCursorAdvanced { skipped, .. } => {
+                                got_frame = true;
                                 if tx
                                     .send(MonitorFrame::CatchUpSummary { channel, skipped })
                                     .await
-                                    .is_err() =>
-                            {
-                                return;
+                                    .is_err()
+                                {
+                                    return;
+                                }
                             }
                             _ => {}
                         }
                     }
+                    // Reset backoff only when this attach actually delivered a
+                    // frame — a daemon that accepts then immediately closes
+                    // (flap) must keep escalating, not pin at the 250ms floor.
+                    if got_frame {
+                        backoff_ms = RECONNECT_INITIAL_BACKOFF_MS;
+                    }
+                    // One attach done → never re-request the backlog.
+                    attach_start = AttachStart::Live;
                     // Stream ended (EOF / read error) — fall through to
                     // reconnect.
                 }


### PR DESCRIPTION
## Receive-resilience — `airc monitor attach` survives daemon churn

**Motivated by today's live disconnect.** The persistent monitor (my Mac-coordination receive channel) went *permanently* dark when its daemon was killed by cargo/test churn. Root cause: each per-channel attach task `return`ed the instant its stream dropped — a single attach with **no reconnect**. When all channel tasks died, the merge channel closed and the whole live tail ended, with no recovery until manually re-armed.

### Fix
Wrap the attach + drain in a **bounded-backoff reconnect loop**:
- dropped stream (EOF/read error) or failed attach → back off and re-attach, instead of `return`.
- only stop when the **consumer** (the merge mpsc) is gone — then there's nothing to feed.
- a **healthy attach resets** the backoff (transient blip recovers in 250ms); a daemon that stays down is retried at most every 5s.
- a single undecodable frame now drops+reattaches instead of killing the tail (was `return`).

### Scope / limitations (called out honestly)
- Reconnect resumes the **LIVE** tail; events during the gap are **not** replayed — cursor-resume is a follow-up.
- Same-scope daemon restarts reuse the deterministic socket path, so the re-attach lands on the respawned daemon. A cross-**scope** identity flip (the `ce8b9074`→`ac873384` case from today's post-mortem) is **seam #1's** domain, out of scope here.

### Test
Pure `next_reconnect_backoff_ms` helper + unit test (doubles, saturates at the 5s cap, no overflow-panic). The reconnect loop itself is integration-level (needs a daemon harness) — noted.

### Why it matters beyond my comms
This is the grid lesson in miniature: **event streams must survive node churn.** Today it was "my monitor broke"; under lane coordination it's "the grid's event bus must not go dark when a node restarts."

🤖 Generated with [Claude Code](https://claude.com/claude-code)