### PR TITLE
feat(purpose): ChannelPurpose — typed room-nature for the deterministic persona participation gate

### DIFF
--- a/crates/airc-core/src/channel_purpose.rs
+++ b/crates/airc-core/src/channel_purpose.rs
@@ -1,0 +1,178 @@
+//! Channel purpose — the substrate-published TYPED nature of a room,
+//! so a citizen calibrates participation (auto-respond cadence, tone,
+//! verbosity) to the room WITHOUT an LLM parsing free-form doctrine
+//! prose.
+//!
+//! Complementary to [`crate::doctrine`], NOT a duplicate of it:
+//!   - **purpose** (this module) = the typed COARSE kind, one enum
+//!     value. Drives a consumer's participation gate deterministically
+//!     (a `Coordination` room tightens auto-respond reliably; a `Game`
+//!     room loosens it). Carries NO prose.
+//!   - **doctrine** = the free-form FINE rules (markdown). Carries NO
+//!     typed kind.
+//!
+//! A room may have both: a `Coordination` purpose AND a doctrine doc
+//! with the specifics. The persona uses purpose for coarse calibration,
+//! doctrine for the rules. This split is what stops Ivar-style
+//! over-talking in coordination rooms without making the model infer
+//! room-nature from markdown every turn.
+//!
+//! Wire shape mirrors [`crate::doctrine::DoctrineEvent`] and
+//! `IdentityEvent`: an internally-tagged event enum so a JSON body
+//! always carries a `kind` field consumers switch on; the projection
+//! (`Airc::channel_purpose`) takes the latest per room by LWW.
+
+use crate::ids::{PeerId, RoomId};
+use serde::{Deserialize, Serialize};
+
+/// The typed coarse KIND of a channel. Consumers (continuum's
+/// `RoomPurposeSource`, future Hermes/OpenClaw adapters) match on this
+/// to calibrate participation deterministically — never inferring it
+/// from prose.
+///
+/// `Other` is the escape hatch for a nature not in the closed set
+/// (matching [`crate::ExternalIdentitySource::Other`]); a recurring
+/// kind should earn a dedicated variant rather than living in `Other`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelPurpose {
+    /// Open conversation — normal cadence, sociable.
+    Chat,
+    /// Work / ops coordination — terse, signal-dense, TIGHT auto-respond
+    /// (the room where a grounded persona must not over-talk).
+    Coordination,
+    /// Play — in-character, playful, looser cadence.
+    Game,
+    /// Teaching / learning — explanatory, patient.
+    Academy,
+    /// Support / Q&A — responsive to questions, otherwise quiet.
+    Help,
+    /// Configuration / control — minimal chatter, act-on-request.
+    Settings,
+    /// Escape hatch — a nature not (yet) in the closed set. Existing
+    /// well-known kinds should add a dedicated variant.
+    Other(String),
+}
+
+/// Typed channel-purpose domain events. Internally tagged via serde so
+/// a JSON body always carries a `kind` field consumers switch on
+/// without parsing the whole payload — same shape as
+/// [`crate::doctrine::DoctrineEvent`]. Single variant today; the enum
+/// keeps the upgrade path honest (an unknown future `kind` surfaces as
+/// a decode error, never a silent mis-decode).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ChannelPurposeEvent {
+    ChannelPurposePublished(ChannelPurposePublished),
+}
+
+/// A room's typed purpose published on the substrate. Authority is flat
+/// (per AGENTS.md §6: no role-based dispatch) — every peer may publish;
+/// the projection takes the latest by `published_at_ms` (LWW).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelPurposePublished {
+    /// The room this purpose applies to.
+    pub room_id: RoomId,
+    /// The typed coarse kind.
+    pub purpose: ChannelPurpose,
+    /// Peer that emitted this version. Not gating — see module doc.
+    pub published_by: PeerId,
+    /// Monotonic emission time. Projection takes the highest
+    /// `published_at_ms` per `room_id` (LWW; ties broken by the durable
+    /// log's event order).
+    pub published_at_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn sample(purpose: ChannelPurpose) -> ChannelPurposePublished {
+        ChannelPurposePublished {
+            room_id: RoomId::from_u128(7),
+            purpose,
+            published_by: PeerId::from_u128(42),
+            published_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn channel_purpose_event_round_trips_through_serde() {
+        for purpose in [
+            ChannelPurpose::Chat,
+            ChannelPurpose::Coordination,
+            ChannelPurpose::Game,
+            ChannelPurpose::Academy,
+            ChannelPurpose::Help,
+            ChannelPurpose::Settings,
+            ChannelPurpose::Other("broadcast".to_string()),
+        ] {
+            let event = ChannelPurposeEvent::ChannelPurposePublished(sample(purpose));
+            let json = serde_json::to_string(&event).expect("serialize");
+            let decoded: ChannelPurposeEvent = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(event, decoded);
+        }
+    }
+
+    #[test]
+    fn wire_kind_discriminator_is_stable() {
+        // Consumers switch on `kind` without parsing the body; pin the
+        // discriminator so a serde change can't silently rename it
+        // (same lesson as DoctrineEvent / IdentityEvent — kink 0cfcc8db).
+        let event =
+            ChannelPurposeEvent::ChannelPurposePublished(sample(ChannelPurpose::Coordination));
+        let value: Value = serde_json::to_value(&event).expect("to_value");
+        assert_eq!(
+            value.get("kind").and_then(Value::as_str),
+            Some("channel_purpose_published"),
+            "event wire kind must be stable",
+        );
+        assert!(value.get("room_id").is_some());
+        assert!(value.get("purpose").is_some());
+        assert!(value.get("published_by").is_some());
+        assert!(value.get("published_at_ms").is_some());
+    }
+
+    #[test]
+    fn closed_variants_serialize_as_stable_snake_case_strings() {
+        // The typed kind drives a deterministic participation gate on the
+        // consumer side, so its wire strings are load-bearing — pin them.
+        for (purpose, wire) in [
+            (ChannelPurpose::Chat, "chat"),
+            (ChannelPurpose::Coordination, "coordination"),
+            (ChannelPurpose::Game, "game"),
+            (ChannelPurpose::Academy, "academy"),
+            (ChannelPurpose::Help, "help"),
+            (ChannelPurpose::Settings, "settings"),
+        ] {
+            let value = serde_json::to_value(&purpose).expect("to_value");
+            assert_eq!(
+                value.as_str(),
+                Some(wire),
+                "closed variant must serialize to a stable string",
+            );
+        }
+    }
+
+    #[test]
+    fn other_escape_hatch_carries_its_payload() {
+        let value =
+            serde_json::to_value(ChannelPurpose::Other("broadcast".to_string())).expect("to_value");
+        // Externally-tagged: `{"other":"broadcast"}`.
+        assert_eq!(
+            value.get("other").and_then(Value::as_str),
+            Some("broadcast"),
+            "Other carries its consumer-defined string",
+        );
+    }
+
+    #[test]
+    fn unknown_event_kind_surfaces_as_decode_error() {
+        // A future-version event a current consumer doesn't know about
+        // must error, not silently mis-decode. Keeps the upgrade honest.
+        let raw = r#"{"kind":"channel_purpose_retired","room_id":"00000000-0000-0000-0000-000000000001"}"#;
+        let result: Result<ChannelPurposeEvent, _> = serde_json::from_str(raw);
+        assert!(result.is_err(), "unknown kind must error");
+    }
+}

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -29,6 +29,7 @@
 
 pub mod attachment;
 pub mod body;
+pub mod channel_purpose;
 pub mod cursor;
 pub mod datetime;
 pub mod doctrine;

--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -103,6 +103,15 @@ pub enum TranscriptKind {
     /// case `category="doctrine"`; the legacy `DoctrinePublished`
     /// remains for back-compat replay.
     WallPostPublished,
+    /// A peer published the room's TYPED purpose — the coarse kind
+    /// (Chat / Coordination / Game / …) a citizen calibrates
+    /// participation to WITHOUT parsing doctrine prose. Body: serialized
+    /// `airc_core::channel_purpose::ChannelPurposeEvent::ChannelPurposePublished`,
+    /// kind="channel_purpose_published", carrying { room_id, purpose,
+    /// published_by, published_at_ms }. Projections take the latest per
+    /// room_id (LWW on published_at_ms). Complementary to
+    /// `DoctrinePublished` (typed kind here; free-form rules there).
+    ChannelPurposePublished,
 }
 
 impl TranscriptKind {
@@ -122,6 +131,7 @@ impl TranscriptKind {
                 | TranscriptKind::IdentityPublished
                 | TranscriptKind::DoctrinePublished
                 | TranscriptKind::WallPostPublished
+                | TranscriptKind::ChannelPurposePublished
         )
     }
 
@@ -160,6 +170,7 @@ impl TranscriptKind {
             TranscriptKind::IdentityPublished => "identity_published",
             TranscriptKind::DoctrinePublished => "doctrine_published",
             TranscriptKind::WallPostPublished => "wall_post_published",
+            TranscriptKind::ChannelPurposePublished => "channel_purpose_published",
         }
     }
 
