### PR TITLE
fix(test): de-flake default_home_uses_git_project_root_scope

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -976,11 +976,26 @@ mod tests {
         assert!(status.success());
 
         let actual = default_home_dir_for(&nested);
-        let expected = repo.join(".airc");
         std::fs::create_dir_all(&actual).unwrap();
+        // Canonicalize `repo` (which ALWAYS exists) and append `.airc`,
+        // rather than canonicalizing the `.airc` dir directly. The old
+        // code did `expected.canonicalize().unwrap()` on `repo/.airc`,
+        // which only exists if `actual == repo/.airc`. When the
+        // git-toplevel walk intermittently fell back to `$HOME/.airc` on
+        // the macOS runner (git refusing the fresh temp repo — dubious
+        // ownership / timing), `actual` was created under $HOME, `repo/
+        // .airc` never existed, and `canonicalize()` panicked with an
+        // opaque `NotFound` instead of a CLEAR assertion. Canonicalizing
+        // `repo` (handles macOS `/var`→`/private/var` symlinks and the
+        // Windows verbatim `\\?\` prefix uniformly) makes a real
+        // mismatch a readable failure, not a flaky panic.
+        let expected = repo.canonicalize().unwrap().join(".airc");
+        let actual_canon = actual.canonicalize().unwrap();
         assert_eq!(
-            actual.canonicalize().unwrap(),
-            expected.canonicalize().unwrap()
+            actual_canon, expected,
+            "git-project-root scope must resolve to <repo>/.airc; a \
+             <HOME>/.airc here means the git toplevel walk fell back to \
+             the machine-account home (git refused the temp repo?)"
         );
     }
 


### PR DESCRIPTION
## Flaky test on the macOS runner

`default_home_uses_git_project_root_scope` canonicalized `repo/.airc` directly:
```rust
expected.canonicalize().unwrap()
```
That dir only exists when `actual == repo/.airc`. When the git-toplevel walk in `default_home_dir_for` intermittently fell back to `$HOME/.airc` on the GitHub macOS runner (git refusing the fresh temp repo — dubious-ownership / FS timing), `actual` got created under `$HOME`, `repo/.airc` never existed, and `canonicalize()` panicked with an opaque `Os { code: 2, NotFound }` — a flaky red that hides *what* diverged.

**Observed:** passed on #1228's macOS run, failed on #1229's — identical code (it's surfaced as the blocker on #1229's macOS check, which is unrelated to that PR's route change).

## Fix

Canonicalize `repo` (which **always** exists) and append `.airc`, instead of canonicalizing the maybe-absent `.airc` dir. Still normalizes macOS `/var`→`/private/var` symlinks and the Windows verbatim `\?\` prefix uniformly, but a genuine `$HOME` fallback now surfaces as a **readable assertion** instead of a panic:

> git-project-root scope must resolve to <repo>/.airc; a <HOME>/.airc here means the git toplevel walk fell back to the machine-account home (git refused the temp repo?)

If the underlying git-refusal is a real recurring runner issue, this assertion will now *say so* instead of an opaque NotFound — turning a flaky panic into a diagnosable signal.

## Validation
- Windows: this test + all 6 `default_home_*` tests pass; `clippy -p airc-cli --bin airc -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)