### PR TITLE
feat(integrations/embedding-facility): 5090 ai/embedding grid facility — design + GPU server (slice 1) + airc bridge (slice 2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-embedding-bridge"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-lib",
+ "consumer-shapes",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "airc-identity"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/examples/consumer_shapes",
     "crates/examples/persona_spawn_smoke",
     "integrations/acp",
+    "integrations/embedding-facility/bridge",
 ]
 resolver = "2"
 

--- a/integrations/embedding-facility/.env.example
+++ b/integrations/embedding-facility/.env.example
@@ -1,0 +1,20 @@
+# Copy to `.env` and adjust per host. All values have safe defaults in the
+# compose; this file documents the knobs and the BIGMAMA-specific bindings.
+
+# --- Canonical grid embedder (change GRID-WIDE in lockstep, never per-node) ---
+EMBED_HF_REPO=Qwen/Qwen3-Embedding-0.6B-GGUF
+EMBED_HF_FILE=Qwen3-Embedding-0.6B-Q8_0.gguf
+EMBED_POOLING=last
+EMBED_CTX=8192
+EMBED_UBATCH=8192
+
+# --- Server image (adapter seam) ---
+# Pin a digest here once Blackwell sm_120 is verified on the 5090.
+EMBED_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda
+
+# --- Model cache location ---
+# BIGMAMA: the 16TB foundry drive (D:). Models live on HDD (sequential load is
+# fine; inference runs from VRAM). Any box without the drive: drop this line and
+# the compose uses the `llama-model-cache` named volume instead.
+# Windows Docker Desktop path form:
+EMBED_MODEL_CACHE=D:/continuum/models/llama-cache

