### PR TITLE
fix(cli): airc network truly read-only — peek_default_room (no lazy subscribe/publish)

### DIFF
--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -283,7 +283,12 @@ fn now_ms() -> u64 {
 pub async fn run_network(home: &Path, show_all_stale: bool) -> Result<(), Box<dyn Error>> {
     let airc = Airc::open(home).await?;
     let me = airc.peer_id();
-    let current = airc.current_room().await?;
+    // READ-ONLY: `default_room` (not `current_room`) — `current_room`
+    // lazily subscribes to #general + publishes a presence beacon on a
+    // fresh scope, which would make this "no mutation" inspection
+    // command mutate. `None` here = no default room subscribed yet.
+    // (#1217 cross-review, M5.)
+    let current = airc.peek_default_room().await?;
 
     // ONE machine-account store (§3.3) — the same events.sqlite the
     // daemon's coordinator writes beacons into. Reading it shows what
@@ -323,11 +328,14 @@ pub async fn run_network(home: &Path, show_all_stale: bool) -> Result<(), Box<dy
             .unwrap_or_default()
     };
 
+    let room_display = match current.as_ref() {
+        Some(room) => format!("#{}", room.name),
+        None => "(none — run `airc join`)".to_string(),
+    };
     println!(
-        "mesh: {identity}    you: {me_short}    default room: #{room}",
+        "mesh: {identity}    you: {me_short}    default room: {room_display}",
         identity = identity.as_str(),
         me_short = short(&me.to_string()),
-        room = current.name,
     );
     println!();
 
@@ -397,11 +405,21 @@ pub async fn run_network(home: &Path, show_all_stale: bool) -> Result<(), Box<dy
     // by default? This is the signal that was missing when BIGMAMA sent
     // into #cambriantech while every Mac was on #general.
     println!();
-    let convergence = convergence_status(&current.name, &other_live_channels);
+    let Some(room) = current.as_ref() else {
+        // No default room on this scope yet (read-only: we did NOT
+        // create one). Nothing to converge against until the operator
+        // joins a room.
+        println!(
+            "\u{2022} no default room on this scope yet — run `airc join` to pick one, \
+             then peers in it show as reachable."
+        );
+        return Ok(());
+    };
+    let convergence = convergence_status(&room.name, &other_live_channels);
     if convergence.reachable {
         println!(
-            "\u{2713} reachable: your default room #{room} has live peer(s) in it.",
-            room = current.name,
+            "\u{2713} reachable: your default room #{room_name} has live peer(s) in it.",
+            room_name = room.name,
         );
     } else if convergence.other_peer_count == 0 {
         println!(
@@ -410,8 +428,8 @@ pub async fn run_network(home: &Path, show_all_stale: bool) -> Result<(), Box<dy
         );
     } else {
         println!(
-            "\u{26a0} CONVERGENCE: your default room #{room} has 0 OTHER reachable peers.",
-            room = current.name,
+            "\u{26a0} CONVERGENCE: your default room #{room_name} has 0 OTHER reachable peers.",
+            room_name = room.name,
         );
         println!(
             "   {count} live peer(s) are on: {rooms}",

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1290,6 +1290,26 @@ impl Airc {
         Ok(room)
     }
 
+    /// Read-only peek at the default room: returns it if one is already
+    /// subscribed, or `None` on a fresh scope — WITHOUT the lazy
+    /// subscribe + `set_default` + `save` + `publish_presence` +
+    /// identity-card emit that [`current_room`] (and its alias
+    /// [`default_room`]) perform on first use.
+    ///
+    /// Inspection commands whose contract is "no mutation" (e.g. `airc
+    /// network`) MUST use this: merely *looking* at the mesh must never
+    /// create a subscription or publish a presence beacon as a side
+    /// effect. Regression for the #1217 cross-review (M5): `airc
+    /// network` on a fresh scope was silently subscribing to #general
+    /// and publishing a beacon via `current_room`, violating its own
+    /// read-only contract.
+    pub async fn peek_default_room(&self) -> Result<Option<Room>, AircError> {
+        let set = self.subscription_set().await?;
+        Ok(set
+            .default_subscription()
+            .map(|subscription| subscription.as_room()))
+    }
+
     pub(crate) fn event_store(&self) -> &dyn EventStore {
         self.inner.store.as_ref()
     }

--- a/crates/airc-lib/tests/default_room_read_only.rs
+++ b/crates/airc-lib/tests/default_room_read_only.rs
@@ -1,0 +1,52 @@
+//! Regression for the #1217 cross-review (M5): `airc network` advertised
+//! a "no mutation" contract but read its default room via
+//! `Airc::current_room`, which on a fresh scope LAZILY subscribes to
+//! #general, sets it default, persists it, and publishes a presence
+//! beacon. Merely *inspecting* the mesh must never mutate it.
+//!
+//! `Airc::peek_default_room` is the read-only accessor the inspection
+//! path now uses. This pins the invariant: on a fresh scope it returns `None`
+//! and persists NOTHING — so a second handle on the same home still sees
+//! no default room. (Against `current_room`, the reopen would find the
+//! lazily-created #general subscription, failing the assert.)
+
+use airc_lib::Airc;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn default_room_is_read_only_and_persists_nothing_on_fresh_scope() {
+    let dir = tempdir().unwrap();
+    let machine = dir.path().join("machine/.airc");
+    let wire = dir.path().join("wire");
+
+    let airc = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("open fresh scope");
+
+    // Fresh scope has no default room — and asking for it must not
+    // create one.
+    assert!(
+        airc.peek_default_room()
+            .await
+            .expect("default_room")
+            .is_none(),
+        "fresh scope must have no default room"
+    );
+
+    // The load-bearing assertion: nothing was persisted. A brand-new
+    // handle on the SAME home still sees no default room. If
+    // `default_room` had gone through `current_room` (subscribe +
+    // set_default + save), this reopened handle would find #general.
+    drop(airc);
+    let reopened = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("reopen same home");
+    assert!(
+        reopened
+            .peek_default_room()
+            .await
+            .expect("default_room after reopen")
+            .is_none(),
+        "default_room must not persist a subscription — read-only contract (#1217)"
+    );
+}


### PR DESCRIPTION
## #1217 cross-review fix-forward (caught by M5)

`airc network` advertised "no mutation, no publish" but read its default room via `current_room()`, which on a **fresh scope** lazily subscribes to #general, sets it default, persists it, **publishes a presence beacon**, and emits an identity card. So merely *inspecting* the mesh mutated it — a real contract violation in shipped code (#1217).

### Fix
- New `Airc::peek_default_room() -> Option<Room>`: read-only via the existing `subscription_set()` loader (`load_or_init`, pure read). Returns `None` on a fresh scope; never subscribes or publishes. (The existing `default_room()` is just an alias for the mutating `current_room()`.)
- `run_network` uses `peek_default_room`; on `None` it prints "no default room — run `airc join`" instead of lazily creating one.
- **Regression test** (`tests/default_room_read_only.rs`): on a fresh scope `peek_default_room` returns `None` **and persists nothing** — a reopened handle still sees no default room (`current_room` would have left #general behind).

### Process note
Verified against the **SHA, not the chat**: a peer claimed this was already fixed+merged; it was not on canary (tip `ae53791` still called `current_room` at `network_commands.rs:286`). Caught by diffing.

### Validation
`cargo fmt --check` clean, `clippy -p airc-lib -p airc-cli --all-targets` clean (0 warnings), `default_room_read_only` 1 passed, `network_commands` 12 passed. Off canary `ae53791`.

cc @M5 for the cross-review you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)