### PR TITLE
fix(monitor): `airc monitor attach --my-name` optional (was required, ignored)

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -857,6 +857,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 // defaults to true; flipped to false by user only
                 // when they want event-by-event replay (audit case).
                 let live_only = from_now && !include_backlog;
+                // `my_name` is optional and unused by attach (the daemon
+                // owns identity); accepted for backward compat.
+                let my_name = my_name.unwrap_or_default();
                 monitor::run_attach(&home, &my_name, live_only, coalesce_backlog).await
             }
         },

--- a/crates/airc-cli/src/monitor/cli.rs
+++ b/crates/airc-cli/src/monitor/cli.rs
@@ -22,9 +22,12 @@ pub enum MonitorAction {
 
     /// Attach to the Rust event stream without owning transport.
     Attach {
-        /// Current local display name.
+        /// Current local display name. Optional and currently unused by
+        /// `attach` (the daemon already owns identity); accepted for
+        /// backward compatibility with callers that still pass it. A
+        /// fresh agent can simply run `airc monitor attach`.
         #[arg(long)]
-        my_name: String,
+        my_name: Option<String>,
         /// **Card 7d5b6a65.** Subscribe from the LIVE EDGE — only
         /// events published strictly after the attach call return.
         ///
@@ -51,4 +54,40 @@ pub enum MonitorAction {
         #[arg(long, default_value_t = true)]
         coalesce_backlog: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        action: MonitorAction,
+    }
+
+    // regression: `airc monitor attach` previously REQUIRED --my-name and
+    // then ignored it (unused in attach::run), failing fresh users with a
+    // clap exit-2. It must now parse with no flags. (audit F7)
+    #[test]
+    fn attach_parses_without_my_name() {
+        let cli = TestCli::try_parse_from(["airc", "attach"])
+            .expect("`airc monitor attach` must parse with no flags");
+        match cli.action {
+            MonitorAction::Attach { my_name, .. } => assert!(my_name.is_none()),
+            other => panic!("expected Attach, got {other:?}"),
+        }
+    }
+
+    // backward compat: callers that still pass --my-name keep working.
+    #[test]
+    fn attach_still_accepts_my_name() {
+        let cli = TestCli::try_parse_from(["airc", "attach", "--my-name", "M5"])
+            .expect("`airc monitor attach --my-name X` must still parse");
+        match cli.action {
+            MonitorAction::Attach { my_name, .. } => assert_eq!(my_name.as_deref(), Some("M5")),
+            other => panic!("expected Attach, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## What

`airc monitor attach` **required** `--my-name`, then **ignored it** — the param is `_my_name`, unused in `attach::run` (the daemon already owns identity). A fresh agent running `airc monitor attach` hit a cryptic clap **exit-2** for a value that does nothing.

Make it `Option<String>`:
- `airc monitor attach` now works **flagless**.
- `--my-name X` still accepted (backward compat).
- Regression tests for both parse paths.

## Scope change (force-pushed)

This branch originally also rerouted `airc join` through `run_attach` to "fix a hang." **Reverted.** Adversarial review + a live experiment proved canary's `join_feed` works fine on a healthy daemon — the join "hang" was the **daemon being starved while blocking on dead-peer dials**, not `join_feed`. Rerouting regressed unread-catch-up, cross-sandbox socket resolution, and join stdout format. The real root cause is filed as **#1210** (daemon-side). This PR is now just the clean, no-regression `--my-name` fix.

## Local gate (green)
- `cargo fmt --all --check` clean
- `cargo clippy -p airc-cli --release` clean
- `cargo test -p airc-cli --bin airc` → **292 passed, 0 failed**