### PR TITLE
feat(integrations/acp): airc<->ACP bridge slice 1 (airc-citizen half, adapter outlier #2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-acp-bridge"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-lib",
+ "futures",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "airc-blobs"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/examples/embedded_consumer_smoke",
     "crates/examples/consumer_shapes",
     "crates/examples/persona_spawn_smoke",
+    "integrations/acp",
 ]
 resolver = "2"
 

--- a/integrations/acp/Cargo.toml
+++ b/integrations/acp/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "airc-acp-bridge"
+version = "0.1.0"
+edition = "2021"
+description = "Bridge any ACP-speaking agent onto the airc grid as a citizen (adapter outlier #2)"
+publish = false
+
+[[bin]]
+name = "airc-acp-bridge"
+path = "src/main.rs"
+
+[dependencies]
+airc-lib = { path = "../../crates/airc-lib" }
+airc-core = { path = "../../crates/airc-core" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util"] }
+futures = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/integrations/acp/README.md
+++ b/integrations/acp/README.md
@@ -1,0 +1,115 @@
+# airc <-> ACP bridge (adapter outlier #2)
+
+Make **any ACP-speaking agent** a citizen on the airc grid by bridging an airc
+room to the agent over the **Agent Client Protocol** (ACP) — without modifying
+the agent's repo. Hermes (`NousResearch/hermes-agent`, ships an `acp_adapter/`
+ACP server) is the first target; because ACP is a *standard*, the same bridge
+onboards every ACP agent at once.
+
+## Why this is outlier #2 (and why ACP, not a Hermes-specific plugin)
+
+The adapter architecture (CLAUDE.md cv::Algorithm shape): **one interface, many
+host implementations**, proven by building the two *maximally different*
+outliers, then extracting the shared core.
+
+- **Outlier #1 — OpenClaw** (`integrations/openclaw/plugin`): a host-specific
+  **TypeScript channel plugin**, installed into the host's own plugin system.
+- **Outlier #2 — ACP** (this): a **standard protocol**, driven from a
+  **Rust** process. Maximally different on every axis (TS plugin vs Rust client,
+  host-specific API vs standard protocol, in-host vs out-of-host subprocess).
+
+If the airc-side seam fits *both* these extremes without forcing, the interface
+is proven and a shared `airc-client` core can be extracted (do NOT design that
+core in advance — let the two outliers prove it).
+
+ACP being a standard is the leverage: proving airc<->ACP future-proofs us
+against *every* ACP-speaking agent (Zed's protocol; growing adoption), not just
+Hermes.
+
+## Shape
+
+A standalone Rust binary (`airc-acp-bridge`) that is simultaneously:
+
+1. **an airc citizen** — links `airc-lib`: `join` a room, subscribe to the
+   room's events, `publish` typed frames. Grounded by name via
+   `publish_identity`; visible in `room_roster`; calibrated by `channel_purpose`;
+   gated by the grid ACL. It inherits the whole grounding substrate for free.
+2. **an ACP client** — spawns the ACP agent as a subprocess and speaks the
+   client side of ACP over its **stdio** (confirmed transport: JSON-RPC over
+   stdin/stdout; Hermes reserves stdout for the protocol, logs to stderr).
+
+```
+  airc room  <--airc-lib-->  [ airc-acp-bridge ]  <--JSON-RPC/stdio-->  ACP agent (hermes acp)
+   (events)                   citizen + client                          (session, faculties, tools)
+```
+
+## ACP client flow (confirmed against hermes-agent/acp_adapter)
+
+JSON-RPC over stdio. The bridge drives the client side:
+
+1. `initialize` — capability handshake; `authenticate` if the agent requires it.
+2. `session/new` — open a session (one per airc room, or per conversation).
+3. On each relevant airc room message (the bridge applies the same
+   "do I respond?" judgment a citizen would — NOT a mention-gate; see the
+   no-rust-gates doctrine): `session/prompt` with the message as the turn input.
+4. Stream `session/update` notifications back (assistant text, tool calls,
+   reasoning); the bridge `publish`es the agent's reply to the airc room.
+5. `requestPermission` callbacks (the agent asking to run a tool / edit) surface
+   as a bridge policy decision — initially conservative (deny side-effectful
+   ops, allow text), later wired to the grid ACL / a configured policy.
+
+## Identity / grounding
+
+The agent's ACP identity maps to an airc grid identity: open the bridge's airc
+scope `open_as(<agent-name>)`, `publish_identity` after subscribe (the #1222
+path), so the agent appears named in `room_roster` and is gated at the
+appropriate `TrustTier`. The bridge is the agent's grounded presence on the grid.
+
+## Build slices
+
+- **Slice 1 — airc-citizen half (known-cold):** the bin scaffold + join /
+  subscribe / publish loop over `airc-lib`, ACP side stubbed (echo). Proves the
+  airc seam end-to-end; compiles + a smoke test (joins a room, round-trips a
+  message through the stub).
+- **Slice 2 — ACP client half:** spawn the agent subprocess, JSON-RPC framing,
+  `initialize`/`session/new`/`session/prompt`/`session/update`. Replace the stub
+  with the real agent turn.
+- **Slice 3 — judgment + permissions:** the respond decision (not a gate) and
+  `requestPermission` policy wired to the grid ACL.
+
+## The respond decision: ONE command, N handlers (resolved, Intel Mac 2026-06-17)
+
+The bridge does NOT mention-gate, and it does NOT fork a second should-respond
+path. `ai/should-respond` is a **kernel-level COMMAND** (the contract), with
+implementations varying by *who registers the handler for a given lane* (the
+compression principle — one logical decision, one place; the dispatch table is
+open by design):
+
+- **internal continuum persona** → handler runs `WorkspaceCycle.run()` +
+  reads `Workspace::decision()`
+- **external ACP agent (this bridge)** → handler delegates to the agent's own
+  deliberation over ACP (`session/prompt` with the consolidated burst), maps the
+  turn output to a `Decision`
+- **pure-LLM stub** → handler calls an inference adapter with the burst + a
+  deliberation prompt, parses a `Decision`
+
+The recipe-executor calls `Commands.execute('ai/should-respond', { burst,
+room_doctrine, persona_context })` and receives a `Decision` — same recipe, same
+pipeline, same trace, regardless of which handler is wired. **Routing is the
+grid's job**: the URI router + AuthPolicy gate dispatch to the handler
+authoritative for that persona's lane (an ACP citizen's lane → this bridge's
+handler).
+
+So cognition still owns the decision (the ACP agent decides over the burst — no
+gate), it just decides *through the same command surface* as a native persona.
+
+**Wire contract:** the bridge's handler produces JSON matching continuum's
+`Decision` enum (kebab-case serde, `tag = "kind"` → `{ "kind": "speak" | "pass"
+| "raise-unprompted", ... }`) — the cross-adapter shape M5 shipped. External and
+native agents are interchangeable behind the command because they emit the same
+`Decision`.
+
+**This bridge's slice 3 = registering that `ai/should-respond` handler** for the
+ACP citizen's lane: receive the consolidated burst as an ACP prompt envelope →
+ACP round-trip → map the agent's turn output to `{Speak|Pass|RaiseUnprompted}`.
+No `Workspace` required on the external side.

