### PR TITLE
test(cli): pin --home/--here parse-time conflict (closes #1204 review advisory)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -879,6 +879,28 @@ mod tests {
         assert_eq!(explicit_home_override(None, false, cwd), None);
     }
 
+    /// what this catches: `--home` and `--here` are mutually exclusive at
+    /// the CLAP layer (`conflicts_with = "home"`). The resolver test above
+    /// proves the value precedence, but not the parse-time guard — a
+    /// future arg-id rename could silently drop the `conflicts_with` and
+    /// let both be passed, with the resolver then quietly preferring
+    /// `--home` while the user thinks `--here` took effect. This pins the
+    /// guard: passing both must be a hard parse error.
+    #[test]
+    fn home_and_here_conflict_at_parse_time() {
+        use super::Cli;
+        use clap::Parser;
+
+        // Both flags → parse error (clap exit code 2 class).
+        assert!(
+            Cli::try_parse_from(["airc", "--home", "/x", "--here", "init"]).is_err(),
+            "--home and --here together must be rejected, not silently merged"
+        );
+        // Each alone parses fine (guard isn't over-broad).
+        assert!(Cli::try_parse_from(["airc", "--here", "init"]).is_ok());
+        assert!(Cli::try_parse_from(["airc", "--home", "/x", "init"]).is_ok());
+    }
+
     #[test]
     fn default_home_uses_enclosing_airc_scope() {
         let root = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
Closes the one non-blocking advisory from the #1204 (`--here`) review: the resolver-precedence unit test didn't pin the clap `conflicts_with = "home"` guard itself. A future arg-id rename could silently drop it, letting `--home /x --here` both pass while the resolver quietly prefers `--home` — the user thinks `--here` took effect, it didn't.

`home_and_here_conflict_at_parse_time`: both flags → hard parse error; each alone → ok (guard not over-broad). Test-only, no logic change. Validated locally (Windows): test ✓, fmt ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)