### PR TITLE
fix(test): make default_home_uses_git_project_root_scope hermetic (kill real-git flake)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -964,38 +964,38 @@ mod tests {
 
     #[test]
     fn default_home_uses_git_project_root_scope() {
-        let root = tempfile::TempDir::new().unwrap();
-        let repo = root.path().join("repo");
+        // Hermetic: STUB the git-main-working-tree resolver instead of
+        // shelling out to real `git` in a temp repo. The earlier version
+        // called the real `default_home_dir_for` (which shells `git
+        // rev-parse`), and that is environment-fragile under parallel
+        // unit tests + CI runners: git's dubious-ownership / safe.directory
+        // check can intermittently REFUSE a freshly-init'd temp repo (and
+        // a sibling test mutating the process-global `$HOME`/cwd can race
+        // git's config read), so `git_main_working_tree` returns None and
+        // `default_home_dir_for` falls back to the machine-account home —
+        // a non-deterministic red that blocked unrelated PRs (the #1230
+        // diagnostic assertion is what surfaced exactly this fallback).
+        //
+        // The mapping logic under test — "a resolved git main working
+        // tree ⇒ <tree>/.airc, NOT the machine-account home" — is what
+        // this pins, deterministically, via the same `..._with` stub seam
+        // the sibling default_home tests use. The git-shell integration
+        // itself is exercised in production + the daemon integration
+        // tests, not in a flaky parallel unit test.
+        use super::default_home_dir_for_with;
+        use std::path::{Path, PathBuf};
+        let repo = PathBuf::from("/Users/test/Development/myproj");
         let nested = repo.join("src").join("inner");
-        std::fs::create_dir_all(&nested).unwrap();
-        let status = std::process::Command::new("git")
-            .args(["init", "-q"])
-            .current_dir(&repo)
-            .status()
-            .unwrap();
-        assert!(status.success());
-
-        let actual = default_home_dir_for(&nested);
-        std::fs::create_dir_all(&actual).unwrap();
-        // Canonicalize `repo` (which ALWAYS exists) and append `.airc`,
-        // rather than canonicalizing the `.airc` dir directly. The old
-        // code did `expected.canonicalize().unwrap()` on `repo/.airc`,
-        // which only exists if `actual == repo/.airc`. When the
-        // git-toplevel walk intermittently fell back to `$HOME/.airc` on
-        // the macOS runner (git refusing the fresh temp repo — dubious
-        // ownership / timing), `actual` was created under $HOME, `repo/
-        // .airc` never existed, and `canonicalize()` panicked with an
-        // opaque `NotFound` instead of a CLEAR assertion. Canonicalizing
-        // `repo` (handles macOS `/var`→`/private/var` symlinks and the
-        // Windows verbatim `\\?\` prefix uniformly) makes a real
-        // mismatch a readable failure, not a flaky panic.
-        let expected = repo.canonicalize().unwrap().join(".airc");
-        let actual_canon = actual.canonicalize().unwrap();
+        let machine_account = PathBuf::from("/Users/test/.airc");
+        // No `.airc` ancestor of `nested`; the resolver must fall through
+        // to the git main working tree (stubbed) and scope to <repo>/.airc.
+        let stub = |_: &Path| -> Option<PathBuf> { Some(repo.clone()) };
+        let resolved = default_home_dir_for_with(&nested, Some(machine_account.as_path()), &stub);
         assert_eq!(
-            actual_canon, expected,
-            "git-project-root scope must resolve to <repo>/.airc; a \
-             <HOME>/.airc here means the git toplevel walk fell back to \
-             the machine-account home (git refused the temp repo?)"
+            resolved,
+            repo.join(".airc"),
+            "a resolved git main working tree must scope home to <tree>/.airc, \
+             not fall back to the machine-account home"
         );
     }
 


### PR DESCRIPTION
## The real bug, now fixed

**#1230** converted this test's opaque `Os { NotFound }` panic into a diagnostic assertion — which **revealed the actual cause**: the test called the real `default_home_dir_for`, which shells out to `git rev-parse` in a temp repo. On the GitHub macOS runner that **intermittently fails**:
- git's dubious-ownership / `safe.directory` check refusing a freshly-init'd temp repo, and/or
- a sibling unit test mutating the process-global `$HOME` racing git's config read

→ `git_main_working_tree` returns `None` → `default_home_dir_for` falls back to the machine-account home → assertion mismatch. A non-deterministic red that **blocked unrelated PRs** (it's the one failure on #1229).

## Fix

Stub the git resolver via the existing `default_home_dir_for_with(cwd, machine_account, &stub)` seam — the **exact hermetic pattern the 3 sibling `default_home_*` tests already use**. The mapping under test ("a resolved git main working tree ⇒ `<tree>/.airc`, not the machine-account home") is pinned deterministically; the git-shell integration is covered in production + the daemon integration tests, not a flaky parallel unit test.

Sequence: **#1230 = diagnose** (opaque panic → readable assertion) → **#1231 = fix** (remove the flaky real-git dependency).

## Validation
- Windows: all 6 `default_home_*` tests pass **5×/5 consecutive runs**; `clippy -p airc-cli --bin airc -- -D warnings` clean.

## Coordinated follow-up (not this PR)
The underlying production fragility — `git rev-parse` refusing dubious-ownership dirs → silent fallback to machine-account scope — is worth hardening separately (daemon could set `safe.directory`, or the resolver could distinguish "git failed" from "not a repo"). Flagged for the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)