### PR TITLE
fix(routing): adapter-ladder liveness OR in capability matching (liveness slice 1)

### DIFF
--- a/crates/airc-lib/src/capability_registry.rs
+++ b/crates/airc-lib/src/capability_registry.rs
@@ -103,6 +103,20 @@ pub struct CapabilityQuery<'a> {
     /// Offers last seen more than this many ms before `now_ms` are aged
     /// out of results.
     pub ttl_ms: u64,
+    /// Peers reachable RIGHT NOW via a live transport adapter (LAN
+    /// connection, a recent direct frame) — the adapter-ladder liveness
+    /// signal. An entry whose `peer_id` is in this set is treated as LIVE
+    /// even if its offer `last_seen_ms` has aged past `ttl_ms`.
+    ///
+    /// Why: capability staleness keys off the rendezvous-beacon / re-advert
+    /// cadence, which is gh-gist-coupled and gh-auth-gated; when that path
+    /// flaps, a peer's offer ages out and routing DROPS it — orphaning a
+    /// node that is perfectly DELIVERABLE over LAN (delivery already uses
+    /// the tried-in-order adapter ladder; liveness must not ignore it).
+    /// `None` = no adapter signal available (preserves the prior
+    /// beacon-only behaviour). The gist beacon stays the rendezvous of
+    /// last resort for DISCOVERY, never the sole truth for LIVENESS.
+    pub reachable_peers: Option<&'a std::collections::HashSet<PeerId>>,
 }
 
 impl CapabilityRegistry {
@@ -182,7 +196,16 @@ impl CapabilityRegistry {
         let mut candidates: Vec<CapabilityCandidate> = self
             .entries
             .values()
-            .filter(|entry| !is_stale(entry.last_seen_ms, query.now_ms, query.ttl_ms))
+            // Live if the offer is fresh OR the peer is reachable right now
+            // via a live adapter (the adapter-ladder liveness OR). A
+            // LAN-connected peer is never dropped from routing just because
+            // its gh-gist-gated beacon/offer aged out.
+            .filter(|entry| {
+                !is_stale(entry.last_seen_ms, query.now_ms, query.ttl_ms)
+                    || query
+                        .reachable_peers
+                        .is_some_and(|live| live.contains(&entry.peer_id))
+            })
             .filter_map(|entry| {
                 let matched_tags = matched_tag_count(&entry.capabilities, query.required_tags);
                 // ALL required tags must be present. Empty required_tags
@@ -271,6 +294,7 @@ mod tests {
             required_tags: tags,
             now_ms,
             ttl_ms: DEFAULT_OFFER_TTL_MS,
+            reachable_peers: None,
         }
     }
 
@@ -319,6 +343,7 @@ mod tests {
             required_tags: &["code"],
             now_ms: 12_000,
             ttl_ms: 5_000,
+            reachable_peers: None,
         };
         let hit = registry.match_for(&q, |_| TrustTier::OwnMachine);
         assert_eq!(hit.len(), 1, "re-advert kept the node live");
@@ -336,6 +361,7 @@ mod tests {
             required_tags: &["code"],
             now_ms: 1_000 + DEFAULT_OFFER_TTL_MS + 1,
             ttl_ms: DEFAULT_OFFER_TTL_MS,
+            reachable_peers: None,
         };
         assert!(
             registry.match_for(&q, |_| TrustTier::OwnMachine).is_empty(),
@@ -343,6 +369,64 @@ mod tests {
         );
         // Entry still physically present until pruned (query-time ageing).
         assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn reachable_peer_matches_despite_stale_offer_adapter_ladder_rescue() {
+        // The orphaning fix: a peer whose offer has aged past ttl (its
+        // gh-gist-gated beacon/re-advert went stale) MUST still match when
+        // it is reachable RIGHT NOW via a live adapter — delivery would
+        // reach it over LAN, so routing must not drop it. Without the OR
+        // this peer ages out (proven by `ages_out_stale_entries_at_query_time`);
+        // with it in `reachable_peers`, it stays routable.
+        let mut registry = CapabilityRegistry::new();
+        let peer = PeerId::from_u128(42);
+        registry.ingest_offer(peer, caps("skylar", &["code"], "fable-5", 100_000), 1_000);
+
+        let now = 1_000 + DEFAULT_OFFER_TTL_MS + 1; // offer is stale at this clock
+        let reachable: std::collections::HashSet<PeerId> = std::iter::once(peer).collect();
+
+        // Beacon-only (reachable_peers: None) → aged out, as the sibling
+        // test pins. With the adapter-ladder set → rescued.
+        let stale_q = CapabilityQuery {
+            required_tags: &["code"],
+            now_ms: now,
+            ttl_ms: DEFAULT_OFFER_TTL_MS,
+            reachable_peers: None,
+        };
+        assert!(
+            registry
+                .match_for(&stale_q, |_| TrustTier::OwnMachine)
+                .is_empty(),
+            "control: a stale offer with no adapter signal still ages out"
+        );
+
+        let rescued_q = CapabilityQuery {
+            reachable_peers: Some(&reachable),
+            ..stale_q
+        };
+        let hit = registry.match_for(&rescued_q, |_| TrustTier::OwnMachine);
+        assert_eq!(
+            hit.len(),
+            1,
+            "a stale-offer peer that is LAN-reachable must still match (adapter-ladder rescue)"
+        );
+        assert_eq!(hit[0].peer_id, peer);
+
+        // And the rescue is targeted: a DIFFERENT reachable peer does not
+        // resurrect this stale one.
+        let other: std::collections::HashSet<PeerId> =
+            std::iter::once(PeerId::from_u128(99)).collect();
+        let other_q = CapabilityQuery {
+            reachable_peers: Some(&other),
+            ..stale_q
+        };
+        assert!(
+            registry
+                .match_for(&other_q, |_| TrustTier::OwnMachine)
+                .is_empty(),
+            "reachability of a different peer must not rescue this stale offer"
+        );
     }
 
     #[test]

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -566,6 +566,12 @@ pub fn select_candidate_for_turn(
         required_tags: &required,
         now_ms,
         ttl_ms,
+        // A real continuum consumer passes the adapter-ladder-reachable
+        // peer set here (connected_lan_peers + recent direct frames) so a
+        // LAN-reachable peer is never dropped from routing on a stale
+        // beacon; this example has no live route state, so None (the prior
+        // beacon-only behaviour).
+        reachable_peers: None,
     };
     registry.match_for(&query, trust_of).into_iter().next()
 }


### PR DESCRIPTION
## The months-long orphaning seam (M5 surfaced, traced in code)

Cross-machine liveness is decided **solely** by gist-beacon / offer staleness. The **capability registry** — the consumer that picks a peer for cross-grid routing — ages a peer out of `match_for` when its offer `last_seen` passes ttl. That offer refreshes via the **gh-gist-coupled, gh-auth-gated** registry tick (`RegistryRefreshGate::GhAuth` cleanly *skips* when gh isn't ready), so a peer that's perfectly **deliverable over LAN** gets **dropped from routing** the instant that path flaps.

The mismatch: **delivery** already uses the tried-in-order adapter ladder (LAN preferred, gist last); **liveness** ignored it.

## Fix — OR-source liveness from the adapter ladder

`CapabilityQuery` gains `reachable_peers: Option<&HashSet<PeerId>>` (peers reachable *right now* via a live adapter — `connected_lan_peers` + recent direct frames), and `match_for` keeps an entry if:
```rust
!is_stale(...) || reachable_peers.is_some_and(|live| live.contains(&peer))
```
The gist beacon stays the rendezvous-of-last-resort for **discovery**, never the sole truth for **liveness**. **Additive** — `None` preserves prior beacon-only behaviour; it only rescues false-deads, can't drop a live peer. Subsumes the cadence-flap too (a connected peer can't flap stale).

## Test
`reachable_peer_matches_despite_stale_offer_adapter_ladder_rescue`: a stale-offer peer that's LAN-reachable **still matches**; the control (no adapter signal) **still ages out**; and the rescue is **targeted** (a *different* reachable peer doesn't resurrect this one).

## Scope
**Slice 1 = the capability-registry routing layer** — the load-bearing orphaning point. Follow-ups: same OR at the coordinator presence partition + account-registry prune; and continuum's consumer passing its `connected_lan_peers` to *activate* it (the `consumer_shapes` example documents the seam, passes `None` for now).

## Validation
`cargo fmt`; `clippy -p airc-lib --lib -- -D warnings`; airc-lib `capability_registry` **11/11**; `consumer-shapes` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)