### PR TITLE
fix(doctrine): room_doctrine is LWW, not first-match (stale-after-republish)

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -622,6 +622,14 @@ impl Airc {
         &self,
     ) -> Result<Option<airc_core::doctrine::RoomDoctrinePublished>, AircError> {
         let events = self.page_recent(200).await?;
+        // True LWW by `published_at_ms` — NOT first-match. `page_recent`
+        // is not guaranteed newest-first (proven by the channel_purpose
+        // LWW test), so returning the first matching event surfaces a
+        // STALE doctrine after a republish — a consumer (continuum's
+        // RoomDoctrineSource) would then inject yesterday's rules. Scan
+        // all candidates and keep the highest timestamp (ties broken by
+        // later-in-page, the durable-log order).
+        let mut latest: Option<airc_core::doctrine::RoomDoctrinePublished> = None;
         for event in events {
             if event.kind != airc_core::TranscriptKind::DoctrinePublished {
                 continue;
@@ -634,9 +642,14 @@ impl Airc {
             else {
                 continue;
             };
-            return Ok(Some(card));
+            if latest
+                .as_ref()
+                .is_none_or(|current| card.published_at_ms >= current.published_at_ms)
+            {
+                latest = Some(card);
+            }
         }
-        Ok(None)
+        Ok(latest)
     }
 
     /// Publish the room operating doctrine — card a9767579 (slice 2/4

--- a/crates/airc-lib/tests/room_doctrine_lww.rs
+++ b/crates/airc-lib/tests/room_doctrine_lww.rs
@@ -1,0 +1,56 @@
+//! `Airc::room_doctrine` is latest-write-wins, not first-match.
+//!
+//! what this catches: the read used to `return Ok(Some(card))` on the
+//! FIRST `DoctrinePublished` event in `page_recent`. `page_recent` is
+//! not guaranteed newest-first (the channel_purpose LWW test proves
+//! it isn't), so after a doctrine is REPUBLISHED, first-match could
+//! surface the STALE prior doctrine — and continuum's RoomDoctrineSource
+//! would inject yesterday's rules into a persona's prompt. This pins
+//! that the projection returns the doctrine with the highest
+//! `published_at_ms`.
+
+use airc_lib::Airc;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn room_doctrine_returns_latest_not_first_match() {
+    let tmp = TempDir::new().expect("tempdir");
+    let airc = Airc::open(tmp.path().join(".airc")).await.expect("open");
+    airc.join("general").await.expect("join general");
+
+    // Unset → None.
+    assert!(
+        airc.room_doctrine().await.expect("read unset").is_none(),
+        "a room with no published doctrine reads back None",
+    );
+
+    // Publish v1, then v2 (a later republish — the operator updated the
+    // rules). LWW must return v2.
+    airc.publish_room_doctrine(
+        "# rules v1\nbe terse".to_string(),
+        "v1aaaaaaaaaa".to_string(),
+    )
+    .await
+    .expect("publish v1");
+    airc.publish_room_doctrine(
+        "# rules v2\nbe terse AND cite sources".to_string(),
+        "v2bbbbbbbbbb".to_string(),
+    )
+    .await
+    .expect("publish v2");
+
+    let current = airc
+        .room_doctrine()
+        .await
+        .expect("read doctrine")
+        .expect("a doctrine is published");
+    assert_eq!(
+        current.version, "v2bbbbbbbbbb",
+        "room_doctrine must return the LATEST republished doctrine (LWW), \
+         not the first match in page_recent: got {current:?}",
+    );
+    assert!(
+        current.body.contains("cite sources"),
+        "the latest body must be returned, not the stale v1: {current:?}",
+    );
+}


### PR DESCRIPTION
## The bug

`room_doctrine()` returned the **first** `DoctrinePublished` event in `page_recent`. But `page_recent` is **not newest-first** — the `channel_purpose` LWW test (#1233) proves an older publish can iterate before a newer one. So after a doctrine is **republished** (operator updates the rules), first-match surfaces the **stale prior doctrine** — and continuum's `RoomDoctrineSource` would inject *yesterday's* rules into a persona's prompt.

Surfaced while building #1233 — same latent bug `channel_purpose` would have had; this brings `room_doctrine` to the same correct LWW.

## Fix

Scan all `DoctrinePublished` candidates, keep the highest `published_at_ms` (true LWW).

## Test
`room_doctrine_lww.rs`: publish v1 → v2, assert `room_doctrine()` returns **v2**, not v1.

## Validation
`cargo fmt`, `clippy -p airc-lib --tests -- -D warnings`, the new test — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)