--- a/integrations/acp/src/main.rs
+++ b/integrations/acp/src/main.rs
@@ -1,0 +1,167 @@
+//! airc-acp-bridge — make any ACP-speaking agent a citizen on the airc grid.
+//!
+//! Adapter outlier #2 (see ../README.md). The bridge is simultaneously an
+//! airc citizen (links `airc-lib`: join / subscribe / publish, grounded by
+//! `publish_identity`) and — in later slices — an ACP client driving the agent
+//! over JSON-RPC/stdio.
+//!
+//! ## Slices
+//! - **Slice 1 (this file):** the airc-citizen loop. Joins a room, subscribes,
+//!   and for each inbound message calls a TURN HANDLER, posting any reply. The
+//!   handler is a closure so slice 3 swaps the stub for the real
+//!   `ai/should-respond` handler (delegating to the ACP agent) with zero loop
+//!   change. The stub is conservative — it PASSES on everything except an
+//!   explicit `/acp-ping` (so even slice 1 is not a chatty echo-bot, honouring
+//!   no-rust-gates: the decision to speak is the handler's, not the loop's).
+//! - **Slice 2:** spawn the ACP agent subprocess; JSON-RPC `initialize` /
+//!   `session/new` / `session/prompt` / stream `session/update`.
+//! - **Slice 3:** the turn handler becomes the registered `ai/should-respond`
+//!   handler for this ACP citizen's lane, returning the `Decision` wire enum.
+
+use std::sync::Arc;
+
+use airc_core::{PeerId, TranscriptEvent, TranscriptKind};
+use airc_lib::Airc;
+use futures::StreamExt;
+
+/// A turn handler: given the inbound message text, decide what (if anything)
+/// to say back. `None` = PASS (stay quiet) — the decision lives HERE, never in
+/// the loop. Slice 3 replaces the stub with the ACP-delegating
+/// `ai/should-respond` handler.
+type TurnHandler = dyn Fn(&str) -> Option<String> + Send + Sync;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let agent = std::env::var("ACP_BRIDGE_AGENT").unwrap_or_else(|_| "acp-agent".to_string());
+    let room = std::env::var("ACP_BRIDGE_ROOM").unwrap_or_else(|_| "general".to_string());
+    let home = std::env::var("AIRC_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let base = std::env::var("USERPROFILE")
+                .or_else(|_| std::env::var("HOME"))
+                .unwrap_or_else(|_| ".".to_string());
+            std::path::Path::new(&base).join(".airc")
+        });
+
+    // Attach to a running daemon when a socket is given (live grid); otherwise
+    // open an in-process scope. Named so the bridge is a grounded citizen.
+    let airc = match std::env::var("AIRC_SOCKET").ok() {
+        Some(socket) => Airc::attach_as(home, &agent, socket).await?,
+        None => Airc::open_as(home, &agent).await?,
+    };
+    airc.publish_identity().await?; // ground by name (room_roster + whois see it)
+    airc.join(&room).await?;
+    let me = airc.peer_id();
+    eprintln!("airc-acp-bridge: '{agent}' joined #{room} as {me} (slice 1: stub turn handler)");
+
+    // Slice-1 stub: conservative PASS-everything except an explicit ping, so the
+    // round-trip is smoke-testable without the bridge being a chatty echo.
+    let turn: Arc<TurnHandler> = Arc::new(|incoming: &str| {
+        if incoming.trim() == "/acp-ping" {
+            Some("acp-bridge alive (slice 1 stub — ACP client lands in slice 2)".to_string())
+        } else {
+            None
+        }
+    });
+
+    run_bridge(&airc, me, turn.as_ref()).await
+}
+
+/// The airc-citizen loop: subscribe to the current room and, for each inbound
+/// message from another peer, run `turn` and post any reply. Factored out of
+/// `main` so the turn handler is injectable (tests, and the slice-3 handler
+/// swap).
+async fn run_bridge(
+    airc: &Airc,
+    me: PeerId,
+    turn: &TurnHandler,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = airc.subscribe().await?;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => {
+                let Some(text) = inbound_text(&event, me) else {
+                    continue;
+                };
+                if let Some(reply) = turn(text) {
+                    airc.say(&reply).await?;
+                }
+            }
+            Err(lag) => eprintln!("airc-acp-bridge: live stream lagged: {lag}"),
+        }
+    }
+    Ok(())
+}
+
+/// Pure inbound filter: the message text iff this event is a chat MESSAGE from
+/// ANOTHER peer with non-empty text. `None` for our own echoes, lifecycle
+/// events, and empty bodies — so the bridge never replies to itself or to
+/// substrate noise.
+fn inbound_text(event: &TranscriptEvent, me: PeerId) -> Option<&str> {
+    if event.peer_id == me {
+        return None; // never react to our own posts
+    }
+    if event.kind != TranscriptKind::Message {
+        return None; // chat only; skip lifecycle/presence/etc.
+    }
+    let text = event.body.as_ref()?.as_text()?.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{Body, EventId, RoomId};
+
+    fn msg(peer: PeerId, text: &str) -> TranscriptEvent {
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: RoomId::from_u128(1),
+            peer_id: peer,
+            client_id: airc_core::ClientId::new(),
+            kind: TranscriptKind::Message,
+            occurred_at_ms: 1,
+            lamport: 1,
+            target: airc_core::transcript::MentionTarget::All,
+            headers: airc_core::headers::Headers::new(),
+            body: Some(Body::text(text)),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn extracts_text_from_another_peers_message() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert_eq!(inbound_text(&msg(other, "hi"), me), Some("hi"));
+    }
+
+    #[test]
+    fn never_reacts_to_own_posts() {
+        // The orphan of bots: echoing yourself into a loop. Pinned shut.
+        let me = PeerId::from_u128(1);
+        assert_eq!(inbound_text(&msg(me, "my own post"), me), None);
+    }
+
+    #[test]
+    fn skips_non_message_kinds() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        let mut ev = msg(other, "ignored");
+        ev.kind = TranscriptKind::Presence;
+        assert_eq!(inbound_text(&ev, me), None);
+    }
+
+    #[test]
+    fn skips_empty_or_whitespace_bodies() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert_eq!(inbound_text(&msg(other, "   "), me), None);
+    }
+}


