### PR TITLE
fix(purpose): ChannelPurpose is an OPEN value, not a closed enum (no rust gate around cognition)

### DIFF
--- a/crates/airc-core/src/channel_purpose.rs
+++ b/crates/airc-core/src/channel_purpose.rs
@@ -1,79 +1,97 @@
-//! Channel purpose — the substrate-published TYPED nature of a room,
-//! so a citizen calibrates participation (auto-respond cadence, tone,
-//! verbosity) to the room WITHOUT an LLM parsing free-form doctrine
-//! prose.
+//! Channel purpose — the substrate-published OPEN room-nature value, so
+//! a citizen can be grounded in what a room is FOR (and continuum can
+//! select the room's cognition recipe) without the substrate enumerating
+//! a closed list of room kinds.
 //!
-//! Complementary to [`crate::doctrine`], NOT a duplicate of it:
-//!   - **purpose** (this module) = the typed COARSE kind, one enum
-//!     value. Drives a consumer's participation gate deterministically
-//!     (a `Coordination` room tightens auto-respond reliably; a `Game`
-//!     room loosens it). Carries NO prose.
-//!   - **doctrine** = the free-form FINE rules (markdown). Carries NO
-//!     typed kind.
+//! ## Why this is an OPEN value, not a typed enum
 //!
-//! A room may have both: a `Coordination` purpose AND a doctrine doc
-//! with the specifics. The persona uses purpose for coarse calibration,
-//! doctrine for the rules. This split is what stops Ivar-style
-//! over-talking in coordination rooms without making the model infer
-//! room-nature from markdown every turn.
+//! An earlier cut (#1233) made `ChannelPurpose` a closed enum
+//! (`Chat | Coordination | Game | …`) intended to drive a persona's
+//! should-respond gate. That was the wrong shape — a Rust enum driving
+//! cognition is the `no-rust-gates-around-cognition` anti-pattern, and
+//! room nature is INFINITE by construction: continuum rooms run a
+//! `RecipeEntity` (recipes are DATA, not an enum of kinds), and the
+//! room's purpose is just the recipe / activity key. So purpose is an
+//! **open string** — the activity/recipe key the room runs.
 //!
-//! Wire shape mirrors [`crate::doctrine::DoctrineEvent`] and
-//! `IdentityEvent`: an internally-tagged event enum so a JSON body
-//! always carries a `kind` field consumers switch on; the projection
-//! (`Airc::channel_purpose`) takes the latest per room by LWW.
+//! Layer split:
+//!   - **airc** publishes + projects the open purpose value (this
+//!     module). It has NO opinion on what a purpose MEANS or how a
+//!     persona should behave for it.
+//!   - **continuum** grounds the persona in the purpose and lets the
+//!     RecipeEntity pipeline (its `ai/should-respond` step) own
+//!     participation behavior — infinite, per-recipe, in the cognition
+//!     layer where it belongs.
+//!
+//! Complementary to [`crate::doctrine`]: purpose = the open activity key
+//! (what the room runs); doctrine = the free-form rules (markdown).
+//!
+//! Wire shape mirrors [`crate::doctrine::DoctrineEvent`]: an internally-
+//! tagged event enum so a JSON body carries a `kind` field; the
+//! projection (`Airc::channel_purpose`) takes the latest per room (LWW).
 
 use crate::ids::{PeerId, RoomId};
 use serde::{Deserialize, Serialize};
 
