### PR TITLE
fix(route): dial peers concurrently in route refresh — kills doctor --health hang

### DIFF
--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -5,6 +5,7 @@
 //! to make normal local/LAN operation work.
 
 use airc_core::PeerId;
+use futures::stream::StreamExt;
 
 use crate::error::AircError;
 use crate::route::health::TransportHealthSample;
@@ -20,6 +21,20 @@ use crate::Airc;
 /// poisoned registry document could plant tarpit endpoints
 /// deliberately (#1120 sentinel blocking-2).
 const PEER_DIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Max peers dialed CONCURRENTLY in one route refresh. Per-peer dials
+/// are independent, so the refresh wall-clock is `~max(single-peer
+/// cost)` rather than the SUM of every unreachable peer's
+/// `PEER_DIAL_TIMEOUT` — the serial sum hung `doctor --health` (and
+/// any send-path refresh) for tens of seconds on a real account with
+/// dozens of enrolled peers (41 on BIGMAMA: ~15 offline × 3s ≈ 45s).
+/// Bounded so a large grid does not open hundreds of sockets at once.
+const DIAL_CONCURRENCY: usize = 16;
+
+/// One peer's route-dial result: the endpoints that failed to dial and
+/// the endpoints skipped for being in backoff. Named so the concurrent
+/// collection below doesn't trip clippy's `type_complexity` gate.
+type PeerDialOutcome = (Vec<PeerDialFailure>, Vec<PeerDialSkip>);
 
 /// Card 625abe6d slice 1 — a stored peer endpoint that could not be
 /// dialed during discovery. Surfaced on the snapshot (and printed by