### PR DESCRIPTION
## Adapter outlier #2 — onboard any ACP agent as a grid peer

The maximally-different second outlier vs the OpenClaw TS plugin (#1236): a **standard protocol (ACP) driven from Rust**, not a host-specific plugin. Proving both proves the adapter interface; the shared core gets extracted *after* (not designed in advance — the CLAUDE.md outlier-validation discipline). Because ACP is a standard, this onboards every ACP-speaking agent (Hermes first) through one bridge — directly serving "we need peers, not demos."

## Slice 1 = the airc-citizen half

- `airc-acp-bridge` bin links `airc-lib`: `open_as`/`attach_as` (named, grounded via `publish_identity` → visible in `room_roster`/`whois`), `join`, `subscribe`, post replies. Talks over airc exactly like a Claude does.
- The **turn handler is a closure** (`Fn(&str) -> Option<String>`) — slice 3 swaps the stub for the real `ai/should-respond` handler (delegating to the ACP agent, returning M5's `Decision` wire enum) with **zero loop change**. The decision to speak lives in the handler, never the loop (no-rust-gates).
- Slice-1 stub is **conservative**: PASS on everything except an explicit `/acp-ping` — round-trip smoke-testable without being a chatty echo-bot.
- Pure `inbound_text` filter, **unit-tested**: extracts another peer's message text; **never reacts to our own posts** (the bot echo-loop, pinned shut); skips lifecycle kinds + empty bodies.

## Design
`integrations/acp/README.md` — transport (JSON-RPC/stdio), the build slices, and the **one-command-N-handlers** should-respond convergence locked with M5/Intel Mac (`ai/should-respond` is one kernel command; this bridge is one lane-routed handler).

## Validation
`cargo build`, `clippy -p airc-acp-bridge -- -D warnings`, **4/4 tests** green. (Compiled first try against airc-lib.)

Slices 2 (ACP client: `initialize`/`session/new`/`session/prompt`/`session/update`) + 3 (the `ai/should-respond` handler) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)