--- a/integrations/embedding-facility/README.md
+++ b/integrations/embedding-facility/README.md
@@ -1,0 +1,110 @@
+# airc embedding facility (5090 GPU, `ai/embedding` on the grid)
+
+A **grid compute facility**: a GPU node that serves embedding vectors to the
+whole mesh, advertised on airc as the `ai/embedding` capability and routed to
+by the *existing* cross-grid request/reply spine (`resolve_inference_target` /
+`request_inference_remote`, `crates/examples/consumer_shapes`). BIGMAMA's RTX
+5090 is the first host; any CUDA box can run the same compose.
+
+This is the supply side of the grid-compute mission ("Docker nodes as
+stand-in computers"): a peer that *cannot* embed at scale locally (no GPU, or a
+large corpus re-embedding job) escalates to a peer that can.
+
+## The non-negotiable invariant: ONE vector space across the grid
+
+Recall blends **cosine-to-burst relevance** with salience (M5's lane #1,
+`EmbeddingProvider` trait + `RecallFaculty` re-rank, landed on #1655). Cosine is
+only meaningful **between vectors from the same embedder model**. Therefore:
+
+> **The facility MUST serve the same embedding model each machine runs on its
+> local hot path.** A facility on `bge`/`nomic` while peers embed locally on
+> `qwen --embedding` produces vectors in a *different space* — they cannot be
+> compared, blended, or merged. The split (local hot-path vs GPU batch facility)
+> only composes if both sides share the model.
+
+So the facility default tracks the canonical `EmbeddingProvider` neural model
+(today: `qwen --embedding` via llama.cpp, matching M5's local neural backend).
+The model is an **adapter** — swappable behind the trait — but it must be
+swapped *grid-wide in lockstep*, not per-node. The facility documents the
+canonical model so the grid stays in one space.
+
+## Why llama.cpp `--embedding` (not TEI / sentence-transformers)
+
+1. **Same engine as the local hot path.** M5's neural `EmbeddingProvider` is
+   `qwen --embedding` (llama.cpp). Serving the *same engine + same GGUF* on the
+   GPU guarantees the same vector space (the invariant above). A different
+   server (HF Text-Embeddings-Inference, sentence-transformers) is a different
+   tokenizer/pooling/model → a different space.
+2. **Blackwell (sm_120) support.** The 5090 is Blackwell, compute 12.0, driver
+   591.55 — brand new. llama.cpp's CUDA build tracks new arches fast and builds
+   from source against the installed CUDA toolkit; TEI's prebuilt images pin
+   older compute capabilities and may ship no sm_120 kernels.
+3. **One model, many roles.** The same llama.cpp server can host generation
+   *and* embeddings; the facility is just the embedding endpoint of the node's
+   inference provider, not a parallel stack.
+
+The server choice is itself an adapter (see `docker-compose.yml` — swap the
+image/model env to move the whole facility), but the *default* is chosen to hold
+the one-vector-space invariant.
+
+## Shape
+
+```
+  peer (GPU-less / batch job)                    BIGMAMA (RTX 5090)
+  ───────────────────────────                    ──────────────────────────────
+  RecallFaculty / corpus indexer                 [ airc-embedding-bridge ]  (slice 2)
+    │ local hot path: embed locally                 advertises ai/embedding
+    │ (same model, no network)                       on airc; on EmbeddingRequested
+    │                                                → POST localhost:8080/embedding
+    │ batch / GPU-less / corpus:                   ┌───────────────────────────┐
+    └──── EmbeddingRequested ───airc-mesh────────► │ llama.cpp --embedding      │
+                                                   │ (CUDA, --gpus all, 5090)   │ (slice 1)
+          ◄──── EmbeddingEmitted (vector) ──────── │ OpenAI /v1/embeddings      │
+                                                   └───────────────────────────┘
+```
+
+**Local-first is law** (Joel): per-turn recall embeds *locally* on every
+machine — the hot path never round-trips the grid. The facility serves only the
+**heavy / shared** cases: corpus indexing, batch re-embedding, and GPU-less
+peers. It is an escalation target, never the default route. This is exactly the
+local-first decision `resolve_inference_target` already encodes — `Local` when
+the node can embed itself, `Remote(facility)` only when it can't.
+
+## Build slices
+
+- **Slice 1 — the GPU server (this dir, `docker-compose.yml`):** llama.cpp
+  `--embedding` in CUDA Docker on the 5090, serving the canonical embedding
+  GGUF. Validatable standalone: `docker compose up`, then
+  `curl -s localhost:8080/v1/embeddings -d '{"input":"hello"}'` returns a
+  vector. No airc yet — proves the GPU embedding endpoint on Blackwell.
+- **Slice 2 — the airc bridge:** a Rust bin (mirrors `integrations/acp`) that
+  joins the grid, advertises the `ai/embedding` capability tag (the
+  `CapabilityOffer` path), and on each `EmbeddingRequested` frame POSTs to the
+  local llama.cpp endpoint and replies `EmbeddingEmitted` with the vector. Wires
+  into the existing `resolve_inference_target` / `request_inference_remote`
+  spine — the facility is just another capability on the same mesh that already
+  routes `lora-clio-v3` turns and the should-respond probe.
+- **Slice 3 — continuum `EmbeddingProvider` backend:** continuum's neural
+  `EmbeddingProvider` (M5's trait) grows a `GridEmbeddingProvider` that embeds
+  locally for the hot path and routes batch jobs to this facility via the
+  capability registry. The trait is the seam; this is the remote implementation
+  behind it.
+
+## Capability tag + wire shape (slice 2 design)
+
+Advertised via `CapabilityOffer` with `capability_tags = ["ai/embedding",
+"ai/embedding/<model>"]` (e.g. `ai/embedding/qwen3-embed`) so a requester can
+demand a *specific* model — the one-vector-space invariant enforced at routing
+time (a peer only routes to a facility advertising **its** embedder model).
+
+Request/reply mirrors `TurnRequested`/`TurnEmitted` with an embedding-shaped
+pair (slice 2 adds these typed nouns to the consumer vocabulary following the
+same "typed struct + enum variant + header projection" pattern):
+
+```
+EmbeddingRequested { request_id, model, inputs: Vec<String>, requested_at_ms }
+EmbeddingEmitted   { request_id, model, vectors: Vec<Vec<f32>>, dim, emitted_at_ms }
+```
+
+`model` is carried so the responder can refuse (loud, typed) if it does not host
+the requested embedder — never silently embed in the wrong space.

--- a/integrations/embedding-facility/README.md
+++ b/integrations/embedding-facility/README.md
@@ -22,11 +22,36 @@ only meaningful **between vectors from the same embedder model**. Therefore:
 > compared, blended, or merged. The split (local hot-path vs GPU batch facility)
 > only composes if both sides share the model.
 
-So the facility default tracks the canonical `EmbeddingProvider` neural model
-(today: `qwen --embedding` via llama.cpp, matching M5's local neural backend).
+**Canonical grid embedder (LOCKED with the fleet, 2026-06-17):
+`Qwen3-Embedding-0.6B`.** A *dedicated retrieval embedder* (purpose-trained for
+cosine retrieval — beats a generative model run in `--embedding` mode, which
+also couples the vector space to whatever gen model happens to be loaded). It is
+small enough that every peer hosts it locally for the hot path (Macs included),
+and GPU-fast on the 5090 for the batch lane. M5's local `NeuralEmbeddingProvider`
+loads this exact model; this facility serves the same one — so vectors are
+comparable grid-wide.
+
 The model is an **adapter** — swappable behind the trait — but it must be
 swapped *grid-wide in lockstep*, not per-node. The facility documents the
 canonical model so the grid stays in one space.
+
+## Embedding is a property of CONTENT, not persona (content-addressed cache)
+
+Joel's directive (2026-06-17): an embedding is a property of the **message
+content**, not the persona that reads it — exactly like
+`VisionDescriptionService` / STT. Fourteen personas in a room reuse **one**
+embedding per message, not fourteen. So both `EmbeddingProvider` impls on the
+consumer side (M5's local `NeuralEmbeddingProvider`, the cross-grid
+`GridEmbeddingProvider`) sit behind a **content-addressed cache**:
+`SHA-256(content) → vector`. The local or cross-grid embed only fires on a
+**cache miss**.
+
+This is what makes the 5090 batch lane efficient: the facility is a pure,
+deterministic function of `(model, content)` — it never sees personas, never
+caches (the cache is the consumer's), and identical content from any peer maps
+to an identical vector. Content-addressing + the one-vector-space invariant are
+the same idea from two directions: a vector is meaningful only as
+`(embedder_model, content_hash)`, and that pair is the cache key.
 
 ## Why llama.cpp `--embedding` (not TEI / sentence-transformers)
 
@@ -93,9 +118,22 @@ the node can embed itself, `Remote(facility)` only when it can't.
 ## Capability tag + wire shape (slice 2 design)
 
 Advertised via `CapabilityOffer` with `capability_tags = ["ai/embedding",
-"ai/embedding/<model>"]` (e.g. `ai/embedding/qwen3-embed`) so a requester can
-demand a *specific* model — the one-vector-space invariant enforced at routing
-time (a peer only routes to a facility advertising **its** embedder model).
+"ai/embedding/<model-slug>"]` so a requester can demand a *specific* model — the
+one-vector-space invariant enforced at routing time (a peer only routes to a
+facility advertising **its** embedder model).
+
+> **CANONICAL ROUTING TAG (verbatim — do NOT hand-shorten):**
+> `ai/embedding/qwen3-embedding-0.6b`
+>
+> The model-qualified tag is the routing contract between this facility and
+> every consumer (slice 3's `GridEmbeddingProvider`). It is derived
+> deterministically from the locked model name `Qwen3-Embedding-0.6B` by the
+> bridge's `model_tag()` (lowercase, non-alphanumeric → `-`, `.` preserved). A
+> consumer that demands a hand-shortened variant (e.g. `qwen3-embed-0.6b`) will
+> **silently fail to match** the advertisement — the dial finds no capable peer
+> and embedding falls back or errors. Both sides MUST use the slug `model_tag()`
+> produces. If the canonical model ever changes, the tag changes with it (in
+> lockstep, grid-wide).
 
 Request/reply mirrors `TurnRequested`/`TurnEmitted` with an embedding-shaped
 pair (slice 2 adds these typed nouns to the consumer vocabulary following the

--- a/integrations/embedding-facility/bridge/Cargo.toml
+++ b/integrations/embedding-facility/bridge/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "airc-embedding-bridge"
+version = "0.1.0"
+edition = "2021"
+description = "Advertise a local llama.cpp embedding server as the ai/embedding capability on the airc grid (5090 facility)"
+publish = false
+
+[[bin]]
+name = "airc-embedding-bridge"
+path = "src/main.rs"
+
+[dependencies]
+airc-lib = { path = "../../../crates/airc-lib" }
+airc-core = { path = "../../../crates/airc-core" }
+consumer-shapes = { path = "../../../crates/examples/consumer_shapes" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+futures = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "json"] }

--- a/integrations/embedding-facility/bridge/src/llamacpp.rs
+++ b/integrations/embedding-facility/bridge/src/llamacpp.rs
@@ -1,0 +1,226 @@
+//! llama.cpp embedding client — the bridge's link to the local GPU server.
+//!
+//! Speaks the OpenAI-compatible `/v1/embeddings` endpoint llama.cpp's
+//! `--embedding` server exposes (the same shape the facility's
+//! `docker-compose.yml` stands up on the 5090). The request build and the
+//! response parse are PURE functions, unit-tested against representative
+//! JSON, so the wire contract is locked without a live server. `embed` is the
+//! thin async call that joins them over HTTP.
+//!
+//! Kept deliberately small and dependency-light (just `reqwest` + `serde_json`,
+//! both already in the workspace): this is a transport adapter, not a place for
+//! cleverness. The embedding MODEL is chosen grid-wide (the one-vector-space
+//! invariant in ../README.md); this client is model-agnostic and simply carries
+//! whichever `model` it is told to request.
+
+use serde_json::{json, Value};
+
+/// Failure modes of an embedding round-trip. Every one is loud — a bridge that
+/// silently returned an empty / wrong-shaped vector would poison cosine recall
+/// across the grid, so a malformed response is an error, never a default.
+#[derive(Debug)]
+pub enum LlamaCppError {
+    /// The HTTP request itself failed (connect, timeout, transport).
+    Http(reqwest::Error),
+    /// The server answered with a non-success status.
+    Status { code: u16, body: String },
+    /// The body was not the expected `{ data: [{ embedding: [...] }] }` shape,
+    /// or carried fewer vectors than inputs. Carries a human reason.
+    Schema(String),
+}
+
+impl std::fmt::Display for LlamaCppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "llama.cpp embedding HTTP error: {e}"),
+            Self::Status { code, body } => {
+                write!(f, "llama.cpp embedding returned status {code}: {body}")
+            }
+            Self::Schema(reason) => write!(f, "llama.cpp embedding response malformed: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for LlamaCppError {}
+
+impl From<reqwest::Error> for LlamaCppError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Http(e)
+    }
+}
+
+/// Build the JSON body for `POST /v1/embeddings`. `input` accepts a single
+/// string or an array; we always send the array form (uniform, and the server
+/// returns one `data` entry per input either way). `model` is included only
+/// when set — llama.cpp serves a single loaded model and ignores it, but a
+/// future multi-model server (or a proxy) routes on it, and sending it makes
+/// the requested vector space explicit on the wire.
+pub fn build_request_body(inputs: &[String], model: Option<&str>) -> Value {
+    let mut body = json!({ "input": inputs });
+    if let Some(model) = model {
+        body["model"] = json!(model);
+    }
+    body
+}
+
+/// Parse the OpenAI-shaped response into one vector per input, ordered by the
+/// response's `index` field (defensive: never assume `data` is pre-sorted).
+/// Errors loudly on any deviation rather than returning a short/empty result.
+pub fn parse_response(value: &Value) -> Result<Vec<Vec<f32>>, LlamaCppError> {
+    let data = value
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| LlamaCppError::Schema("missing `data` array".into()))?;
+    if data.is_empty() {
+        return Err(LlamaCppError::Schema("`data` array is empty".into()));
+    }
+
+    // Collect (index, vector) so we can order by the server-reported index.
+    let mut indexed: Vec<(u64, Vec<f32>)> = Vec::with_capacity(data.len());
+    for (pos, entry) in data.iter().enumerate() {
+        let embedding = entry
+            .get("embedding")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                LlamaCppError::Schema(format!("entry {pos} missing `embedding` array"))
+            })?;
+        let vector = embedding
+            .iter()
+            .map(|n| {
+                n.as_f64().map(|f| f as f32).ok_or_else(|| {
+                    LlamaCppError::Schema(format!("entry {pos} has non-number in `embedding`"))
+                })
+            })
+            .collect::<Result<Vec<f32>, _>>()?;
+        if vector.is_empty() {
+            return Err(LlamaCppError::Schema(format!(
+                "entry {pos} `embedding` is empty"
+            )));
+        }
+        // `index` is optional in some servers; fall back to position.
+        let index = entry
+            .get("index")
+            .and_then(Value::as_u64)
+            .unwrap_or(pos as u64);
+        indexed.push((index, vector));
+    }
+    indexed.sort_by_key(|(i, _)| *i);
+    Ok(indexed.into_iter().map(|(_, v)| v).collect())
+}
+
+/// Embed `inputs` against the llama.cpp server at `base_url` (e.g.
+/// `http://127.0.0.1:8080`). Returns one vector per input. Thin: builds the
+/// body, POSTs, checks status, parses — all the contract logic is in the two
+/// pure functions above so this needs no test of its own beyond the live smoke.
+pub async fn embed(
+    client: &reqwest::Client,
+    base_url: &str,
+    inputs: &[String],
+    model: Option<&str>,
+) -> Result<Vec<Vec<f32>>, LlamaCppError> {
+    let url = format!("{}/v1/embeddings", base_url.trim_end_matches('/'));
+    let resp = client
+        .post(url)
+        .json(&build_request_body(inputs, model))
+        .send()
+        .await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(LlamaCppError::Status {
+            code: status.as_u16(),
+            body,
+        });
+    }
+    let value: Value = resp.json().await?;
+    parse_response(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_body_sends_array_input_and_optional_model() {
+        // what this catches: the bridge must always send the array form (one
+        // `data` entry per input) and must propagate the requested model so the
+        // vector space is explicit on the wire.
+        let body = build_request_body(&["a".into(), "b".into()], Some("qwen3-embed"));
+        assert_eq!(body["input"], json!(["a", "b"]));
+        assert_eq!(body["model"], json!("qwen3-embed"));
+    }
+
+    #[test]
+    fn request_body_omits_model_when_absent() {
+        let body = build_request_body(&["solo".into()], None);
+        assert_eq!(body["input"], json!(["solo"]));
+        assert!(body.get("model").is_none(), "no model key when unset");
+    }
+
+    #[test]
+    fn parses_openai_shaped_response_in_index_order() {
+        // what this catches: a real llama.cpp /v1/embeddings body must decode to
+        // one f32 vector per input, ORDERED BY index (not array position) — a
+        // mis-ordered parse would silently pair vectors with the wrong inputs.
+        let value = json!({
+            "object": "list",
+            "model": "qwen3-embed",
+            "data": [
+                { "object": "embedding", "index": 1, "embedding": [0.4, 0.5, 0.6] },
+                { "object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3] }
+            ]
+        });
+        let vectors = parse_response(&value).expect("parses");
+        assert_eq!(vectors, vec![vec![0.1, 0.2, 0.3], vec![0.4, 0.5, 0.6]]);
+    }
+
+    #[test]
+    fn missing_index_falls_back_to_position() {
+        let value = json!({
+            "data": [
+                { "embedding": [1.0] },
+                { "embedding": [2.0] }
+            ]
+        });
+        let vectors = parse_response(&value).expect("parses");
+        assert_eq!(vectors, vec![vec![1.0], vec![2.0]]);
+    }
+
+    #[test]
+    fn empty_data_is_a_loud_error_not_an_empty_result() {
+        // what this catches: an empty `data` must NOT decode to `vec![]` — that
+        // would feed "no vector" into recall as if it were a valid answer.
+        let value = json!({ "data": [] });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+
+    #[test]
+    fn missing_data_array_is_a_schema_error() {
+        let value = json!({ "object": "list" });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+
+    #[test]
+    fn empty_embedding_vector_is_rejected() {
+        let value = json!({ "data": [ { "embedding": [] } ] });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+
+    #[test]
+    fn non_numeric_embedding_component_is_rejected() {
+        let value = json!({ "data": [ { "embedding": [0.1, "nope", 0.3] } ] });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+}

--- a/integrations/embedding-facility/bridge/src/main.rs
+++ b/integrations/embedding-facility/bridge/src/main.rs
@@ -1,0 +1,317 @@
+//! airc-embedding-bridge — the 5090 embedding facility's presence on the grid.
+//!
+//! Adapter sibling to `integrations/acp`: a standalone Rust bin that is both an
+//! airc citizen (join / publish_identity / advertise a capability / subscribe)
+//! and the client of a local compute backend — here llama.cpp's `--embedding`
+//! server (the `docker-compose.yml` in the parent dir). See ../README.md for
+//! the facility architecture and the one-vector-space invariant.
+//!
+//! ## Slices
+//! - **Slice 2a (this file):** the citizen + capability-advertisement half.
+//!   Joins a room, grounds by name, advertises the `ai/embedding` capability
+//!   (re-advertised on a cadence so it never ages out of peers' registries —
+//!   the staleness-flap is a known routing P0), and answers an `/embed <text>`
+//!   PROBE by round-tripping through the local llama.cpp server. The probe is
+//!   the live smoke test (mirrors acp's `/acp-ping`); it exercises the whole
+//!   chain (airc → llama.cpp → reply) the moment the GPU server is up.
+//! - **Slice 2b:** typed `EmbeddingRequested`/`EmbeddingEmitted` nouns in the
+//!   consumer vocabulary + the command-bus request/reply path, so peers route
+//!   embeddings through the SAME `resolve_inference_target` spine that routes
+//!   turns — not the `/embed` probe string.
+//! - **Slice 3:** continuum's neural `EmbeddingProvider` grows a
+//!   `GridEmbeddingProvider` that embeds locally for the hot path and escalates
+//!   batch jobs to this facility via the capability registry.
+
+mod llamacpp;
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use airc_core::PersonaCapabilities;
+use airc_core::{PeerId, TranscriptEvent, TranscriptKind};
+use airc_lib::Airc;
+use consumer_shapes::continuum::{encode_capability_offer, CapabilityOffer};
+use futures::StreamExt;
+
+/// How often to re-publish the capability offer. Kept well under the registry's
+/// freshness TTL (cross-grid spine uses 180s) so a live facility never flaps to
+/// "stale" and gets skipped by `resolve_inference_target` — the cadence-flap
+/// lesson, applied at the supply side.
+const READVERTISE_EVERY: Duration = Duration::from_secs(60);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let name = std::env::var("EMBED_BRIDGE_NAME").unwrap_or_else(|_| "embedding-facility".into());
+    let room = std::env::var("EMBED_BRIDGE_ROOM").unwrap_or_else(|_| "general".into());
+    let base_url = std::env::var("EMBED_BRIDGE_LLAMACPP_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8080".into());
+    let model =
+        std::env::var("EMBED_BRIDGE_MODEL").unwrap_or_else(|_| "Qwen3-Embedding-0.6B".into());
+    let home = std::env::var("AIRC_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let base = std::env::var("USERPROFILE")
+                .or_else(|_| std::env::var("HOME"))
+                .unwrap_or_else(|_| ".".into());
+            std::path::Path::new(&base).join(".airc")
+        });
+
+    let airc = match std::env::var("AIRC_SOCKET").ok() {
+        Some(socket) => Airc::attach_as(home, &name, socket).await?,
+        None => Airc::open_as(home, &name).await?,
+    };
+    airc.publish_identity().await?; // grounded by name (room_roster + whois)
+    airc.join(&room).await?;
+    let me = airc.peer_id();
+
+    let offer = capability_offer(me, &name, &model);
+    advertise(&airc, &offer).await?;
+    eprintln!(
+        "airc-embedding-bridge: '{name}' joined #{room} as {me}; advertising {:?} (model={model}, llama.cpp={base_url})",
+        offer.capabilities.capability_tags,
+    );
+
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+
+    run_bridge(&airc, me, &offer, &http, &base_url, &model).await
+}
+
+/// Build the standing capability advert for this facility. `persona_id` carries
+/// the facility name (the WHO); the tags are the routable capability (the
+/// WHAT). Both a coarse `ai/embedding` tag (any embedder) and a model-qualified
+/// `ai/embedding/<model>` tag (the one-vector-space contract — a peer can
+/// demand ITS embedder) are advertised.
+fn capability_offer(me: PeerId, name: &str, model: &str) -> CapabilityOffer {
+    CapabilityOffer {
+        peer_id: me,
+        capabilities: PersonaCapabilities {
+            persona_id: name.to_string(),
+            capability_tags: vec!["ai/embedding".to_string(), model_tag(model)],
+            model: model.to_string(),
+            context_window_tokens: 8192,
+        },
+        offered_at_ms: now_ms(),
+    }
+}
+
+/// `ai/embedding/<model-slug>` — lowercased, spaces/slashes to dashes, so the
+/// tag is a stable routable token regardless of how the model name is cased.
+fn model_tag(model: &str) -> String {
+    let slug: String = model
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("ai/embedding/{slug}")
+}
+
+/// Publish the capability offer to the room. Refreshes `offered_at_ms` each call
+/// so the re-advertisement keeps the offer fresh in peers' registries.
+async fn advertise(airc: &Airc, offer: &CapabilityOffer) -> Result<(), Box<dyn std::error::Error>> {
+    let mut fresh = offer.clone();
+    fresh.offered_at_ms = now_ms();
+    let (headers, body) = encode_capability_offer(&fresh)?;
+    airc.send(body, headers).await?;
+    Ok(())
+}
+
+/// The citizen loop: re-advertise on a cadence, and for each inbound `/embed`
+/// probe from another peer, round-trip through the local llama.cpp server and
+/// post the result. Anything else is left alone (no chatty echo — the bridge
+/// answers only an explicit probe until slice 2b's typed request path lands).
+async fn run_bridge(
+    airc: &Airc,
+    me: PeerId,
+    offer: &CapabilityOffer,
+    http: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = airc.subscribe().await?;
+    let mut readvertise = tokio::time::interval(READVERTISE_EVERY);
+    readvertise.tick().await; // first tick fires immediately; we already advertised at startup
+
+    loop {
+        tokio::select! {
+            _ = readvertise.tick() => {
+                if let Err(e) = advertise(airc, offer).await {
+                    eprintln!("airc-embedding-bridge: re-advertise failed: {e}");
+                }
+            }
+            item = stream.next() => {
+                let Some(item) = item else { break }; // stream ended
+                match item {
+                    Ok(event) => {
+                        let Some(text) = probe_input(&event, me) else { continue };
+                        let reply = match llamacpp::embed(http, base_url, &[text.to_string()], Some(model)).await {
+                            Ok(vectors) => format_probe_reply(&vectors, model),
+                            Err(e) => format!("embed probe failed: {e}"),
+                        };
+                        airc.say(&reply).await?;
+                    }
+                    Err(lag) => eprintln!("airc-embedding-bridge: live stream lagged: {lag}"),
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Pure probe filter: returns the text to embed iff this event is a chat
+/// MESSAGE from ANOTHER peer of the form `/embed <text>` with non-empty text.
+/// `None` for our own posts, lifecycle events, and non-probe messages — so the
+/// bridge never replies to itself or to ordinary chatter.
+fn probe_input(event: &TranscriptEvent, me: PeerId) -> Option<&str> {
+    if event.peer_id == me {
+        return None;
+    }
+    if event.kind != TranscriptKind::Message {
+        return None;
+    }
+    let text = event.body.as_ref()?.as_text()?.trim();
+    let rest = text.strip_prefix("/embed ")?.trim();
+    if rest.is_empty() {
+        None
+    } else {
+        Some(rest)
+    }
+}
+
+/// Human-readable probe reply: the model, the vector dimension, and a short
+/// preview of the leading components — enough to confirm a real vector came
+/// back from the GPU without dumping a 1024-float array into the room.
+fn format_probe_reply(vectors: &[Vec<f32>], model: &str) -> String {
+    let Some(first) = vectors.first() else {
+        return "embed probe: server returned no vectors".to_string();
+    };
+    let preview: Vec<String> = first.iter().take(4).map(|f| format!("{f:.4}")).collect();
+    format!(
+        "embed probe ok — model={model}, dim={}, head=[{}, ...]",
+        first.len(),
+        preview.join(", ")
+    )
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{Body, EventId, RoomId};
+
+    fn msg(peer: PeerId, text: &str) -> TranscriptEvent {
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: RoomId::from_u128(1),
+            peer_id: peer,
+            client_id: airc_core::ClientId::new(),
+            kind: TranscriptKind::Message,
+            occurred_at_ms: 1,
+            lamport: 1,
+            target: airc_core::transcript::MentionTarget::All,
+            headers: airc_core::headers::Headers::new(),
+            body: Some(Body::text(text)),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn probe_extracts_text_after_embed_prefix() {
+        // what this catches: the probe must trigger on `/embed <text>` and
+        // hand the trailing text (trimmed) to the embedder.
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert_eq!(
+            probe_input(&msg(other, "/embed hello grid"), me),
+            Some("hello grid")
+        );
+    }
+
+    #[test]
+    fn probe_ignores_ordinary_chatter() {
+        // what this catches: the bridge is NOT a chatty echo — a normal message
+        // (no `/embed` prefix) draws no reply.
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert_eq!(probe_input(&msg(other, "hello grid"), me), None);
+    }
+
+    #[test]
+    fn probe_never_reacts_to_own_posts() {
+        // The orphan of bots: embedding your own reply into a loop. Pinned shut.
+        let me = PeerId::from_u128(1);
+        assert_eq!(probe_input(&msg(me, "/embed my own post"), me), None);
+    }
+
+    #[test]
+    fn probe_skips_non_message_kinds() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        let mut ev = msg(other, "/embed ignored");
+        ev.kind = TranscriptKind::Presence;
+        assert_eq!(probe_input(&ev, me), None);
+    }
+
+    #[test]
+    fn probe_rejects_empty_payload() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert_eq!(probe_input(&msg(other, "/embed    "), me), None);
+    }
+
+    #[test]
+    fn capability_offer_advertises_coarse_and_model_qualified_tags() {
+        // what this catches: a peer must be able to demand EITHER any embedder
+        // (`ai/embedding`) or specifically ITS model (`ai/embedding/<model>`) —
+        // the model-qualified tag is the one-vector-space routing contract.
+        let me = PeerId::from_u128(7);
+        let offer = capability_offer(me, "embedding-facility", "Qwen3-Embedding-0.6B");
+        assert_eq!(offer.peer_id, me);
+        assert!(offer
+            .capabilities
+            .capability_tags
+            .contains(&"ai/embedding".to_string()));
+        assert!(offer
+            .capabilities
+            .capability_tags
+            .contains(&"ai/embedding/qwen3-embedding-0.6b".to_string()));
+        assert_eq!(offer.capabilities.model, "Qwen3-Embedding-0.6B");
+    }
+
+    #[test]
+    fn model_tag_slugifies_punctuation_and_case() {
+        assert_eq!(
+            model_tag("Qwen3-Embedding-0.6B"),
+            "ai/embedding/qwen3-embedding-0.6b"
+        );
+        assert_eq!(model_tag("bge/small en"), "ai/embedding/bge-small-en");
+    }
+
+    #[test]
+    fn probe_reply_reports_dim_and_preview() {
+        let reply = format_probe_reply(&[vec![0.1, 0.2, 0.3, 0.4, 0.5]], "m");
+        assert!(
+            reply.contains("dim=5"),
+            "reply states the dimension: {reply}"
+        );
+        assert!(
+            reply.contains("0.1000"),
+            "reply previews leading components: {reply}"
+        );
+    }
+}

--- a/integrations/embedding-facility/docker-compose.yml
+++ b/integrations/embedding-facility/docker-compose.yml
@@ -1,0 +1,71 @@
+# airc embedding facility — slice 1: the GPU embedding server.
+#
+# llama.cpp `--embedding` in CUDA Docker on the RTX 5090. Serves the CANONICAL
+# grid embedding model (see README "one vector space" invariant) over an
+# OpenAI-compatible `/v1/embeddings` endpoint.
+#
+# Validate standalone (no airc yet):
+#   cd integrations/embedding-facility
+#   docker compose up            # first run pulls the GGUF to the model cache
+#   curl -s localhost:8080/v1/embeddings \
+#        -H 'content-type: application/json' \
+#        -d '{"input":"hello grid"}' | jq '.data[0].embedding | length'
+#   # → prints the vector dimension (e.g. 1024). Facility proven on Blackwell.
+#
+# The model + server are ADAPTERS: override EMBED_HF_REPO / EMBED_HF_FILE to
+# move the whole facility to another embedder, but do it GRID-WIDE in lockstep
+# (the one-vector-space invariant) — never per-node.
+
+services:
+  embedder:
+    # Official llama.cpp CUDA server image. Tracks new GPU arches fast and
+    # builds CUDA kernels for the installed toolkit — the path most likely to
+    # carry Blackwell (sm_120) support for the 5090. If this image lacks sm_120
+    # kernels, the documented fallback is a from-source build against CUDA 12.8+
+    # (see README); pin a known-good digest here once Blackwell is verified.
+    image: ${EMBED_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
+    container_name: airc-embedder
+    restart: unless-stopped
+    # The canonical grid embedder. Qwen3-Embedding-0.6B: a DEDICATED retrieval
+    # embedder (not a generative model in embedding mode) — small enough to also
+    # run on every peer's CPU/Mac for the local hot path, GPU-accelerated here
+    # for batch. Same family as the qwen generation stack. Proposed grid default;
+    # ratify with the fleet before locking (it constrains every node's local
+    # EmbeddingProvider — that IS the one-vector-space decision).
+    command: >
+      --hf-repo ${EMBED_HF_REPO:-Qwen/Qwen3-Embedding-0.6B-GGUF}
+      --hf-file ${EMBED_HF_FILE:-Qwen3-Embedding-0.6B-Q8_0.gguf}
+      --embedding
+      --pooling ${EMBED_POOLING:-last}
+      --ubatch-size ${EMBED_UBATCH:-8192}
+      --ctx-size ${EMBED_CTX:-8192}
+      --host 0.0.0.0
+      --port 8080
+      --n-gpu-layers 99
+    ports:
+      # Bind to loopback only: the airc bridge (slice 2) is the sole client and
+      # runs on this host. The grid reaches embeddings via airc + the capability
+      # ACL, NOT via an exposed HTTP port. Do not publish 0.0.0.0:8080.
+      - "127.0.0.1:8080:8080"
+    volumes:
+      # Model cache on the 16TB foundry drive (HDD is fine — model load is
+      # sequential; inference runs from VRAM). Falls back to a named volume if
+      # the drive isn't mounted, so the compose is portable to any CUDA box.
+      - ${EMBED_MODEL_CACHE:-llama-model-cache}:/root/.cache/llama.cpp
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      # /health is llama.cpp's readiness endpoint (200 once the model is loaded).
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 180s
+
+volumes:
+  llama-model-cache:


### PR DESCRIPTION
## What

A **grid compute facility**: a GPU node serving embedding vectors to the whole mesh, advertised on airc as the `ai/embedding` capability and routed via the *existing* cross-grid request/reply spine (`resolve_inference_target` / `request_inference_remote`, `crates/examples/consumer_shapes`). The supply side of the grid-compute mission — a GPU-less / batch peer escalates to a peer that can embed at scale. Directly unblocks M5's lane #1 (relevance recall, `EmbeddingProvider` trait landed on #1655): the facility is the GPU/batch backend behind that trait.

## The one-vector-space invariant (needs fleet ratification)

The facility **MUST serve the same embedder model each node runs on its local hot path.** Cosine recall only compares vectors from the *same* embedder model; a facility on a different model produces a different vector space that can't be blended or merged with locally-embedded vectors. So the canonical grid embedder is a **grid-wide** decision, swapped in lockstep, never per-node.

**Proposed canonical model: `Qwen3-Embedding-0.6B`** — a dedicated retrieval embedder (not a generative model in embedding mode), small enough to run on every peer's CPU/Mac for the local hot path, GPU-accelerated here for batch. @m5 — this constrains your neural `EmbeddingProvider` model choice; confirm or counter before we lock it.

## Slices

- **README.md** — facility architecture, the one-vector-space invariant, why llama.cpp (same engine as M5's local `qwen --embedding` → same space; better Blackwell sm_120 support than TEI), local-first / grid-escalate split, slice-2b capability tag + `EmbeddingRequested`/`EmbeddingEmitted` wire shape.
- **docker-compose.yml (slice 1)** — llama.cpp `--embedding` in CUDA Docker on the 5090, OpenAI `/v1/embeddings`, loopback-bound (grid reaches it via airc + ACL, not an exposed port), model cache on the 16TB foundry drive. Validated by `docker compose config`. **Live GPU round-trip on Blackwell pending Docker engine recovery on BIGMAMA** (Docker Desktop backend is up but the engine API is currently wedged; this is the one piece not yet runtime-verified).
- **bridge/ (slice 2a)** — `airc-embedding-bridge`: grounded citizen (`join` + `publish_identity`) advertising `ai/embedding` + `ai/embedding/<model>` (re-advertised every 60s to beat the registry freshness TTL — the cadence-flap lesson applied at the supply side), answering an `/embed <text>` probe by round-tripping through the local llama.cpp server (live smoke, mirrors acp's `/acp-ping`). `llamacpp.rs`: pure request-build + index-ordered response-parse, loud on malformed.

## Validation

`cargo fmt` + `cargo clippy -D warnings` + `cargo test -p airc-embedding-bridge` — **16 tests, all green**. Docker GPU runtime: pending engine recovery (tracked, not skipped).

## Next (not in this PR)

- **slice 2b**: typed `EmbeddingRequested`/`EmbeddingEmitted` nouns + command-bus request/reply so peers route embeddings through the same spine as turns.
- **slice 3**: continuum `GridEmbeddingProvider` behind M5's `EmbeddingProvider` trait — local hot path, escalate batch to this facility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)