### PR TITLE
feat(embedding-facility): slice 2b — typed EmbeddingRequested/Emitted command-bus path

### DIFF
--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -753,3 +753,230 @@ pub fn activity_event_filter(activity_id: &str) -> EventFilter {
         ]),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Embedding service shape — the `ai/embedding` capability (BigMama 5090 facility)
+// ---------------------------------------------------------------------------
+//
+// `EmbeddingRequested` / `EmbeddingEmitted` are the request/reply pair for the
+// `ai/embedding` capability, riding the SAME command-bus carriage as
+// `TurnRequested`/`TurnEmitted`: a consumer (`GridEmbeddingProvider`, slice 3)
+// calls [`request_embedding_remote`] against a facility candidate; the bridge
+// (`integrations/embedding-facility`) answers with [`reply_embedding_emitted`].
+// Distinct wire family from persona events (an embedding is a property of
+// CONTENT, not a persona), so it gets its own body hint, not a `PersonaEvent`
+// variant — same reasoning as `CapabilityOffer`.
+//
+// Wire body hint: `forge.ai.embedding.v1`. The **model slug** is projected to a
+// header so a responder filters by vector-space identity without decoding the
+// body. That slug is the SAME identity used three ways — "identity is the
+// model, transport is the policy": the routing URI fragment
+// (`ai/embedding/<slug>`), the cache `provider_id` (`<slug>`), and this
+// envelope header all carry the model, never the transport. Locking them to one
+// derived slug is what keeps a locally-embedded vector and a grid-embedded one
+// in the same space + the same cache entry.
+
+/// Body hint for the embedding request/reply family. Versioned independently of
+/// the persona-event + capability-offer hints (distinct wire shape → own `v1`).
+pub const BODY_HINT_FORGE_AI_EMBEDDING: &str = "forge.ai.embedding.v1";
+
+/// Header projecting the event variant (`requested` | `emitted`) for a cheap
+/// filter without decoding the body.
+pub const HEADER_FORGE_AI_EMBEDDING_KIND: &str = "forge.ai.embedding.kind";
+
+/// Header projecting the embedder **model slug** — the vector-space identity.
+/// A responder filters/refuses by this without decoding; it is the same slug as
+/// the routing URI fragment and the cache `provider_id`.
+pub const HEADER_FORGE_AI_EMBEDDING_MODEL: &str = "forge.ai.embedding.model";
+
+/// Header projecting the request id so a reply correlates at the application
+/// layer too (the substrate also stamps `airc.correlation_id`; this is the
+/// human/debug-visible echo).
+pub const HEADER_FORGE_AI_EMBEDDING_REQUEST_ID: &str = "forge.ai.embedding.request_id";
+
+/// The embedding request/reply family. Mirrors [`PersonaEvent`]'s shape (tagged
+/// enum + typed noun structs + header projection) for a different domain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EmbeddingEvent {
+    /// A request to embed one or more inputs in a specific model's space.
+    Requested(EmbeddingRequested),
+    /// The vectors produced for a prior [`EmbeddingRequested`].
+    Emitted(EmbeddingEmitted),
+}
+
+/// Ask a facility to embed `inputs` in `model`'s vector space.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingRequested {
+    /// Correlates the reply at the application layer.
+    pub request_id: String,
+    /// The embedder model slug — the vector-space identity. A responder that
+    /// does not host this model MUST refuse (loud), never embed in another
+    /// space. Same slug as the routing URI fragment + cache `provider_id`.
+    pub model: String,
+    /// One or more inputs to embed; the reply carries one vector per input,
+    /// positionally aligned.
+    pub inputs: Vec<String>,
+    pub requested_at_ms: u64,
+}
+
+/// The vectors a facility produced for an [`EmbeddingRequested`]. (No `Eq`: it
+/// carries `f32` vectors.)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmbeddingEmitted {
+    /// Echoes the request's `request_id`.
+    pub request_id: String,
+    /// The model the vectors are in — MUST equal the request's `model`. The
+    /// consumer checks this before caching, so a space mismatch is caught, not
+    /// silently mis-keyed.
+    pub model: String,
+    /// One vector per input, in input order.
+    pub vectors: Vec<Vec<f32>>,
+    /// Vector dimension (redundant with `vectors[..].len()` but explicit on the
+    /// wire so a consumer validates without inspecting every row).
+    pub dim: u32,
+    pub emitted_at_ms: u64,
+}
+
+impl EmbeddingEvent {
+    pub fn request_id(&self) -> &str {
+        match self {
+            Self::Requested(e) => &e.request_id,
+            Self::Emitted(e) => &e.request_id,
+        }
+    }
+
+    pub fn model(&self) -> &str {
+        match self {
+            Self::Requested(e) => &e.model,
+            Self::Emitted(e) => &e.model,
+        }
+    }
+
+    fn variant_kind(&self) -> &'static str {
+        match self {
+            Self::Requested(_) => "requested",
+            Self::Emitted(_) => "emitted",
+        }
+    }
+}
+
+/// Encode an [`EmbeddingEvent`] to `(Headers, Body)`. Projects body hint, kind,
+/// model slug, and request id as headers — same pattern as
+/// [`encode_persona_event`].
+pub fn encode_embedding_event(
+    event: &EmbeddingEvent,
+) -> Result<(Headers, Body), PersonaCodecError> {
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        BODY_HINT_FORGE_AI_EMBEDDING.to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_AI_EMBEDDING_KIND.to_string(),
+        event.variant_kind().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_AI_EMBEDDING_MODEL.to_string(),
+        event.model().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_AI_EMBEDDING_REQUEST_ID.to_string(),
+        event.request_id().to_string(),
+    );
+    let body = Body::Json(serde_json::to_value(event)?);
+    Ok((headers, body))
+}
+
+/// Decode an [`EmbeddingEvent`] off headers + body. Loud on a body-hint
+/// mismatch (an embedding frame mis-read as something else would drop a reply).
+pub fn decode_embedding_event(
+    headers: &Headers,
+    body: Option<&Body>,
+) -> Result<EmbeddingEvent, PersonaCodecError> {
+    match headers.get(HEADER_FORGE_BODY_HINT) {
+        Some(value) if value == BODY_HINT_FORGE_AI_EMBEDDING => {}
+        actual => {
+            return Err(PersonaCodecError::BodyHintMismatch {
+                actual: actual.cloned(),
+                expected: BODY_HINT_FORGE_AI_EMBEDDING,
+            });
+        }
+    }
+    let body = body.ok_or(PersonaCodecError::MissingBody)?;
+    let Body::Json(value) = body else {
+        return Err(PersonaCodecError::NonJsonBody);
+    };
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+/// A consumer-side filter admitting any embedding event (e.g. the facility
+/// bridge subscribing only to embedding traffic).
+pub fn any_embedding_event_filter() -> EventFilter {
+    EventFilter {
+        channel: None,
+        channels: HashSet::new(),
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::Exact {
+            key: HEADER_FORGE_BODY_HINT.to_string(),
+            value: BODY_HINT_FORGE_AI_EMBEDDING.to_string(),
+        },
+    }
+}
+
+/// Send an [`EmbeddingRequested`] through the command-bus request path. Await
+/// with [`Airc::await_reply`] — it resolves with the responder's
+/// [`EmbeddingEmitted`] (see [`request_embedding_remote`] for the typed
+/// convenience), or errors `AircError::CommandDeadline` on timeout.
+pub async fn request_embedding(
+    airc: &Airc,
+    target: MentionTarget,
+    request: &EmbeddingRequested,
+    deadline: Duration,
+) -> Result<PendingCommand, PersonaTurnError> {
+    let (headers, body) = encode_embedding_event(&EmbeddingEvent::Requested(request.clone()))?;
+    Ok(airc.request(target, headers, body, deadline).await?)
+}
+
+/// Reply to an [`EmbeddingRequested`] with an [`EmbeddingEmitted`], echoing the
+/// request's correlation so the requester's [`Airc::await_reply`] resolves.
+pub async fn reply_embedding_emitted(
+    airc: &Airc,
+    request_headers: &Headers,
+    emitted: &EmbeddingEmitted,
+) -> Result<(), PersonaTurnError> {
+    let address = turn_reply_address(request_headers)?;
+    let (headers, body) = encode_embedding_event(&EmbeddingEvent::Emitted(emitted.clone()))?;
+    airc.reply(address.reply_to, address.correlation_id, headers, body)
+        .await?;
+    Ok(())
+}
+
+/// Run the cross-grid embedding request/reply against a facility candidate and
+/// await its [`EmbeddingEmitted`] within `deadline`. The embedding-domain twin
+/// of [`request_inference_remote`]; this is what slice 3's `GridEmbeddingProvider`
+/// calls on a cache miss it routes to the grid.
+pub async fn request_embedding_remote(
+    airc: &Airc,
+    candidate: &CapabilityCandidate,
+    request: &EmbeddingRequested,
+    deadline: Duration,
+) -> Result<EmbeddingEmitted, PersonaTurnError> {
+    let pending = request_embedding(
+        airc,
+        MentionTarget::Peer(candidate.peer_id),
+        request,
+        deadline,
+    )
+    .await?;
+    let reply = airc.await_reply(pending).await?;
+    match decode_embedding_event(&reply.headers, reply.body.as_ref())? {
+        EmbeddingEvent::Emitted(emitted) => Ok(emitted),
+        EmbeddingEvent::Requested(_) => Err(PersonaTurnError::Codec(
+            PersonaCodecError::UnexpectedReplyVariant {
+                actual: "requested",
+                expected: "emitted",
+            },
+        )),
+    }
+}

--- a/crates/examples/consumer_shapes/tests/embedding_wire.rs
+++ b/crates/examples/consumer_shapes/tests/embedding_wire.rs
@@ -1,0 +1,240 @@
+//! `ai/embedding` request/reply wire contract — the BigMama 5090 facility
+//! (airc PR #1239 / slice 2b).
+//!
+//! Asserts the embedding codec projects the right headers and roundtrips, the
+//! filter admits only embedding frames, and `EmbeddingRequested` /
+//! `EmbeddingEmitted` ride the command bus as a request/reply pair (the same
+//! carriage `TurnRequested`/`TurnEmitted` use) so slice 3's
+//! `GridEmbeddingProvider` can `request_embedding_remote` against the facility
+//! and get its vectors back before the deadline. These fixtures are the
+//! source-of-truth for the embedding wire shape — any change coordinates with
+//! the facility bridge AND the continuum consumer that share the contract.
+//!
+//! "identity is the model, transport is the policy": the model SLUG rides as a
+//! filterable header so a responder refuses a wrong-space request without
+//! decoding the body.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_lib::{Airc, Headers, MentionTarget};
+use consumer_shapes::continuum::{
+    any_embedding_event_filter, decode_embedding_event, encode_embedding_event,
+    reply_embedding_emitted, request_embedding, EmbeddingEmitted, EmbeddingEvent,
+    EmbeddingRequested, PersonaCodecError, BODY_HINT_FORGE_AI_EMBEDDING,
+    HEADER_FORGE_AI_EMBEDDING_KIND, HEADER_FORGE_AI_EMBEDDING_MODEL,
+    HEADER_FORGE_AI_EMBEDDING_REQUEST_ID,
+};
+use futures::StreamExt;
+use tempfile::TempDir;
+
+const MODEL: &str = "qwen3-embedding-0.6b";
+
+fn request() -> EmbeddingRequested {
+    EmbeddingRequested {
+        request_id: "req-1".to_string(),
+        model: MODEL.to_string(),
+        inputs: vec!["hello grid".to_string(), "second input".to_string()],
+        requested_at_ms: 1_700_000_000_000,
+    }
+}
+
+fn emitted() -> EmbeddingEmitted {
+    EmbeddingEmitted {
+        request_id: "req-1".to_string(),
+        model: MODEL.to_string(),
+        vectors: vec![vec![0.1, 0.2, 0.3], vec![0.4, 0.5, 0.6]],
+        dim: 3,
+        emitted_at_ms: 1_700_000_000_100,
+    }
+}
+
+#[test]
+fn request_roundtrips_and_projects_headers() {
+    let (headers, body) = encode_embedding_event(&EmbeddingEvent::Requested(request())).unwrap();
+
+    assert_eq!(
+        headers.get("forge.body_hint").map(String::as_str),
+        Some(BODY_HINT_FORGE_AI_EMBEDDING),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_AI_EMBEDDING_KIND)
+            .map(String::as_str),
+        Some("requested"),
+    );
+    // The model slug rides on the envelope — the vector-space identity, the
+    // same slug as the routing URI fragment and the cache provider_id.
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_AI_EMBEDDING_MODEL)
+            .map(String::as_str),
+        Some(MODEL),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_AI_EMBEDDING_REQUEST_ID)
+            .map(String::as_str),
+        Some("req-1"),
+    );
+
+    let decoded = decode_embedding_event(&headers, Some(&body)).unwrap();
+    assert_eq!(decoded, EmbeddingEvent::Requested(request()));
+}
+
+#[test]
+fn emitted_roundtrips_carrying_vectors() {
+    // what this catches: the reply must carry the f32 vectors + dim + model
+    // intact through encode/decode (no Eq on f32, so PartialEq round-trip).
+    let (headers, body) = encode_embedding_event(&EmbeddingEvent::Emitted(emitted())).unwrap();
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_AI_EMBEDDING_KIND)
+            .map(String::as_str),
+        Some("emitted"),
+    );
+    let decoded = decode_embedding_event(&headers, Some(&body)).unwrap();
+    assert_eq!(decoded, EmbeddingEvent::Emitted(emitted()));
+}
+
+#[test]
+fn decode_rejects_wrong_body_hint() {
+    // what this catches: an embedding frame mis-read as a persona event (or vice
+    // versa) must fail LOUD — a silently-dropped reply would hang the requester.
+    let (mut headers, body) =
+        encode_embedding_event(&EmbeddingEvent::Requested(request())).unwrap();
+    headers.insert(
+        "forge.body_hint".to_string(),
+        "forge.persona.event.v1".to_string(),
+    );
+    let err = decode_embedding_event(&headers, Some(&body)).unwrap_err();
+    assert!(matches!(err, PersonaCodecError::BodyHintMismatch { .. }));
+}
+
+#[test]
+fn filter_admits_only_embedding_frames() {
+    let (headers, _) = encode_embedding_event(&EmbeddingEvent::Requested(request())).unwrap();
+    let filter = any_embedding_event_filter();
+    assert!(filter.headers_filter.matches(&headers));
+
+    let mut other = Headers::new();
+    other.insert(
+        "forge.body_hint".to_string(),
+        "forge.persona.event.v1".to_string(),
+    );
+    assert!(!filter.headers_filter.matches(&other));
+}
+
+#[test]
+fn missing_body_is_a_loud_error() {
+    let (headers, _) = encode_embedding_event(&EmbeddingEvent::Requested(request())).unwrap();
+    let err = decode_embedding_event(&headers, None).unwrap_err();
+    assert!(matches!(err, PersonaCodecError::MissingBody));
+}
+
+/// The headline: an `EmbeddingRequested` rides the command bus and the
+/// requester's `await_reply` resolves with the facility's `EmbeddingEmitted`
+/// before the deadline — proving the embedding pair uses the same carriage as
+/// turns. LAN-TCP with separate homes (no shared local-fs).
+#[tokio::test]
+async fn embedding_request_reply_resolves_before_deadline() {
+    let requester_home = TempDir::new().expect("requester home");
+    let facility_home = TempDir::new().expect("facility home");
+
+    let requester = Airc::open(requester_home.path())
+        .await
+        .expect("requester opens");
+    let facility = Airc::open(facility_home.path())
+        .await
+        .expect("facility opens");
+
+    let requester_spec = requester.peer_spec().parse().expect("requester peer spec");
+    let facility_spec = facility.peer_spec().parse().expect("facility peer spec");
+    requester
+        .add_peer(facility_spec)
+        .await
+        .expect("requester trusts facility");
+    facility
+        .add_peer(requester_spec)
+        .await
+        .expect("facility trusts requester");
+
+    requester.join("embedding-bus").await.unwrap();
+    facility.join("embedding-bus").await.unwrap();
+
+    let facility_addr = facility
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("facility listens on LAN");
+    requester
+        .connect_lan(facility_addr, facility.peer_id())
+        .await
+        .expect("requester connects to facility over LAN");
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let responder = tokio::spawn(facility_answers_one_embedding(facility.clone(), ready_tx));
+    ready_rx.await.expect("facility subscriber is ready");
+
+    let pending = request_embedding(
+        &requester,
+        MentionTarget::All,
+        &request(),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("embedding request emits");
+
+    let reply = requester
+        .await_reply(pending)
+        .await
+        .expect("await_reply resolves with the EmbeddingEmitted reply");
+    let decoded =
+        decode_embedding_event(&reply.headers, reply.body.as_ref()).expect("reply decodes");
+    assert_eq!(decoded, EmbeddingEvent::Emitted(emitted()));
+
+    responder.await.expect("responder completes");
+}
+
+/// The facility side: subscribe, decode the typed `EmbeddingRequested`, assert
+/// the model slug rode as a header (the routing/space identity), and reply
+/// `EmbeddingEmitted` correlating the command bus.
+async fn facility_answers_one_embedding(facility: Airc, ready: tokio::sync::oneshot::Sender<()>) {
+    let mut stream = facility.subscribe().await.unwrap();
+    let _ = ready.send(());
+    loop {
+        let Some(Ok(event)) = stream.next().await else {
+            continue;
+        };
+        if event.peer_id == facility.peer_id() {
+            continue;
+        }
+        if event
+            .headers
+            .get(HEADER_FORGE_AI_EMBEDDING_KIND)
+            .map(String::as_str)
+            != Some("requested")
+        {
+            continue;
+        }
+        // The model slug rides as a filterable header — a facility refuses a
+        // wrong-space request off this without decoding the body.
+        assert_eq!(
+            event
+                .headers
+                .get(HEADER_FORGE_AI_EMBEDDING_MODEL)
+                .map(String::as_str),
+            Some(MODEL),
+        );
+        let EmbeddingEvent::Requested(req) =
+            decode_embedding_event(&event.headers, event.body.as_ref()).unwrap()
+        else {
+            continue;
+        };
+        assert_eq!(req.inputs.len(), 2, "both inputs rode the request");
+
+        reply_embedding_emitted(&facility, &event.headers, &emitted())
+            .await
+            .expect("embedding reply emits");
+        return;
+    }
+}

--- a/integrations/embedding-facility/bridge/src/main.rs
+++ b/integrations/embedding-facility/bridge/src/main.rs
@@ -7,17 +7,18 @@
 //! the facility architecture and the one-vector-space invariant.
 //!
 //! ## Slices
-//! - **Slice 2a (this file):** the citizen + capability-advertisement half.
-//!   Joins a room, grounds by name, advertises the `ai/embedding` capability
-//!   (re-advertised on a cadence so it never ages out of peers' registries —
-//!   the staleness-flap is a known routing P0), and answers an `/embed <text>`
-//!   PROBE by round-tripping through the local llama.cpp server. The probe is
-//!   the live smoke test (mirrors acp's `/acp-ping`); it exercises the whole
-//!   chain (airc → llama.cpp → reply) the moment the GPU server is up.
-//! - **Slice 2b:** typed `EmbeddingRequested`/`EmbeddingEmitted` nouns in the
-//!   consumer vocabulary + the command-bus request/reply path, so peers route
-//!   embeddings through the SAME `resolve_inference_target` spine that routes
-//!   turns — not the `/embed` probe string.
+//! - **Slice 2a:** the citizen + capability-advertisement half. Joins a room,
+//!   grounds by name, advertises the `ai/embedding` capability (re-advertised on
+//!   a cadence so it never ages out of peers' registries — the staleness-flap is
+//!   a known routing P0), and answers an `/embed <text>` PROBE by round-tripping
+//!   the local llama.cpp server (the live smoke, mirrors acp's `/acp-ping`).
+//! - **Slice 2b (this file, with 2a):** the MACHINE path. Answers a typed
+//!   `EmbeddingRequested` command-bus request (`consumer_shapes::continuum`) by
+//!   embedding via llama.cpp and replying `EmbeddingEmitted` — the same
+//!   request/reply carriage `TurnRequested`/`TurnEmitted` ride. This is what
+//!   slice 3's `GridEmbeddingProvider` drives via `request_embedding_remote`;
+//!   the `/embed` probe stays as the human smoke. Refuses (loud) a request for a
+//!   model it does not host — never embeds in the wrong vector space.
 //! - **Slice 3:** continuum's neural `EmbeddingProvider` grows a
 //!   `GridEmbeddingProvider` that embeds locally for the hot path and escalates
 //!   batch jobs to this facility via the capability registry.
@@ -29,7 +30,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use airc_core::PersonaCapabilities;
 use airc_core::{PeerId, TranscriptEvent, TranscriptKind};
 use airc_lib::Airc;
-use consumer_shapes::continuum::{encode_capability_offer, CapabilityOffer};
+use consumer_shapes::continuum::{
+    decode_embedding_event, encode_capability_offer, reply_embedding_emitted, CapabilityOffer,
+    EmbeddingEmitted, EmbeddingEvent, HEADER_FORGE_AI_EMBEDDING_KIND,
+};
 use futures::StreamExt;
 
 /// How often to re-publish the capability offer. Kept well under the registry's
@@ -123,10 +127,10 @@ async fn advertise(airc: &Airc, offer: &CapabilityOffer) -> Result<(), Box<dyn s
     Ok(())
 }
 