@@ -132,9 +147,7 @@ impl Airc {
     /// skew the operator must see), per the no-silent-fallback rule.
     /// CONNECTION failures are not errors — offline peers are a normal
     /// mesh state — but every failed attempt is returned for display.
-    async fn dial_stored_peer_endpoints(
-        &self,
-    ) -> Result<(Vec<PeerDialFailure>, Vec<PeerDialSkip>), AircError> {
+    async fn dial_stored_peer_endpoints(&self) -> Result<PeerDialOutcome, AircError> {
         // Both registries: the machine-account wire root (where
         // account-registry import writes) FIRST, then the scope's own
         // store (where the CLI's `peer add --endpoint` writes).
@@ -214,92 +227,132 @@ impl Airc {
             }
         }
 
-        for peer_id in order {
-            let Some(endpoints) = merged.get(&peer_id) else {
-                continue;
+        // Per-peer dial work in first-seen (wire-root) order. Each
+        // peer's endpoints are walked in stored (cost) order, breaking
+        // on the first connect — that INNER walk stays serial (the
+        // cost-order + stop-on-success contract the stored_endpoint_dial
+        // tests pin). What is now CONCURRENT is ACROSS peers: dialing
+        // peer B must not wait on peer A's 3s timeout (see
+        // DIAL_CONCURRENCY — the serial-sum hang this fixes).
+        let dial_list: Vec<(PeerId, Vec<RouteEndpoint>)> = order
+            .into_iter()
+            .filter_map(|peer_id| merged.remove(&peer_id).map(|eps| (peer_id, eps)))
+            .collect();
+
+        // Dial peers concurrently (bounded), then merge results in the
+        // original peer order so operator display stays stable. `&self`
+        // is shared immutably across the dials; connect_lan clones an
+        // Arc adapter and every mutation (quarantine map, transport
+        // health) sits behind its own brief lock, so concurrent dials to
+        // distinct peers do not race.
+        let mut dialed: Vec<(usize, PeerDialOutcome)> =
+            futures::stream::iter(dial_list.into_iter().enumerate())
+                .map(|(idx, (peer_id, endpoints))| async move {
+                    (idx, self.dial_one_peer(peer_id, endpoints, now_ms).await)
+                })
+                .buffer_unordered(DIAL_CONCURRENCY)
+                .collect()
+                .await;
+        dialed.sort_by_key(|(idx, _)| *idx);
+        for (_, (peer_failures, peer_skips)) in dialed {
+            failures.extend(peer_failures);
+            skips.extend(peer_skips);
+        }
+        Ok((failures, skips))
+    }
+
+    /// Dial ONE peer's stored endpoints in cost order, breaking on the
+    /// first connect. Returns this peer's dial failures + quarantine
+    /// skips. Extracted from `dial_stored_peer_endpoints` so the
+    /// per-peer dials run concurrently; the inner endpoint walk here
+    /// stays serial because cost-order + stop-on-first-success is the
+    /// pinned contract.
+    async fn dial_one_peer(
+        &self,
+        peer_id: PeerId,
+        endpoints: Vec<RouteEndpoint>,
+        now_ms: u64,
+    ) -> PeerDialOutcome {
+        let mut failures = Vec::new();
+        let mut skips = Vec::new();
+        for endpoint in &endpoints {
+            let addr = match endpoint {
+                RouteEndpoint::LanTcp { addr } | RouteEndpoint::TailscaleTcp { addr } => *addr,
+                // Relay/UDP/WebRTC/Reticulum dialing lands in later
+                // slices; recording them as failures here would be noise
+                // about unimplemented transports, not signal about
+                // unreachable peers. Variants enumerated, not wildcarded,
+                // per the production no-silent-fallback clippy gate: a
+                // FUTURE endpoint variant must force this match to be
+                // revisited, not silently fall into "skip" (the wildcard
+                // slipped past #1120's review because the merge-push CI
+                // run was hand-cancelled — caught by the #1121 sentinel).
+                RouteEndpoint::Udp { .. }
+                | RouteEndpoint::Relay { .. }
+                | RouteEndpoint::Reticulum { .. }
+                | RouteEndpoint::WebRtcSignaling { .. } => continue,
             };
-            for endpoint in endpoints {
-                let addr = match endpoint {
-                    RouteEndpoint::LanTcp { addr } | RouteEndpoint::TailscaleTcp { addr } => *addr,
-                    // Relay/UDP/WebRTC/Reticulum dialing lands in later
-                    // slices; recording them as failures here would be
-                    // noise about unimplemented transports, not signal
-                    // about unreachable peers. Variants enumerated, not
-                    // wildcarded, per the production no-silent-fallback
-                    // clippy gate: a FUTURE endpoint variant must force
-                    // this match to be revisited, not silently fall into
-                    // "skip" (the wildcard slipped past #1120's review
-                    // because the merge-push CI run was hand-cancelled —
-                    // caught by the #1121 sentinel).
-                    RouteEndpoint::Udp { .. }
-                    | RouteEndpoint::Relay { .. }
-                    | RouteEndpoint::Reticulum { .. }
-                    | RouteEndpoint::WebRtcSignaling { .. } => continue,
-                };
-                // Card 7e3c9a1f: skip endpoints still inside their
-                // dial-failure backoff window. A daemon that restarted on
-                // a new port leaves its old `addr` in every peer's trust
-                // store until the registry re-converges; without this
-                // skip each refresh re-pays PEER_DIAL_TIMEOUT on that
-                // corpse, starving the dial to the live endpoint. The
-                // freshest (most likely live) endpoint is listed first and
-                // is never quarantined unless it itself just failed, so
-                // this never blocks a genuinely reachable peer.
-                //
-                // The skip is SURFACED, not silent — but on the SEPARATE
-                // `peer_dial_skips` channel, NOT as a `PeerDialFailure`. No
-                // dial was attempted, so reporting it as a failure would
-                // emit false `PeerDialFailed` warnings every refresh and
-                // inflate `airc transport health`'s failure count. The
-                // operator still sees "in backoff" via the skips channel —
-                // honest, not a clean-list lie and not an over-report.
-                if let Some(remaining_ms) = self.dial_quarantine_remaining_ms(peer_id, addr, now_ms)
-                {
-                    skips.push(PeerDialSkip {
+            // Card 7e3c9a1f: skip endpoints still inside their dial-
+            // failure backoff window. A daemon that restarted on a new
+            // port leaves its old `addr` in every peer's trust store
+            // until the registry re-converges; without this skip each
+            // refresh re-pays PEER_DIAL_TIMEOUT on that corpse, starving
+            // the dial to the live endpoint. The freshest (most likely
+            // live) endpoint is listed first and is never quarantined
+            // unless it itself just failed, so this never blocks a
+            // genuinely reachable peer.
+            //
+            // The skip is SURFACED, not silent — but on the SEPARATE
+            // `peer_dial_skips` channel, NOT as a `PeerDialFailure`. No
+            // dial was attempted, so reporting it as a failure would emit
+            // false `PeerDialFailed` warnings every refresh and inflate
+            // `airc transport health`'s failure count. The operator still
+            // sees "in backoff" via the skips channel — honest, not a
+            // clean-list lie and not an over-report.
+            if let Some(remaining_ms) = self.dial_quarantine_remaining_ms(peer_id, addr, now_ms) {
+                skips.push(PeerDialSkip {
+                    peer_id,
+                    endpoint: endpoint.clone(),
+                    remaining_ms,
+                });
+                continue;
+            }
+            // #1120 sentinel blocking-2: connect_lan has no inner
+            // timeout, and a SYN-dropping firewall (the default posture
+            // of the NATs this card exists to cross) hangs the OS connect
+            // for ~21-130s per endpoint. Bound every dial; a timeout is a
+            // recorded failure like any other.
+            match tokio::time::timeout(PEER_DIAL_TIMEOUT, self.connect_lan(addr, peer_id)).await {
+                Ok(Ok(())) => {
+                    // Card 7e3c9a1f: a live connect lifts any prior
+                    // quarantine so a flapped-but-recovered endpoint is
+                    // immediately eligible again next refresh.
+                    self.dial_quarantine_record_success(peer_id, addr);
+                    break;
+                }
+                Ok(Err(error)) => {
+                    self.dial_quarantine_record_failure(peer_id, addr, now_ms);
+                    failures.push(PeerDialFailure {
                         peer_id,
                         endpoint: endpoint.clone(),
-                        remaining_ms,
+                        error: error.to_string(),
                     });
-                    continue;
                 }
-                // #1120 sentinel blocking-2: connect_lan has no inner
-                // timeout, and a SYN-dropping firewall (the default
-                // posture of the NATs this card exists to cross) hangs
-                // the OS connect for ~21-130s per endpoint. Bound every
-                // dial; a timeout is a recorded failure like any other.
-                match tokio::time::timeout(PEER_DIAL_TIMEOUT, self.connect_lan(addr, peer_id)).await
-                {
-                    Ok(Ok(())) => {
-                        // Card 7e3c9a1f: a live connect lifts any prior
-                        // quarantine so a flapped-but-recovered endpoint is
-                        // immediately eligible again next refresh.
-                        self.dial_quarantine_record_success(peer_id, addr);
-                        break;
-                    }
-                    Ok(Err(error)) => {
-                        self.dial_quarantine_record_failure(peer_id, addr, now_ms);
-                        failures.push(PeerDialFailure {
-                            peer_id,
-                            endpoint: endpoint.clone(),
-                            error: error.to_string(),
-                        });
-                    }
-                    Err(_elapsed) => {
-                        self.dial_quarantine_record_failure(peer_id, addr, now_ms);
-                        failures.push(PeerDialFailure {
-                            peer_id,
-                            endpoint: endpoint.clone(),
-                            error: format!(
-                                "dial timed out after {}s (endpoint unreachable or \
-                                 firewall drops SYN)",
-                                PEER_DIAL_TIMEOUT.as_secs()
-                            ),
-                        });
-                    }
+                Err(_elapsed) => {
+                    self.dial_quarantine_record_failure(peer_id, addr, now_ms);
+                    failures.push(PeerDialFailure {
+                        peer_id,
+                        endpoint: endpoint.clone(),
+                        error: format!(
+                            "dial timed out after {}s (endpoint unreachable or \
+                             firewall drops SYN)",
+                            PEER_DIAL_TIMEOUT.as_secs()
+                        ),
+                    });
                 }
             }
         }
-        Ok((failures, skips))
+        (failures, skips)
     }
 
     /// Snapshot the last known discovery state without mutating

--- a/crates/airc-lib/tests/stored_endpoint_dial.rs
+++ b/crates/airc-lib/tests/stored_endpoint_dial.rs
@@ -588,3 +588,97 @@ async fn dial_walks_endpoints_in_stored_order_and_stops_on_success() {
         started.elapsed()
     );
 }
+
+/// Concurrency pin — peers are dialed CONCURRENTLY, so the refresh
+/// wall-clock is `~max(single-peer dial)`, NOT the SUM across peers.
+///
+/// what this catches: the serial-dial hang. The loop in
+/// `dial_stored_peer_endpoints` used to walk peers one at a time, each
+/// unreachable peer paying the full `PEER_DIAL_TIMEOUT` before the next
+/// was even attempted. On a real account with dozens of enrolled peers
+/// (41 on BIGMAMA, ~15 off-LAN), a cold refresh — before any endpoint
+/// is quarantined — serially burned ~45s, hanging `airc doctor
+/// --health` and every send-path refresh. A regression to serial
+/// dialing makes N tarpit peers take N×3s; this test bounds the whole
+/// refresh well under that.
+///
+/// Each "peer" advertises a TARPIT endpoint: a TCP listener that
+/// ACCEPTS the connection but never speaks TLS, so `connect_lan` blocks
+/// in the handshake until `PEER_DIAL_TIMEOUT` fires (a closed port would
+/// be refused instantly and prove nothing about concurrency). With
+/// N_TARPITS peers, serial = N×3s = 15s; concurrent ≈ 3s. The 9s bound
+/// is generous enough for a loaded CI runner yet still fails loudly if
+/// the dials ever go serial again.
+#[tokio::test]
+async fn peers_are_dialed_concurrently_not_serially() {
+    const N_TARPITS: usize = 5;
+
+    let tmp_b = TempDir::new().expect("bob tempdir");
+    let bob = Airc::open(tmp_b.path().join(".airc"))
+        .await
+        .expect("bob open");
+
+    // Hold the tarpit listeners + their accept tasks alive for the whole
+    // test: each accepts inbound TCP and parks the stream, never
+    // completing TLS, so the dialer's handshake stalls to the deadline.
+    let mut tarpits = Vec::new();
+    let mut peer_tmps = Vec::new();
+    for _ in 0..N_TARPITS {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("tarpit bind");
+        let addr = listener.local_addr().expect("tarpit addr");
+        let handle = tokio::spawn(async move {
+            let mut held = Vec::new();
+            // Accept and PARK every inbound stream — never speak TLS, so
+            // the dialer's handshake stalls to PEER_DIAL_TIMEOUT.
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+        tarpits.push(handle);
+
+        // A real enrolled peer identity whose ONLY endpoint is the tarpit.
+        let tmp = TempDir::new().expect("peer tempdir");
+        let peer = Airc::open(tmp.path().join(".airc"))
+            .await
+            .expect("peer open");
+        let peer_spec: PeerSpec = peer.peer_spec().parse().expect("peer spec");
+        let peer_id = peer.peer_id();
+        bob.add_peer(peer_spec).await.expect("bob trusts peer");
+        let endpoints_json =
+            endpoints_to_json(&[RouteEndpoint::LanTcp { addr }]).expect("encode endpoints");
+        airc_trust::set_endpoints_json(bob.home(), peer_id, Some(endpoints_json))
+            .await
+            .expect("store endpoints")
+            .expect("peer must be enrolled on bob");
+        peer_tmps.push((tmp, peer));
+    }
+
+    let started = std::time::Instant::now();
+    let snapshot = bob
+        .refresh_route_discovery()
+        .await
+        .expect("bob discovery refresh");
+    let elapsed = started.elapsed();
+
+    // Every tarpit dial must be recorded as a failure (none connects).
+    assert_eq!(
+        snapshot.peer_dial_failures.len(),
+        N_TARPITS,
+        "each tarpit peer must record one failed dial: {:?}",
+        snapshot.peer_dial_failures
+    );
+    // The load-bearing assert: concurrent, not serial. Serial would be
+    // N_TARPITS × PEER_DIAL_TIMEOUT (15s); concurrent is ~3s.
+    assert!(
+        elapsed < std::time::Duration::from_secs(9),
+        "{N_TARPITS} tarpit peers must be dialed CONCURRENTLY (~3s), not \
+         serially ({N_TARPITS}×3s=15s); took {elapsed:?} — the serial-dial \
+         hang has regressed"
+    );
+
+    for handle in tarpits {
+        handle.abort();
+    }
+}


### PR DESCRIPTION
## The bug

`dial_stored_peer_endpoints` dialed enrolled peers **serially**, so `refresh_route_discovery`'s wall-clock = **SUM** of every unreachable peer's `PEER_DIAL_TIMEOUT` (3s each).

On a real account with dozens of enrolled peers (**41 on BIGMAMA**, ~15 off-LAN/offline), a cold refresh — before any endpoint is quarantined — serially burned **~45s**, hanging:
- `airc doctor --health` (reproduced: SIGTERM'd at 45s; the staleness banner literally *recommends* running it)
- every send-path refresh (`send_frame_to_room` calls the same refresh)

The serial cost was already pinned, intentionally, by `off_lan_peer_pays_lan_dial_timeout_then_connects_via_tailscale` and its *"when the dialer eventually gets a same-subnet reachability gate (BIGMAMA's real fix #3)"* note. **This is that fix** (the concurrency half of it).

## The fix

Per-peer dials are independent — `connect_lan` clones an Arc adapter and every shared mutation (dial-quarantine map, transport health) is behind its own brief lock. So:
- the **outer** per-peer loop now runs **concurrently** (bounded by `DIAL_CONCURRENCY = 16`; ordered results merged back for stable operator display)
- the **inner** per-endpoint walk stays **serial** — preserving the cost-order + stop-on-first-success contract the `stored_endpoint_dial` tests pin

Inner walk extracted into `dial_one_peer`.

## Validation
- `cargo fmt --check` ✅, `cargo clippy -p airc-lib --tests -- -D warnings` ✅
- `stored_endpoint_dial`: **9/9** (whole file in 4s — 5 tarpits serial alone would be 15s); `daemon_route_refresh`: **1/1**
- **end-to-end**: `doctor --health` on a fresh build with 41 enrolled peers completed in **9s** (was >45s / hung) → `route health: 1 route(s) healthy`

New regression test `peers_are_dialed_concurrently_not_serially`: 5 tarpit peers (accept TCP, never speak TLS → each dial stalls the full 3s). Serial = 15s; concurrent ≈ 3s; bound asserts < 9s, failing loudly if dials ever regress to serial.

## Notes for review (M5 / route-owner)
This touches the route-refresh hot path that `send_frame_to_room` also drives, so concurrency-safety of `connect_lan` under parallel dials is the load-bearing claim — flagged explicitly for adversarial review. Follow-up still open: the *other* half of "BIGMAMA real fix #3", a same-subnet reachability gate that skips dialing off-LAN LAN-rungs entirely (avoids the 3s even concurrently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)