### PR TITLE
fix(node): containerized airc nodes converge AND hold two-way room conversations

### DIFF
--- a/crates/airc-cli/src/client_id.rs
+++ b/crates/airc-cli/src/client_id.rs
@@ -77,9 +77,22 @@ struct ProcessRow {
 
 #[cfg(unix)]
 fn read_process(pid: u32) -> Result<Option<ProcessRow>, Box<dyn Error>> {
-    let output = Command::new("ps")
+    let output = match Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "ppid=,command="])
-        .output()?;
+        .output()
+    {
+        Ok(output) => output,
+        // `ps` is not installed (slim containers ship without procps).
+        // Client-id detection is BEST-EFFORT — it tags a frame with the
+        // calling agent when discoverable, nothing more. A missing probe
+        // must degrade to "can't detect" (Ok(None)), NEVER propagate os
+        // error 2 up through runtime_headers() and break EVERY send/msg
+        // (the bug that left containerized nodes able to converge but
+        // unable to deliver a single frame). Genuinely unexpected `ps`
+        // failures still surface.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
     if !output.status.success() {
         return Ok(None);
     }
@@ -151,6 +164,33 @@ mod tests {
                 );
             });
         });
+    }
+
+    // what this catches: client-id detection is best-effort — when `ps`
+    // is absent (slim containers ship without procps) current_client_id()
+    // must return Ok(None), NOT propagate os error 2. That ENOENT
+    // propagated through runtime_headers() and broke EVERY send/msg —
+    // containerized nodes converged but could not deliver a single frame.
+    // Empty PATH makes `ps` unresolvable on any runner, so this is
+    // deterministic regardless of whether the host has procps.
+    #[cfg(unix)]
+    #[test]
+    fn missing_ps_degrades_to_ok_not_os_error_2() {
+        temp_env::with_vars(
+            [
+                ("AIRC_CLIENT_ID", None::<&str>),
+                ("CODEX_THREAD_ID", None),
+                ("CLAUDE_CODE_SESSION_ID", None),
+                ("CLAUDE_SESSION_ID", None),
+                ("PATH", Some("")),
+            ],
+            || {
+                assert!(
+                    current_client_id().is_ok(),
+                    "ps-absent must degrade to Ok, never break the send path with os error 2"
+                );
+            },
+        );
     }
 
     #[test]

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1426,10 +1426,7 @@ pub async fn run_daemon(
 /// connections live on its adapter, so re-opening per tick would sever
 /// them. Inbound sink + forwarder link are installed once in
 /// `run_daemon` before this spawns.
-fn spawn_route_refresh(
-    state: Arc<DaemonState>,
-    airc: Airc,
-) -> tokio::task::JoinHandle<()> {
+fn spawn_route_refresh(state: Arc<DaemonState>, airc: Airc) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
             refresh_routes_once(&airc)

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1278,7 +1278,11 @@ pub async fn run_daemon(
         // (subnet/reachability gate at the dialer) will eliminate the
         // 3s for off-LAN peers; until then the truth is visible in the
         // recorded peer_dial_failures, not hidden in comments.
-        let lan_ip = crate::network_commands::detect_lan_ip();
+        // Card 7e3c9a1f: `advertise_lan_ip()` honors the `AIRC_ADVERTISE_IP`
+        // handoff (host launcher / container entrypoint) before host
+        // auto-detection — so a containerized node advertises a routable
+        // endpoint instead of nothing (detect_lan_ip bails in a container).
+        let lan_ip = crate::network_commands::advertise_lan_ip();
         let tailscale_ip = crate::network_commands::detect_tailscale_ip();
         if lan_ip.is_none() && tailscale_ip.is_none() {
             eprintln!(

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1175,11 +1175,29 @@ pub async fn run_daemon(
         airc_lib::RoutedForwarderConfig::default(),
     );
 
+    // Card 7e3c9a1f: ONE daemon LAN handle, shared across the listener,
+    // the dialer (route refresh), and the forwarder. Accepted AND dialed
+    // connections then live on the SAME `LanTcpAdapter` connection map, so
+    // receive + delivery-ack + routed-forward all see the same peers.
+    // Previously the listener handle (registry task) and the route-refresh
+    // handle were SEPARATE `Airc::open`s with separate adapters: a
+    // connection accepted on the listener was invisible to the dialer
+    // handle, so reverse-direction room broadcast — forwarding/acking back
+    // over an inbound-accepted connection — failed with "lan-tcp adapter
+    // has no connected peers". The inbound sink and the forwarder link are
+    // installed ONCE here; the listener bind stays in the registry task
+    // (gated), the dial happens in route refresh — all on this one handle.
+    let daemon_airc = Airc::open(&state.home).await?;
+    daemon_airc.set_inbound_frame_sink(Arc::new(airc_lib::RouterInboundBridge::new(
+        state.router.clone(),
+        state.coordinator_store.clone(),
+    )));
+    routed_forwarder.add_link(daemon_airc.clone()).await;
+
     // Card 625abe6d slice 2: the daemon, not the operator, keeps
     // routes alive. Spawn the periodic route-discovery refresh before
     // the accept loop blocks; it exits on the same shutdown notifier.
-    let route_refresh_task =
-        spawn_route_refresh(home.to_path_buf(), state.clone(), routed_forwarder.clone());
+    let route_refresh_task = spawn_route_refresh(state.clone(), daemon_airc.clone());
 
     // KEYSTONE (card a134b370-10b1-49c6-aa42-e1a05446e887): spawn the
     // account-registry publish/refresh loop alongside the IPC accept
@@ -1197,7 +1215,10 @@ pub async fn run_daemon(
     // holds internally (same lost-wakeup discipline as `server::run`).
     let registry_state = state.clone();
     let registry_home = state.home.clone();
-    let registry_forwarder = routed_forwarder.clone();
+    // Card 7e3c9a1f: the registry task binds the LAN listener on the SHARED
+    // daemon handle (one adapter for accept + dial + forward) rather than
+    // opening its own — that split was the reverse-broadcast bug.
+    let registry_airc = daemon_airc.clone();
     let registry_handle = tokio::spawn(async move {
         // HERMETIC GATE (card d793c242): test/temp daemons inherit the
         // operator's working gh auth, so without this gate they publish
@@ -1210,32 +1231,13 @@ pub async fn run_daemon(
             eprintln!("airc daemon: account-registry loop DISABLED — {block}");
             return;
         }
-        let airc = match Airc::open(&registry_home).await {
-            Ok(airc) => airc,
-            Err(error) => {
-                eprintln!(
-                    "airc daemon: account-registry loop disabled — could not open handle: {error}"
-                );
-                return;
-            }
-        };
-
-        // Card 4132f48c: this handle owns the daemon's LAN listener, so
-        // every inbound cross-machine frame is ingested HERE. Route it
-        // into the daemon's owner-core router — the transcript every
-        // attached scope reads — instead of this handle's private store
-        // (the store-split bug: durable in `~/.airc` events, invisible
-        // to every operator scope). Must be installed BEFORE the
-        // listener binds so no frame can race past it.
-        airc.set_inbound_frame_sink(Arc::new(airc_lib::RouterInboundBridge::new(
-            registry_state.router.clone(),
-            registry_state.coordinator_store.clone(),
-        )));
-
-        // Card 1998f6cb: this handle's LAN connections (accepted by
-        // the listener below) are routes the forwarder may reuse for
-        // outbound traversal of router publishes.
-        registry_forwarder.add_link(airc.clone()).await;
+        // Card 7e3c9a1f: the SHARED daemon handle (opened in `run_daemon`).
+        // Its inbound sink (Card 4132f48c: inbound cross-machine frames
+        // ingest into the owner-core router, not a private store) and its
+        // forwarder link (Card 1998f6cb) are installed ONCE in `run_daemon`
+        // before this task spawns; the route-refresh loop dials on this
+        // same handle, so accept + dial connections share one adapter.
+        let airc = registry_airc;
 
         // Endpoint-in-beacon (the second half of same-account
         // auto-discovery): bind a LAN listener on THIS handle so its
@@ -1414,78 +1416,34 @@ pub async fn run_daemon(
 /// daemon restarts re-establish routes with zero operator action,
 /// instead of waiting for someone to run `airc transport health`.
 ///
-/// The `Airc` handle is opened lazily and then kept for the daemon's
-/// lifetime: LAN connections established by discovery dials live on
-/// the handle's adapter, so re-opening per tick would sever them on
-/// every refresh. Lazy-with-retry (rather than open-or-die at spawn)
-/// is the no-single-point-of-failure posture: a transient store
-/// failure at boot must neither take the IPC daemon down nor
-/// permanently disable route refresh — the open is retried, loudly,
-/// on every tick until it succeeds.
+/// Card 7e3c9a1f: the route-refresh loop dials on the SHARED daemon
+/// handle (the same one that binds the listener and is registered with
+/// the forwarder). Accepted (inbound) and dialed (outbound) connections
+/// therefore live on ONE `LanTcpAdapter` connection map, so the
+/// forwarder and the delivery-ack path can reach a peer regardless of
+/// which side opened the link — the fix for reverse-direction room
+/// broadcast. The handle is kept for the daemon's lifetime: LAN
+/// connections live on its adapter, so re-opening per tick would sever
+/// them. Inbound sink + forwarder link are installed once in
+/// `run_daemon` before this spawns.
 fn spawn_route_refresh(
-    home: PathBuf,
     state: Arc<DaemonState>,
-    forwarder: airc_lib::RoutedForwarder,
+    airc: Airc,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let handle: tokio::sync::Mutex<Option<Airc>> = tokio::sync::Mutex::new(None);
-        let refresh_state = state.clone();
         airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
-            refresh_routes_once(&home, &handle, &refresh_state, &forwarder)
+            refresh_routes_once(&airc)
         })
         .await;
     })
 }
 
-/// One periodic route refresh: ensure the daemon's substrate handle
-/// is open, run discovery (which dials stored peer endpoints
-/// outbound, 3s-bounded each), and surface every failure through the
-/// daemon's diagnostic sink — loud, never silent. Failures never
-/// propagate: the loop's next tick is the retry path (self-heal
-/// doctrine, card 625abe6d).
-async fn refresh_routes_once(
-    home: &Path,
-    handle: &tokio::sync::Mutex<Option<Airc>>,
-    state: &Arc<DaemonState>,
-    forwarder: &airc_lib::RoutedForwarder,
-) {
-    let mut guard = handle.lock().await;
-    if guard.is_none() {
-        match Airc::open(home).await {
-            Ok(airc) => {
-                // Card 4132f48c: discovery dials open LAN connections
-                // whose inbound frames are ingested on THIS handle —
-                // same router bridge as the listener handle, so a frame
-                // arriving on either (or both — `publish_if_new` dedups
-                // by event_id) lands in the machine transcript scopes
-                // read.
-                airc.set_inbound_frame_sink(Arc::new(airc_lib::RouterInboundBridge::new(
-                    state.router.clone(),
-                    state.coordinator_store.clone(),
-                )));
-                // Card 1998f6cb: the stored-endpoint dials this handle
-                // makes are routes the forwarder reuses for outbound
-                // traversal of router publishes.
-                forwarder.add_link(airc.clone()).await;
-                *guard = Some(airc)
-            }
-            Err(error) => {
-                StderrJsonDiagnosticSink.emit(
-                    DiagnosticEvent::error(
-                        DiagnosticComponent::Daemon,
-                        DiagnosticCode::RouteRefreshFailed,
-                        "route refresh could not open the substrate handle; retrying next interval",
-                    )
-                    .with_field("home", home.display())
-                    .with_field("error", error),
-                );
-                return;
-            }
-        }
-    }
-    let Some(airc) = guard.as_ref() else {
-        return;
-    };
+/// One periodic route refresh: run discovery on the shared daemon handle
+/// (which dials stored peer endpoints outbound, 3s-bounded each), and
+/// surface every failure through the diagnostic sink — loud, never
+/// silent. Failures never propagate: the loop's next tick is the retry
+/// path (self-heal doctrine, card 625abe6d).
+async fn refresh_routes_once(airc: &Airc) {
     match airc.refresh_route_discovery().await {
         Ok(snapshot) => {
             for failure in &snapshot.peer_dial_failures {

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -41,6 +41,49 @@ fn is_routable_lan_ipv4(ip: Ipv4Addr) -> bool {
     !ip.is_loopback() && !ip.is_unspecified()
 }
 
+/// The IPv4 the daemon should ADVERTISE as its dialable LAN endpoint.
+///
+/// Card 7e3c9a1f — the container-reachability seam. `detect_lan_ip()`
+/// deliberately bails inside a container (its only "LAN" is the Docker
+/// bridge, unreachable from any other machine — the `172.18.x` ghost
+/// flood). But a containerized node still needs to advertise SOMETHING
+/// routable: on the same Docker network its bridge IP IS reachable by
+/// sibling containers, and for the real grid the HOST (where detection
+/// works) hands in the host's LAN/Tailscale endpoint. `AIRC_ADVERTISE_IP`
+/// is that explicit handoff — the launcher or the node entrypoint sets
+/// it; the daemon advertises it verbatim. Absent the override we fall
+/// back to host auto-detection, so non-container hosts are unchanged.
+///
+/// This is the "advertise the host endpoints you were given" half of the
+/// container fix — the route/dial layer is untouched; only the source of
+/// the advertised address changes.
+pub(crate) fn advertise_lan_ip() -> Option<Ipv4Addr> {
+    if let Some(ip) = env_advertise_ip() {
+        return Some(ip);
+    }
+    detect_lan_ip()
+}
+
+/// Parse `AIRC_ADVERTISE_IP` into an IPv4, or `None` when unset/blank.
+/// A SET-but-unparseable value is loud (no silent fallback): we warn and
+/// return `None` so the caller falls through to auto-detection rather
+/// than silently advertising garbage.
+fn env_advertise_ip() -> Option<Ipv4Addr> {
+    match std::env::var("AIRC_ADVERTISE_IP") {
+        Ok(raw) if !raw.trim().is_empty() => match raw.trim().parse::<Ipv4Addr>() {
+            Ok(ip) => Some(ip),
+            Err(_) => {
+                eprintln!(
+                    "airc daemon: AIRC_ADVERTISE_IP='{raw}' is not a valid IPv4 address — \
+                     ignoring it and falling back to host auto-detection"
+                );
+                None
+            }
+        },
+        _ => None,
+    }
+}
+
 /// True when this process is running inside an OCI container (Docker,
 /// Podman, containerd). Two cheap probes:
 ///   - `/.dockerenv` exists (Docker writes it on container start)
@@ -115,6 +158,31 @@ mod tests {
     /// dev macOS/Linux that has neither /.dockerenv nor a docker
     /// cgroup. (This test running green is itself the negative-case
     /// proof.)
+    // what this catches: the container-reachability seam — an explicit
+    // AIRC_ADVERTISE_IP handoff is advertised verbatim, BEFORE (and
+    // instead of) host auto-detection. Without this a containerized node
+    // (detect_lan_ip → None) advertises no endpoint and never converges.
+    #[test]
+    fn advertise_ip_env_override_is_honored() {
+        temp_env::with_var("AIRC_ADVERTISE_IP", Some("10.0.0.5"), || {
+            assert_eq!(advertise_lan_ip(), Some(Ipv4Addr::new(10, 0, 0, 5)));
+        });
+    }
+
+    // what this catches: a SET-but-garbage override is NOT advertised as a
+    // bogus endpoint (no silent fallthrough to a malformed addr); it is
+    // ignored so the caller auto-detects. Pins env_advertise_ip directly
+    // to stay hermetic (advertise_lan_ip's fallback hits the network).
+    #[test]
+    fn advertise_ip_invalid_or_blank_is_ignored() {
+        temp_env::with_var("AIRC_ADVERTISE_IP", Some("not-an-ip"), || {
+            assert_eq!(env_advertise_ip(), None);
+        });
+        temp_env::with_var("AIRC_ADVERTISE_IP", Some("   "), || {
+            assert_eq!(env_advertise_ip(), None);
+        });
+    }
+
     #[test]
     fn in_container_returns_false_on_real_host() {
         // The CI runners + dev hosts this test runs on are not OCI

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1004,15 +1004,34 @@ impl Airc {
     pub(crate) async fn sync_account_peer_registry(&self) -> Result<(), AircError> {
         let peers = load_peer_registries(&self.inner.home, &self.inner.wire_root).await?;
         for peer in peers {
-            self.inner
-                .registry
-                .enrol(
-                    peer.peer_id,
-                    0,
-                    peer.pubkey_bytes()
-                        .map_err(|e| AircError::Crypto(e.to_string()))?,
-                )
-                .map_err(|e| AircError::Crypto(e.to_string()))?;
+            // Card 7e3c9a1f: a single malformed peer record (bad base64,
+            // wrong pubkey length, invalid Ed25519 point — version skew or
+            // a poisoned store row) must NOT abort the whole sync and leave
+            // EVERY other peer un-enrolled. This runs on the daemon's
+            // route-refresh path (`refresh_route_discovery`) before dialing,
+            // so a `?`-propagated error would skip ALL dials for the tick.
+            // Match the per-peer tolerance the dialer already has: skip the
+            // bad record loudly, enrol the rest.
+            let pubkey = match peer.pubkey_bytes() {
+                Ok(pubkey) => pubkey,
+                Err(error) => {
+                    tracing::warn!(
+                        peer_id = %peer.peer_id,
+                        %error,
+                        "skipping peer with undecodable pubkey during verifier sync \
+                         (other peers still enrolled)"
+                    );
+                    continue;
+                }
+            };
+            if let Err(error) = self.inner.registry.enrol(peer.peer_id, 0, pubkey) {
+                tracing::warn!(
+                    peer_id = %peer.peer_id,
+                    %error,
+                    "skipping peer the verifier registry rejected during sync \
+                     (other peers still enrolled)"
+                );
+            }
         }
         Ok(())
     }

--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -63,6 +63,21 @@ impl Airc {
     /// an inbound port. Dial failures are recorded on the snapshot,
     /// never swallowed.
     pub async fn refresh_route_discovery(&self) -> Result<RouteDiscoverySnapshot, AircError> {
+        // Card 7e3c9a1f: refresh this handle's in-memory verifier registry
+        // from the trust store BEFORE dialing. The daemon's route-refresh
+        // handle is opened ONCE at startup; peers that converge later (via
+        // the account-registry gist import) land in the trust STORE but
+        // not in this long-lived handle's `PeerKeyRegistry`. Dialing such a
+        // peer then fails the TLS handshake — "server cert pubkey is not
+        // enrolled" — so no connection forms and the RoutedForwarder has no
+        // link to deliver room broadcasts over. (`lan-send` sidesteps this
+        // by opening a fresh handle per call, which is why direct sends
+        // worked while room broadcast did not.) This is the same refresh
+        // the non-daemon send path already does in `send_frame_to_room`;
+        // the registry is a shared `Arc`, so the live LAN adapter's
+        // verifier sees the newly-enrolled pubkeys.
+        self.sync_account_peer_registry().await?;
+
         let peer_dial_failures = self.dial_stored_peer_endpoints().await?;
 
         let endpoints = self.route_endpoints()?;

--- a/docker/airc-node.Dockerfile
+++ b/docker/airc-node.Dockerfile
@@ -41,6 +41,27 @@ RUN apt-get update \
  && apt-get update && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /airc /usr/local/bin/airc
+# Card 7e3c9a1f: the node entrypoint runs `airc daemon` as the container's
+# long-lived process and advertises a routable endpoint. Inlined via
+# heredoc (the build context excludes docker/ — see .dockerignore — so a
+# COPY from there can't see it; this keeps the entrypoint self-contained).
+#   Bug 1: `airc join` returns without leaving a daemon, so nothing
+#          advertises. The container must RUN the daemon — this is it.
+#   Bug 2: detect_lan_ip() bails inside a container; AIRC_ADVERTISE_IP is
+#          the explicit handoff of the routable endpoint (host launcher
+#          passes the host LAN/Tailscale IP; same-host convergence falls
+#          back to this container's own bridge IP, reachable by siblings).
+COPY <<'EOF' /usr/local/bin/airc-node-run
+#!/bin/sh
+set -eu
+if [ -z "${AIRC_ADVERTISE_IP:-}" ]; then
+  AIRC_ADVERTISE_IP="$(hostname -i 2>/dev/null | awk '{print $1}')"
+  export AIRC_ADVERTISE_IP
+fi
+echo "airc-node: advertising endpoint IP ${AIRC_ADVERTISE_IP:-<none>} (override via AIRC_ADVERTISE_IP)"
+exec airc daemon
+EOF
+RUN chmod +x /usr/local/bin/airc-node-run
 
 # Each node is its own "machine": a distinct HOME → distinct ~/.airc
 # identity + local wire + governor state. The harness overrides HOME per
@@ -50,6 +71,8 @@ RUN useradd -m -d /node node && chown -R node:node /node
 USER node
 WORKDIR /node
 
-# A node does nothing until told to `airc join`; the harness drives it.
-# Keep the container alive so the harness can exec convergence steps.
-CMD ["airc", "version"]
+# Default: run the daemon (Card 7e3c9a1f) as the container's long-lived
+# process so the node advertises a routable endpoint and stays alive for
+# the harness / operator to `docker exec airc-node airc join` + drive it.
+# Override the CMD (e.g. `sleep infinity`) for a passive container.
+CMD ["airc-node-run"]

--- a/docker/airc-node.Dockerfile
+++ b/docker/airc-node.Dockerfile
@@ -31,7 +31,7 @@ RUN cargo build --release -p airc-cli \
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      ca-certificates git curl gnupg \
+      ca-certificates git curl gnupg procps \
  # GitHub CLI (the rendezvous/registry transport — the ONLY gh path,
  # governed by airc's request counter).
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/docker/mesh-converge.sh
+++ b/docker/mesh-converge.sh
@@ -68,14 +68,23 @@ SNAP_READY=1
 echo "== bring up $N isolated nodes on one account =="
 docker network create "$NET" >/dev/null
 for i in $(seq 1 "$N"); do
+  # Card 7e3c9a1f: NO `sleep infinity` override — the image's default CMD
+  # runs `airc daemon` (the node's long-lived process), which self-detects
+  # its container IP into AIRC_ADVERTISE_IP and advertises it. Without a
+  # running daemon advertising a routable endpoint, `registry sync` refuses
+  # to publish (endpoint-less #33 guard) and nodes never converge.
   docker run -d --name "airc-node-$i" --network "$NET" \
     -e GH_TOKEN="$TOKEN" -e HOME=/node \
     -e AIRC_GH_MAX_REQUESTS_PER_MIN=500 \
-    "$IMAGE" sleep infinity >/dev/null
-  echo "  node-$i up"
+    "$IMAGE" >/dev/null
+  echo "  node-$i up (daemon)"
 done
 
 run() { docker exec "airc-node-$1" sh -lc "$2" 2>&1; }
+
+# Give each daemon a moment to bind its listener + record the advertised
+# endpoint before we subscribe and publish.
+sleep 3
 
 echo "== each node: airc join, capture its OWN peer_id =="
 declare -a ID


### PR DESCRIPTION
Makes two airc nodes — each in its own Linux container — converge, see each other, and exchange room messages **both directions**. Root-caused and proven entirely in clean containers (no SAC, no native binary), via `docker/mesh-converge.sh` + direct delivery tests. Five stacked fixes, each proven before the next:

## The fixes
1. **Run the daemon + advertise a routable endpoint.** `airc join` left no persistent daemon, and in a container `detect_lan_ip()` bails (bridge IP), so the daemon advertised nothing → `registry sync` refused → no route. Node image now runs `airc daemon`; `AIRC_ADVERTISE_IP` hands it the host-reachable endpoint (host launcher / self-detect). → **CONVERGED** (2 and 3 nodes).
2. **Send path `os error 2`.** `client_id::current_client_id()` shelled out to `ps` (absent in the slim image) → broke every send. Now degrades gracefully + `procps` in the image. → `airc msg` works; `lan-send` delivers with a typed ack.
3. **Verifier refresh before dialing.** The daemon's dialing handle never re-loaded the trust store, so freshly-converged peers' certs were rejected ("server cert pubkey is not enrolled") → no connection → forwarder had no link. `refresh_route_discovery` now syncs the verifier first. → **forward-direction room broadcast delivers.**
4. **Daemon LAN handle unification.** The daemon ran separate handles (listener vs dialer), each with its own adapter/connection map, so an accepted connection was invisible to the forwarding/ack handle ("lan-tcp adapter has no connected peers"). Now ONE shared `daemon_airc` owns the adapter; listener + dialer + forwarder all share it. → **reverse-direction room broadcast delivers.**

## Proof
- `mesh-converge.sh 2` / `3` → **CONVERGED** (all-see-all).
- `airc lan-send` cross-container → typed delivery ack, receiver persists + inbox shows it.
- Bidirectional `airc msg`: node-1's message lands in node-2's `inbox` AND node-2's lands in node-1's, over lan-tcp. **Two containerized peers hold a full two-way conversation.**
- 285 airc-cli unit tests + 5 network_commands + client_id regression tests pass.

## The reachability model this lands
Host carries the network (LAN always; an overlay — Tailscale now → our own relay later, behind a provider seam — only when cross-LAN). The container carries airc, publishes its port, advertises the host's reachable endpoint. Agents/personas reach in via `docker exec`. No native binary, no SAC, no Tailscale-in-Docker.

## Follow-ups (non-blocking, separate)
- **Endpoint-TTL prune + isolated test gh account** — the shared account-registry gist accumulates stale beacons (recycled container IPs → cert-mismatch dials). Pairs with #1206 (dial quarantine).
- **Cross-machine proof** (BIGMAMA ↔ Mac/Toby over LAN then Tailscale) once a signed-binary path exists (Windows SAC blocks unsigned local builds).
- **`OverlayProvider` seam** so Tailscale stays swappable (anti-vendor-lock).

Pairs with #1206 (dial-failure quarantine). Both off `canary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)