-/// The citizen loop: re-advertise on a cadence, and for each inbound `/embed`
-/// probe from another peer, round-trip through the local llama.cpp server and
-/// post the result. Anything else is left alone (no chatty echo — the bridge
-/// answers only an explicit probe until slice 2b's typed request path lands).
+/// The citizen loop: re-advertise on a cadence, and for each inbound event
+/// either (a) answer a typed `EmbeddingRequested` command-bus request — the
+/// MACHINE path that slice 3's `GridEmbeddingProvider` drives — or (b) answer an
+/// `/embed <text>` human PROBE. Anything else is left alone (no chatty echo).
 async fn run_bridge(
     airc: &Airc,
     me: PeerId,
@@ -150,6 +154,12 @@ async fn run_bridge(
                 let Some(item) = item else { break }; // stream ended
                 match item {
                     Ok(event) => {
+                        // Machine path (slice 2b): typed command-bus embedding request.
+                        if is_embedding_request(&event, me) {
+                            handle_embedding_request(airc, &event, http, base_url, model).await;
+                            continue;
+                        }
+                        // Human path (slice 2a): the /embed live smoke probe.
                         let Some(text) = probe_input(&event, me) else { continue };
                         let reply = match llamacpp::embed(http, base_url, &[text.to_string()], Some(model)).await {
                             Ok(vectors) => format_probe_reply(&vectors, model),
@@ -163,6 +173,73 @@ async fn run_bridge(
         }
     }
     Ok(())
+}
+
+/// True iff this event is a typed embedding REQUEST from another peer. Cheap:
+/// keys off the projected `forge.ai.embedding.kind = requested` header, no body
+/// decode. (Our own posts and `emitted` replies are not requests.)
+fn is_embedding_request(event: &TranscriptEvent, me: PeerId) -> bool {
+    event.peer_id != me
+        && event
+            .headers
+            .get(HEADER_FORGE_AI_EMBEDDING_KIND)
+            .map(String::as_str)
+            == Some("requested")
+}
+
+/// Answer a typed `EmbeddingRequested`: decode, refuse loudly if it asks for a
+/// model we do not host (never embed in the wrong vector space), embed via
+/// llama.cpp, and reply `EmbeddingEmitted` correlating the command bus. Errors
+/// are logged, not propagated — one bad request must not kill the facility loop;
+/// the requester's `await_reply` deadlines loudly on a non-reply.
+async fn handle_embedding_request(
+    airc: &Airc,
+    event: &TranscriptEvent,
+    http: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+) {
+    let req = match decode_embedding_event(&event.headers, event.body.as_ref()) {
+        Ok(EmbeddingEvent::Requested(r)) => r,
+        Ok(EmbeddingEvent::Emitted(_)) => return, // we answer requests, not replies
+        Err(e) => {
+            eprintln!("airc-embedding-bridge: undecodable embedding request: {e}");
+            return;
+        }
+    };
+    if req.model != model {
+        // Routing should prevent this (the model-qualified capability tag), but
+        // refuse defensively rather than serve a wrong-space vector.
+        eprintln!(
+            "airc-embedding-bridge: refusing request {} for model '{}' — this facility serves '{}'",
+            req.request_id, req.model, model
+        );
+        return;
+    }
+    let vectors = match llamacpp::embed(http, base_url, &req.inputs, Some(model)).await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "airc-embedding-bridge: embed failed for {}: {e}",
+                req.request_id
+            );
+            return;
+        }
+    };
+    let dim = vectors.first().map(|v| v.len() as u32).unwrap_or(0);
+    let emitted = EmbeddingEmitted {
+        request_id: req.request_id.clone(),
+        model: model.to_string(),
+        vectors,
+        dim,
+        emitted_at_ms: now_ms(),
+    };
+    if let Err(e) = reply_embedding_emitted(airc, &event.headers, &emitted).await {
+        eprintln!(
+            "airc-embedding-bridge: reply failed for {}: {e}",
+            req.request_id
+        );
+    }
 }
 
 /// Pure probe filter: returns the text to embed iff this event is a chat
