### PR TITLE
fix(ci): green canary — stale send-receipt test + dead integration-suite job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,10 @@ name: ci
 #   clean-install-macos   macos install.sh + airc doctor + smoke test
 #   clean-install-windows windows install.ps1 + airc doctor (PS-side)
 #
-# Plus on canary/main only (skipped on PR): integration-suite runs the
-# full test/integration.sh on ubuntu — the most thorough gate, but
-# expensive (real gh-gist scenarios + ~5min runtime).
+# Integration coverage now lives in the Rust suite: the per-crate
+# `crates/*/tests/` integration tests run under the `cargo test` jobs on
+# every PR + push. The old bash `test/integration.sh` gate was deleted
+# in the Rust cutover (#1173, demolition #864); its job is gone too.
 #
 # The clean-install jobs are the "guarantee installs work from zero"
 # gate Joel asked for (2026-04-28). They run on a stock runner image
@@ -219,29 +220,3 @@ jobs:
           New-Item -ItemType Directory -Force -Path $env:AIRC_DIR | Out-Null
           Copy-Item -Recurse -Force * $env:AIRC_DIR
           & "$env:AIRC_DIR\install.ps1"
-
-  integration-suite:
-    # Heavy gate: the full test/integration.sh, including scenarios that
-    # hit real gh-gists. Runs on canary/main pushes, NOT on PRs (rate
-    # limits + flaky network). When canary→main bundle PRs come up, this
-    # already-green status on the canary tip is the signal that cross-
-    # branch validation passed.
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Stage + install (real install path)
-        run: |
-          mkdir -p $HOME/.airc/src
-          cp -r . $HOME/.airc/src/
-          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc/src bash install.sh
-
-      - name: Run integration suite
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          # Tests that need real gists self-skip without gh auth. The
-          # remaining ~85% of the suite covers the local-only scenarios
-          # that catch the lion's share of regressions.
-          bash test/integration.sh

--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -101,24 +101,37 @@ fn events_list_json_emits_machine_readable_contract() {
 }
 
 #[test]
-fn send_receipt_distinguishes_zero_paired_peers_without_lying_about_delivery() {
+fn send_receipt_distinguishes_zero_enrolled_peers_without_lying_about_delivery() {
     let workspace = common::daemon_tempdir();
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
     let output = run_ok(&home, &["send", "wire-only send"]);
 
-    // With zero paired remote peers, the message IS still delivered
+    // With zero enrolled remote peers, the message IS still delivered
     // to any same-machine scope tailing the channel (post-#857
-    // cross-process broadcast fix). The receipt must not lie about
-    // non-delivery.
+    // cross-process broadcast fix). The receipt must be HONEST: it must
+    // not imply confirmed remote delivery, and it must not claim
+    // non-delivery either (local tailers still receive it). This mirrors
+    // the canonical `format_send_receipt` invariants unit-tested in
+    // `commands.rs` — the verb is "queued to" (not the old delivery-
+    // implying "sent to"), the count is framed as "enrolled" (not
+    // "paired"), and the local-tailer fan-out is surfaced.
     assert!(
-        output.contains("sent to"),
-        "receipt must lead with 'sent to' — not the old 'stored locally' wording, got: {output}"
+        output.contains("queued to"),
+        "receipt must use the honest verb 'queued to' — not the old delivery-implying 'sent to', got: {output}"
     );
     assert!(
-        output.contains("0 paired remote peers"),
-        "receipt must surface zero-paired-remote-peers without claiming non-delivery, got: {output}"
+        output.contains("0 enrolled remote peer(s)"),
+        "receipt must surface zero enrolled remote peers without claiming non-delivery, got: {output}"
+    );
+    assert!(
+        !output.contains("sent to"),
+        "receipt must NOT imply confirmed delivery via 'sent to', got: {output}"
+    );
+    assert!(
+        output.contains("tailing this channel on this machine"),
+        "receipt must surface that same-machine tailers still receive it, got: {output}"
     );
     assert!(
         !output.contains("not delivered"),


### PR DESCRIPTION
## Two real failures, red on every canary push since the Rust cutover

Surfaced while triaging #1224's CI (the failing `cargo test` there was NOT #1224's code — it was this pre-existing canary red).

### 1. Stale send-receipt integration test
`events_commands::send_receipt_distinguishes_zero_paired_peers…` asserted the **old** receipt contract:
- `output.contains("sent to")`  ❌
- `output.contains("0 paired remote peers")`  ❌

The receipt wording was deliberately changed to the honest form because `"sent to N peers"` falsely implied confirmed remote delivery (the "false it works" bug):

```
queued to general (<uuid>) — 0 enrolled remote peer(s); any scope tailing this channel on this machine will receive it.
```

The unit tests in `commands.rs` (`format_send_receipt`) were updated; this integration test was missed. Realigned to the canonical invariants (verb `queued to`, count `enrolled`, local-tailer fan-out surfaced) and renamed to the `enrolled` vocabulary.

### 2. Dead `integration-suite` CI job
The job runs `bash test/integration.sh`, but that 5269-line bash suite was **deleted** in the Rust cutover (#1173, demolition #864). The job has failed with **exit 127 (no such file)** on every canary/main push since. Integration coverage now lives in the per-crate `crates/*/tests/` suites under the `cargo test` jobs (exactly where the test in #1 runs), so the dead job provided zero unique coverage. Removed it + fixed the stale header comment.

## Validation
- `cargo fmt -p airc-cli --check` ✅
- `cargo clippy -p airc-cli --tests -- -D warnings` ✅
- `cargo test -p airc-cli --test events_commands` → 3/3 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)