@@ -184,6 +195,7 @@ impl TranscriptKind {
             "identity_published" => TranscriptKind::IdentityPublished,
             "doctrine_published" => TranscriptKind::DoctrinePublished,
             "wall_post_published" => TranscriptKind::WallPostPublished,
+            "channel_purpose_published" => TranscriptKind::ChannelPurposePublished,
             _ => return None,
         })
     }
@@ -210,6 +222,7 @@ impl TranscriptKind {
         TranscriptKind::IdentityPublished,
         TranscriptKind::DoctrinePublished,
         TranscriptKind::WallPostPublished,
+        TranscriptKind::ChannelPurposePublished,
     ];
 }
 

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -678,6 +678,83 @@ impl Airc {
         .await
     }
 
+    /// The current room's TYPED purpose (latest published, LWW), or
+    /// `None` if no purpose has been published in the recent window.
+    ///
+    /// The single airc-side read continuum's `RoomPurposeSource`
+    /// consumes (M5 groundedness, 2026-06-16): the typed coarse kind
+    /// drives the persona's participation/should-respond gate
+    /// DETERMINISTICALLY (a `Coordination` room tightens auto-respond
+    /// without the model parsing prose — the structural fix for
+    /// Ivar-style over-talking) and a compact grounding line. Same
+    /// scan-recent + LWW shape as [`Self::room_doctrine`]; purpose and
+    /// doctrine are complementary (typed kind here, free-form rules
+    /// there).
+    pub async fn channel_purpose(
+        &self,
+    ) -> Result<Option<airc_core::channel_purpose::ChannelPurpose>, AircError> {
+        let events = self.page_recent(200).await?;
+        // True LWW by `published_at_ms` — NOT first-match. `page_recent`
+        // is not guaranteed newest-first, so returning the first matching
+        // event would surface a STALE purpose after a republish. Scan all
+        // candidates and keep the highest timestamp (ties broken by
+        // later-in-page, the durable-log order).
+        let mut latest: Option<(u64, airc_core::channel_purpose::ChannelPurpose)> = None;
+        for event in events {
+            if event.kind != airc_core::TranscriptKind::ChannelPurposePublished {
+                continue;
+            }
+            let Some(airc_core::Body::Json(value)) = event.body else {
+                continue;
+            };
+            let Ok(airc_core::channel_purpose::ChannelPurposeEvent::ChannelPurposePublished(
+                published,
+            )) = serde_json::from_value::<airc_core::channel_purpose::ChannelPurposeEvent>(value)
+            else {
+                continue;
+            };
+            if latest
+                .as_ref()
+                .is_none_or(|(ts, _)| published.published_at_ms >= *ts)
+            {
+                latest = Some((published.published_at_ms, published.purpose));
+            }
+        }
+        Ok(latest.map(|(_, purpose)| purpose))
+    }
+
+    /// Publish the current room's TYPED purpose — the coarse kind a
+    /// citizen calibrates participation to. Emits a
+    /// `TranscriptKind::ChannelPurposePublished` lifecycle event
+    /// carrying a serialized
+    /// `ChannelPurposeEvent::ChannelPurposePublished`; every attaching
+    /// agent's subscribe stream surfaces it. Authority is flat (any
+    /// peer may publish); projections take latest by `published_at_ms`.
+    /// Complementary to [`Self::publish_room_doctrine`] — purpose is the
+    /// typed kind, doctrine is the free-form rules.
+    pub async fn publish_channel_purpose(
+        &self,
+        purpose: airc_core::channel_purpose::ChannelPurpose,
+    ) -> Result<(), AircError> {
+        let room = self.current_room().await?;
+        let event = airc_core::channel_purpose::ChannelPurposeEvent::ChannelPurposePublished(
+            airc_core::channel_purpose::ChannelPurposePublished {
+                room_id: room.channel,
+                purpose,
+                published_by: self.inner.identity.peer_id,
+                published_at_ms: time::now_ms()?,
+            },
+        );
+        let body_json = serde_json::to_value(&event)
+            .map_err(|e| AircError::Crypto(format!("channel purpose event serialize: {e}")))?;
+        self.emit_lifecycle(
+            airc_core::TranscriptKind::ChannelPurposePublished,
+            room.channel,
+            airc_core::Body::Json(body_json),
+        )
+        .await
+    }
+
     /// Card b4742d9c: pin a wall post in the current room.
     ///
     /// The wall is the room's living document — multiple typed posts

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -202,6 +202,7 @@ pub use work_subscription::{
 // just to type the common return values.
 pub use airc_core::{
     body::Body,
+    channel_purpose::{ChannelPurpose, ChannelPurposeEvent, ChannelPurposePublished},
     headers::{HeaderFilter, Headers},
     transcript::MentionTarget,
     ClientId, EventId, PeerId, PersonaCapabilities, PersonaCapabilitiesError, RoomId,

--- a/crates/airc-lib/tests/channel_purpose.rs
+++ b/crates/airc-lib/tests/channel_purpose.rs
@@ -1,0 +1,65 @@
+//! `Airc::publish_channel_purpose` / `Airc::channel_purpose` — the
+//! typed room-nature the persona-groundedness consumer (continuum's
+//! `RoomPurposeSource`) reads to drive a DETERMINISTIC participation
+//! gate (M5 groundedness, 2026-06-16).
+//!
+//! Contract proven here:
+//!   - an unset room reads back `None` (honest "no typed purpose");
+//!   - a published typed kind round-trips back through the substrate
+//!     verbatim (the consumer matches on the same enum the publisher
+//!     sent — no prose, no inference);
+//!   - latest-write-wins: republishing a different kind supersedes the
+//!     prior one (the projection returns the newest).
+//!
+//! Purpose is published via `emit_lifecycle` (a local-store append, same
+//! path as `publish_room_doctrine` + identity cards), so a single
+//! in-process `Airc` proves the publish→projection round-trip
+//! synchronously — no daemon route needed (and a daemon-backed
+//! `page_recent` wouldn't see a local-only lifecycle append anyway).
+
+use airc_lib::{Airc, ChannelPurpose};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn channel_purpose_publishes_reads_back_and_is_lww() {
+    let tmp = TempDir::new().expect("tempdir");
+    let airc = Airc::open(tmp.path().join(".airc")).await.expect("open");
+    airc.join("general").await.expect("join general");
+
+    // Unset → None (no typed purpose published in the window).
+    assert_eq!(
+        airc.channel_purpose().await.expect("read unset"),
+        None,
+        "a room with no published purpose reads back None",
+    );
+
+    // Publish a typed kind; the projection returns it verbatim.
+    airc.publish_channel_purpose(ChannelPurpose::Coordination)
+        .await
+        .expect("publish coordination");
+    assert_eq!(
+        airc.channel_purpose().await.expect("read coordination"),
+        Some(ChannelPurpose::Coordination),
+        "the typed purpose reads back verbatim — same enum the publisher sent",
+    );
+
+    // Latest-write-wins: a newer publish of a different kind supersedes.
+    airc.publish_channel_purpose(ChannelPurpose::Game)
+        .await
+        .expect("republish game");
+    assert_eq!(
+        airc.channel_purpose().await.expect("read game"),
+        Some(ChannelPurpose::Game),
+        "LWW: the newest published purpose wins over the prior one",
+    );
+
+    // The `Other` escape hatch round-trips its consumer-defined string.
+    airc.publish_channel_purpose(ChannelPurpose::Other("broadcast".to_string()))
+        .await
+        .expect("publish other");
+    assert_eq!(
+        airc.channel_purpose().await.expect("read other"),
+        Some(ChannelPurpose::Other("broadcast".to_string())),
+        "Other carries its consumer-defined kind through the substrate",
+    );
+}


### PR DESCRIPTION
## What M5 asked for

A **typed** room-purpose so continuum's `RoomPurposeSource` drives the persona's should-respond gate **deterministically** — a `Coordination` room tightens auto-respond **without the LLM parsing free-form doctrine prose**. That's the structural fix for Ivar-style over-talking in coordination rooms, plus a compact `[Room purpose: X]` grounding line.

## Reconciled with `room_doctrine` (complementary, not duplicate)

| | purpose (this) | doctrine (existing) |
|---|---|---|
| granularity | typed **coarse kind** (one enum) | free-form **fine rules** (markdown) |
| drives | deterministic participation gate | prompt prose + specifics |
| carries | no prose | no typed kind |

A room may carry both. M5 keeps `RoomDoctrineSource` as-is and adds a `RoomPurposeSource` over this.

## API

```rust
pub enum ChannelPurpose { Chat, Coordination, Game, Academy, Help, Settings, Other(String) }

impl Airc {
    pub async fn publish_channel_purpose(&self, purpose: ChannelPurpose) -> Result<(), AircError>;
    pub async fn channel_purpose(&self) -> Result<Option<ChannelPurpose>, AircError>;  // LWW
}
```

- `airc_core::channel_purpose`: internally-tagged `ChannelPurposeEvent` + `ChannelPurposePublished`, wire shape mirroring `DoctrineEvent`/`IdentityEvent` (serde round-trip + stable-discriminator + unknown-kind-errors tests).
- `TranscriptKind::ChannelPurposePublished` wired through all **five** guarded points (enum, `is_lifecycle`, `as_wire_str`, `from_wire_str`, `ALL_VARIANTS`); the `wire_str` round-trip guard stays green.
- `publish_channel_purpose` / `channel_purpose` mirror `publish_room_doctrine` / `room_doctrine` — **but the read does TRUE LWW by `published_at_ms`**. `page_recent` isn't newest-first, so first-match (what `room_doctrine` does) would surface a **stale** purpose after a republish — caught by the LWW test. (Flagging the latent `room_doctrine` first-match issue separately.)
- Re-exported `ChannelPurpose{,Event,Published}` from `airc_lib`.

## Test
`channel_purpose.rs`: unset→`None`, typed publish round-trips verbatim, **LWW** (republish supersedes), `Other` escape hatch carries its string. Single in-process `Airc` proves it synchronously.

## Validation
`cargo fmt`, `clippy -p airc-core -p airc-lib --tests -- -D warnings`, airc-core 68 lib tests + the channel_purpose integration test — all green.

## For M5
Variant set as we agreed (Chat/Coordination/Game/Academy/Help/Settings + `Other`). `channel_purpose() -> Result<Option<ChannelPurpose>, AircError>`, LWW, `pub`+serde, re-exported from `airc_lib`. Consume after the next continuum pin bump (same one that picks up room_roster #1232). If you want Broadcast or another kind promoted out of `Other` to first-class, say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)