@@ -313,5 +390,44 @@ mod tests {
             reply.contains("0.1000"),
             "reply previews leading components: {reply}"
         );
+    }
+
+    fn with_kind(peer: PeerId, kind: &str) -> TranscriptEvent {
+        let mut ev = msg(peer, "{}");
+        ev.headers
+            .insert(HEADER_FORGE_AI_EMBEDDING_KIND.to_string(), kind.to_string());
+        ev
+    }
+
+    #[test]
+    fn detects_typed_embedding_request_from_another_peer() {
+        // what this catches: the MACHINE path (slice 2b) must fire on a typed
+        // `requested` frame from another peer — that's the command-bus request
+        // slice 3's GridEmbeddingProvider sends.
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert!(is_embedding_request(&with_kind(other, "requested"), me));
+    }
+
+    #[test]
+    fn emitted_frame_is_not_a_request() {
+        // what this catches: the bridge answers REQUESTS, never replies — an
+        // `emitted` frame must not be treated as inbound work (would loop).
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert!(!is_embedding_request(&with_kind(other, "emitted"), me));
+    }
+
+    #[test]
+    fn own_embedding_request_is_ignored() {
+        let me = PeerId::from_u128(1);
+        assert!(!is_embedding_request(&with_kind(me, "requested"), me));
+    }
+
+    #[test]
+    fn plain_message_is_not_an_embedding_request() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert!(!is_embedding_request(&msg(other, "hello"), me));
     }
 }


