### PR TITLE
feat(cli): add `ipc-endpoint` subcommand — restore the socket-path contract Continuum depends on

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -756,6 +756,16 @@ pub enum Command {
     /// package version.)
     Version,
 
+    /// Print the resolved daemon IPC socket path for this scope and exit.
+    ///
+    /// The canonical answer to "where does my daemon bind?". Consumers
+    /// (Continuum's airc discovery) call this to locate the socket
+    /// without re-deriving airc's path convention or hand-setting an env
+    /// var — airc owns the path, callers ask for it. Resolves the path
+    /// only; does NOT require the daemon to be running (callers probe
+    /// liveness separately via `status`/`ping`).
+    IpcEndpoint,
+
     /// Fast-forward the installed source checkout and refresh the
     /// installed `airc` binary + skills from that source.
     #[command(visible_aliases = ["upgrade", "pull"])]
@@ -899,6 +909,25 @@ mod tests {
         // Each alone parses fine (guard isn't over-broad).
         assert!(Cli::try_parse_from(["airc", "--here", "init"]).is_ok());
         assert!(Cli::try_parse_from(["airc", "--home", "/x", "init"]).is_ok());
+    }
+
+    // what this catches: the `ipc-endpoint` subcommand silently vanishing
+    // or being renamed. Continuum's airc discovery shells out to exactly
+    // `airc ipc-endpoint` to locate the daemon socket; when this command
+    // was never shipped, discovery returned Unreachable and personas never
+    // spawned. This pins the kebab-case spelling to the contract.
+    #[test]
+    fn ipc_endpoint_subcommand_parses() {
+        use super::{Cli, Command};
+        use clap::Parser;
+
+        let parsed = Cli::try_parse_from(["airc", "ipc-endpoint"])
+            .expect("`airc ipc-endpoint` must parse — Continuum discovery depends on it");
+        assert!(
+            matches!(parsed.command, Command::IpcEndpoint),
+            "ipc-endpoint must map to Command::IpcEndpoint, got {:?}",
+            parsed.command
+        );
     }
 
     #[test]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -503,6 +503,15 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         Command::Version => commands::run_version(),
 
+        Command::IpcEndpoint => {
+            // Resolve-only: print the canonical socket path airc would
+            // bind for this scope. No daemon required (callers probe
+            // liveness via `status`/`ping`). This is the contract
+            // Continuum's airc discovery depends on.
+            println!("{}", cli::default_socket_path_in(&home).display());
+            Ok(())
+        }
+
         Command::Update => update_commands::run_update(&home, cli::default_socket_path_in(&home)),
 
         Command::Doctor { fix, health } => doctor::run_doctor(&home, fix, health).await,


### PR DESCRIPTION
## Why

Continuum's airc discovery (`continuum-core/src/airc/discovery.rs:138`) shells out to **`airc ipc-endpoint`** to locate the daemon IPC socket — without re-deriving airc's path convention or forcing an operator to hand-set `$AIRC_DAEMON_SOCKET`. That command was referenced as airc **#1095** ("add the command or upgrade airc") but **was never actually shipped** (`git log -S"ipc-endpoint"` in `crates/` = empty).

Consequence: discovery returned `Unreachable` → `AircDiscovery` never went `Healthy` → **personas never spawned onto the grid.** This was a load-bearing piece of "personas can't talk over airc."

## What

Expose the existing canonical resolver `cli::default_socket_path_in(home)` as the `ipc-endpoint` subcommand.

- **Resolve-only**: prints the path airc *would* bind; does NOT require the daemon running (callers probe liveness via `status`/`ping`).
- **One source of truth**: airc owns the socket-path convention; callers ask for it instead of duplicating the `airc-machine-<account-key>-v<N>.sock` derivation. No env var.

## Verification

```
$ airc ipc-endpoint
/Users/joel/.airc/runtime/airc-machine-2012e155624a8250-v5.sock   # matches the live socket
$ airc ping --socket "$(airc ipc-endpoint)"
pong
```

Regression guard `ipc_endpoint_subcommand_parses` pins the kebab-case spelling to the contract so the command can't silently vanish/rename again — that's the exact bug class that caused this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)