-/// The typed coarse KIND of a channel. Consumers (continuum's
-/// `RoomPurposeSource`, future Hermes/OpenClaw adapters) match on this
-/// to calibrate participation deterministically — never inferring it
-/// from prose.
-///
-/// `Other` is the escape hatch for a nature not in the closed set
-/// (matching [`crate::ExternalIdentitySource::Other`]); a recurring
-/// kind should earn a dedicated variant rather than living in `Other`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ChannelPurpose {
-    /// Open conversation — normal cadence, sociable.
-    Chat,
-    /// Work / ops coordination — terse, signal-dense, TIGHT auto-respond
-    /// (the room where a grounded persona must not over-talk).
-    Coordination,
-    /// Play — in-character, playful, looser cadence.
-    Game,
-    /// Teaching / learning — explanatory, patient.
-    Academy,
-    /// Support / Q&A — responsive to questions, otherwise quiet.
-    Help,
-    /// Configuration / control — minimal chatter, act-on-request.
-    Settings,
-    /// Escape hatch — a nature not (yet) in the closed set. Existing
-    /// well-known kinds should add a dedicated variant.
-    Other(String),
+/// A room's OPEN purpose value — the activity / recipe key the room
+/// runs (e.g. `"coordination"`, `"game:chess"`, a recipe id). Deliberately
+/// NOT an enum: room nature is infinite, and continuum's RecipeEntity
+/// pipeline — not a substrate type — owns what a purpose means for
+/// cognition. Serializes transparently as the bare string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ChannelPurpose(pub String);
+
+impl ChannelPurpose {
+    /// Build a purpose from any activity/recipe key.
+    pub fn new(key: impl Into<String>) -> Self {
+        Self(key.into())
+    }
+
+    /// The activity/recipe key as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-/// Typed channel-purpose domain events. Internally tagged via serde so
-/// a JSON body always carries a `kind` field consumers switch on
-/// without parsing the whole payload — same shape as
-/// [`crate::doctrine::DoctrineEvent`]. Single variant today; the enum
-/// keeps the upgrade path honest (an unknown future `kind` surfaces as
-/// a decode error, never a silent mis-decode).
+impl From<String> for ChannelPurpose {
+    fn from(key: String) -> Self {
+        Self(key)
+    }
+}
+
+impl From<&str> for ChannelPurpose {
+    fn from(key: &str) -> Self {
+        Self(key.to_string())
+    }
+}
+
+impl std::fmt::Display for ChannelPurpose {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Typed channel-purpose domain events. Internally tagged via serde so a
+/// JSON body always carries a `kind` field consumers switch on — same
+/// shape as [`crate::doctrine::DoctrineEvent`]. The EVENT is typed; the
+/// `purpose` payload it carries is an open value. Single variant today;
+/// the enum keeps the upgrade path honest (an unknown future `kind`
+/// surfaces as a decode error, never a silent mis-decode).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ChannelPurposeEvent {
     ChannelPurposePublished(ChannelPurposePublished),
 }
 
-/// A room's typed purpose published on the substrate. Authority is flat
+/// A room's open purpose published on the substrate. Authority is flat
 /// (per AGENTS.md §6: no role-based dispatch) — every peer may publish;
 /// the projection takes the latest by `published_at_ms` (LWW).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChannelPurposePublished {
     /// The room this purpose applies to.
     pub room_id: RoomId,
-    /// The typed coarse kind.
+    /// The open activity/recipe key the room runs.
     pub purpose: ChannelPurpose,
     /// Peer that emitted this version. Not gating — see module doc.
     pub published_by: PeerId,
@@ -88,27 +106,29 @@ mod tests {
     use super::*;
     use serde_json::Value;
 
-    fn sample(purpose: ChannelPurpose) -> ChannelPurposePublished {
+    fn sample(purpose: &str) -> ChannelPurposePublished {
         ChannelPurposePublished {
             room_id: RoomId::from_u128(7),
-            purpose,
+            purpose: ChannelPurpose::new(purpose),
             published_by: PeerId::from_u128(42),
             published_at_ms: 1_700_000_000_000,
         }
     }
 
     #[test]
-    fn channel_purpose_event_round_trips_through_serde() {
-        for purpose in [
-            ChannelPurpose::Chat,
-            ChannelPurpose::Coordination,
-            ChannelPurpose::Game,
-            ChannelPurpose::Academy,
-            ChannelPurpose::Help,
-            ChannelPurpose::Settings,
-            ChannelPurpose::Other("broadcast".to_string()),
+    fn channel_purpose_event_round_trips_for_arbitrary_open_values() {
+        // The whole point: ANY activity/recipe key round-trips — there is
+        // no closed set. A future recipe key the substrate has never seen
+        // is just a string, not a decode error.
+        for key in [
+            "chat",
+            "coordination",
+            "game:chess",
+            "academy:rust-101",
+            "continuum:recipe:7f3a",
+            "",
         ] {
-            let event = ChannelPurposeEvent::ChannelPurposePublished(sample(purpose));
+            let event = ChannelPurposeEvent::ChannelPurposePublished(sample(key));
             let json = serde_json::to_string(&event).expect("serialize");
             let decoded: ChannelPurposeEvent = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(event, decoded);
@@ -116,63 +136,42 @@ mod tests {
     }
 
     #[test]
-    fn wire_kind_discriminator_is_stable() {
-        // Consumers switch on `kind` without parsing the body; pin the
-        // discriminator so a serde change can't silently rename it
-        // (same lesson as DoctrineEvent / IdentityEvent — kink 0cfcc8db).
-        let event =
-            ChannelPurposeEvent::ChannelPurposePublished(sample(ChannelPurpose::Coordination));
+    fn purpose_serializes_as_a_bare_string_not_an_enum_tag() {
+        // `#[serde(transparent)]` means the wire value is the open key
+        // itself — `"coordination"`, never `{"coordination":...}` or a
+        // closed-variant tag. Consumers read an open string.
+        let value = serde_json::to_value(ChannelPurpose::new("coordination")).expect("to_value");
+        assert_eq!(
+            value.as_str(),
+            Some("coordination"),
+            "purpose is an OPEN string value, not a typed enum",
+        );
+    }
+
+    #[test]
+    fn event_carries_open_purpose_and_stable_kind_discriminator() {
+        let event = ChannelPurposeEvent::ChannelPurposePublished(sample("game:chess"));
         let value: Value = serde_json::to_value(&event).expect("to_value");
         assert_eq!(
             value.get("kind").and_then(Value::as_str),
             Some("channel_purpose_published"),
             "event wire kind must be stable",
         );
-        assert!(value.get("room_id").is_some());
-        assert!(value.get("purpose").is_some());
-        assert!(value.get("published_by").is_some());
-        assert!(value.get("published_at_ms").is_some());
-    }
-
-    #[test]
-    fn closed_variants_serialize_as_stable_snake_case_strings() {
-        // The typed kind drives a deterministic participation gate on the
-        // consumer side, so its wire strings are load-bearing — pin them.
-        for (purpose, wire) in [
-            (ChannelPurpose::Chat, "chat"),
-            (ChannelPurpose::Coordination, "coordination"),
-            (ChannelPurpose::Game, "game"),
-            (ChannelPurpose::Academy, "academy"),
-            (ChannelPurpose::Help, "help"),
-            (ChannelPurpose::Settings, "settings"),
-        ] {
-            let value = serde_json::to_value(&purpose).expect("to_value");
-            assert_eq!(
-                value.as_str(),
-                Some(wire),
-                "closed variant must serialize to a stable string",
-            );
-        }
-    }
-
-    #[test]
-    fn other_escape_hatch_carries_its_payload() {
-        let value =
-            serde_json::to_value(ChannelPurpose::Other("broadcast".to_string())).expect("to_value");
-        // Externally-tagged: `{"other":"broadcast"}`.
         assert_eq!(
-            value.get("other").and_then(Value::as_str),
-            Some("broadcast"),
-            "Other carries its consumer-defined string",
+            value.get("purpose").and_then(Value::as_str),
+            Some("game:chess"),
+            "the open purpose key rides as a bare string on the event",
         );
     }
 
     #[test]
     fn unknown_event_kind_surfaces_as_decode_error() {
-        // A future-version event a current consumer doesn't know about
-        // must error, not silently mis-decode. Keeps the upgrade honest.
+        // A future-version EVENT kind a current consumer doesn't know
+        // about must error (the event enum stays honest). Distinct from
+        // the PURPOSE value, which is open and never errors on an unknown
+        // key.
         let raw = r#"{"kind":"channel_purpose_retired","room_id":"00000000-0000-0000-0000-000000000001"}"#;
         let result: Result<ChannelPurposeEvent, _> = serde_json::from_str(raw);
-        assert!(result.is_err(), "unknown kind must error");
+        assert!(result.is_err(), "unknown event kind must error");
     }
 }

--- a/crates/airc-lib/tests/channel_purpose.rs
+++ b/crates/airc-lib/tests/channel_purpose.rs
@@ -26,40 +26,32 @@ async fn channel_purpose_publishes_reads_back_and_is_lww() {
     let airc = Airc::open(tmp.path().join(".airc")).await.expect("open");
     airc.join("general").await.expect("join general");
 
-    // Unset → None (no typed purpose published in the window).
+    // Unset → None (no purpose published in the window).
     assert_eq!(
         airc.channel_purpose().await.expect("read unset"),
         None,
         "a room with no published purpose reads back None",
     );
 
-    // Publish a typed kind; the projection returns it verbatim.
-    airc.publish_channel_purpose(ChannelPurpose::Coordination)
+    // Publish an OPEN purpose key; the projection returns it verbatim.
+    airc.publish_channel_purpose(ChannelPurpose::new("coordination"))
         .await
         .expect("publish coordination");
     assert_eq!(
         airc.channel_purpose().await.expect("read coordination"),
-        Some(ChannelPurpose::Coordination),
-        "the typed purpose reads back verbatim — same enum the publisher sent",
+        Some(ChannelPurpose::new("coordination")),
+        "the open purpose key reads back verbatim",
     );
 
-    // Latest-write-wins: a newer publish of a different kind supersedes.
-    airc.publish_channel_purpose(ChannelPurpose::Game)
+    // Latest-write-wins: a newer publish supersedes the prior one. The
+    // value is an OPEN key (here a per-recipe activity key the substrate
+    // has never enumerated) — proving purpose is infinite, not a closed set.
+    airc.publish_channel_purpose(ChannelPurpose::new("game:chess"))
         .await
         .expect("republish game");
     assert_eq!(
         airc.channel_purpose().await.expect("read game"),
-        Some(ChannelPurpose::Game),
-        "LWW: the newest published purpose wins over the prior one",
-    );
-
-    // The `Other` escape hatch round-trips its consumer-defined string.
-    airc.publish_channel_purpose(ChannelPurpose::Other("broadcast".to_string()))
-        .await
-        .expect("publish other");
-    assert_eq!(
-        airc.channel_purpose().await.expect("read other"),
-        Some(ChannelPurpose::Other("broadcast".to_string())),
-        "Other carries its consumer-defined kind through the substrate",
+        Some(ChannelPurpose::new("game:chess")),
+        "LWW: the newest published purpose wins; an arbitrary open key round-trips",
     );
 }


### PR DESCRIPTION
## The correction

#1233 made `ChannelPurpose` a **closed enum** (`Chat | Coordination | Game | …`) to drive a persona's should-respond gate. **Joel caught it; M5 + Intel Mac confirmed** — that's the `no-rust-gates-around-cognition` anti-pattern (a Rust enum driving cognition), and room nature is **infinite by construction**: continuum rooms run a `RecipeEntity` (recipes are DATA — "what is NOT a recipe: an enum of recipe kinds"), and a room's purpose is just the recipe / activity key.

## The fix

`ChannelPurpose` becomes an **open value**:
```rust
#[serde(transparent)]
pub struct ChannelPurpose(pub String);   // "coordination", "game:chess", a recipe id…
```
The wire value is the bare open key — never a closed-variant tag. **airc** publishes + projects it with no opinion on meaning; **continuum** grounds the persona in it and lets the `RecipeEntity` pipeline (`ai/should-respond`) own participation behavior — infinite, per-recipe, *in the cognition layer*. Doctrine stays the complementary free-form rules.

**Does NOT touch grid-auth #1653** (`GridTrustAuthPolicy`): that gates **commands/authz** — a legitimate gate. The anti-pattern is only about gating should-respond / what-to-say with a substrate type.

## Validation
- API unchanged (`publish_channel_purpose` / `channel_purpose() -> Option<ChannelPurpose>`, LWW); only the value type opens.
- `cargo fmt`, `clippy -p airc-core -p airc-lib --tests -- -D warnings`, airc-core channel_purpose tests (4, incl. arbitrary-open-key round-trip + serializes-as-bare-string) + the open-value LWW integration test — all green.

## For M5
You haven't consumed #1233 yet (gated on the pin bump), so this lands clean. Build `RoomPurposeSource` to read `channel_purpose() -> Option<ChannelPurpose>` as an **open string** (`.0` / `.as_str()` is the recipe/activity key) and let the recipe pipeline own should-respond. No enum to match on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)