### PR DESCRIPTION
## What

The **machine path** for the `ai/embedding` facility (#1239 landed slices 1+2a). Peers now route embeddings through the **same command-bus request/reply carriage** that `TurnRequested`/`TurnEmitted` ride — not the `/embed` human probe. This is the wire contract slice 3's `GridEmbeddingProvider` calls (`request_embedding_remote`), so it's on the critical path for the cross-grid embedding loop.

Built on canary (has #1655 brain-core + #1239 facility).

## `consumer_shapes/continuum.rs` — the embedding wire family

Own body hint `forge.ai.embedding.v1` (distinct wire shape → own version, same reasoning as `CapabilityOffer`, not a `PersonaEvent` variant):
- `EmbeddingEvent { Requested, Emitted }` + `EmbeddingRequested` / `EmbeddingEmitted` typed nouns. `Emitted` carries `Vec<Vec<f32>>` + `dim` (→ `PartialEq`, not `Eq`).
- `encode`/`decode_embedding_event` projecting body-hint + kind + **model slug** + request_id as headers. The model slug is the **vector-space identity** — the same slug as the routing URI fragment and the cache `provider_id` (**"identity is the model, transport is the policy"**, locked with the fleet). A responder refuses a wrong-space request off the header without decoding the body.
- `request_embedding` / `reply_embedding_emitted` (reuse the command-bus reply addressing) + `request_embedding_remote` (the embedding twin of `request_inference_remote` — what `GridEmbeddingProvider` calls on a grid-routed cache miss) + `any_embedding_event_filter`.

## `bridge/src/main.rs` — the facility answers it

`is_embedding_request` (cheap header check) → `handle_embedding_request` decodes, **refuses loud** if asked for a model it doesn't host (never embeds in the wrong space), embeds via llama.cpp, replies `EmbeddingEmitted` correlating the bus. The `/embed` probe stays as the human smoke.

## Validation

`cargo fmt` + `cargo clippy -D warnings` + `cargo test` — all green. New tests:
- **6 `embedding_wire` tests**: codec roundtrip (request + emitted-with-vectors), header projection, wrong-body-hint + missing-body loud errors, filter, and a **live LAN command-bus request/reply round-trip** (requester `request_embedding` → facility stub decodes + `reply_embedding_emitted` → `await_reply` resolves with the `EmbeddingEmitted` before deadline).
- **4 bridge `is_embedding_request` tests**: detects a typed request from another peer; ignores `emitted` replies, own posts, and plain chatter.

## Unblocks

Slice 3 (`GridEmbeddingProvider`, Intel Mac): `embed()` on a grid-routed cache miss calls `request_embedding_remote(airc, candidate, &EmbeddingRequested{ model: "qwen3-embedding-0.6b", .. }, deadline)` → gets `EmbeddingEmitted.vectors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)