### PR TITLE
feat(integrations/generate-facility): ai/generate 5090 compute-lease facility — remote grid inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-generate-bridge"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-lib",
+ "consumer-shapes",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "airc-identity"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/examples/persona_spawn_smoke",
     "integrations/acp",
     "integrations/embedding-facility/bridge",
+    "integrations/generate-facility/bridge",
 ]
 resolver = "2"
 

--- a/integrations/generate-facility/README.md
+++ b/integrations/generate-facility/README.md
@@ -1,0 +1,71 @@
+# airc generate facility (5090 GPU, `ai/generate` on the grid)
+
+The **compute-lease** provider: a GPU node that serves text generation to the
+whole mesh as the `ai/generate` capability, so a GPU-less persona keeps its
+cognition **local** and escalates only the model call over the grid. This is
+"remote grid inference" — a Mac persona thinks locally (WorkspaceCycle Decision,
+recall, grounding) and answers using a capable model it does not own.
+
+Sibling to `integrations/embedding-facility`: same pattern (airc citizen +
+capability advertisement + a thin llama.cpp HTTP client), different capability.
+Embedding was the dress rehearsal; generation is the headline.
+
+## Why it needs no new wire types
+
+Generation reuses the EXISTING cross-grid inference spine
+(`crates/examples/consumer_shapes`): `TurnRequested` → `TurnEmitted`, driven by
+`request_inference_remote`, routed by `resolve_inference_target` (local-first;
+escalate only when local can't satisfy). The facility is the responder half — it
+runs the model and replies the text. The consumer half is continuum's
+`AircRemoteInferenceAdapter` / `GridInferenceProvider` (the sibling of
+`GridEmbeddingProvider`), which swaps the deliberation faculty's local
+`AIProviderAdapter` for one that routes the model call to this facility.
+
+## Shape
+
+```
+  GPU-less persona (Mac)                          BIGMAMA (RTX 5090)
+  ───────────────────────                         ──────────────────────────────
+  WorkspaceCycle decides locally                  [ airc-generate-bridge ]
+  deliberation needs a model call                   advertises ai/generate;
+    │ local-first: run if capable                    on TurnRequested →
+    │ else escalate:                               ┌───────────────────────────┐
+    └── TurnRequested ───airc mesh───────────────► │ llama.cpp server (CUDA)    │
+        (request_inference_remote, model_hint)     │ /v1/chat/completions, 5090 │
+        ◄── TurnEmitted (text) ───────────────────  └───────────────────────────┘
+```
+
+Routing is by `model_hint`: the facility advertises `ai/generate`,
+`ai/generate/<model-slug>`, AND the raw model string (because
+`resolve_inference_target` matches `model_hint` against `capability_tags`
+verbatim). The bridge **refuses (loud)** a turn whose `model_hint` names a model
+it does not host — never silently answers with a different model.
+
+## Build slices
+
+- **Slice 1 — the GPU server (`docker-compose.yml`):** llama.cpp chat server on
+  the 5090, OpenAI `/v1/chat/completions`, loopback-bound. Validate with the
+  `curl` in the compose header. Live Blackwell (sm_120) round-trip pending a
+  Docker engine (BIGMAMA's was wedged — the Docker Desktop service was stopped).
+- **Slice 2 — the bridge (`bridge/`):** `airc-generate-bridge` — grounded
+  citizen advertising `ai/generate` (re-advert every 60s vs the registry TTL),
+  answering `TurnRequested` by running the model and replying `TurnEmitted`.
+  llama.cpp client: pure request-build + response-parse, loud on malformed.
+- **Slice 3 (continuum-side, Intel Mac):** `GridInferenceProvider` behind the
+  inference adapter — local-first, escalate the model call to this facility.
+
+## Limitations
+
+- **Text-only over the grid (today).** `TurnEmitted` carries `text: String`. A
+  model that emits **structured tool calls** (`tool_calls` / `ContentPart::ToolUse`,
+  the structured agent-tool contract — see
+  `docs/architecture/PERSONA-COGNITION-PIPELINE.md`) with no text is rejected
+  with a clear error rather than silently dropped. Tool-call-preserving remote
+  inference needs a **structured `TurnEmitted`** (ContentParts) — a deliberate
+  wire extension, the natural follow-up once tool-using personas run remote.
+  Until then: tool execution stays where the cognition runs (local), and this
+  facility serves the text-generation half.
+- **The prompt rides as a single user message** so the server applies the
+  model's chat template (correct for instruct models). The consumer's
+  deliberation prompt is the user message; system/context framing the persona
+  wants applied should be part of that prompt or a future structured request.

--- a/integrations/generate-facility/bridge/Cargo.toml
+++ b/integrations/generate-facility/bridge/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "airc-generate-bridge"
+version = "0.1.0"
+edition = "2021"
+description = "Advertise a local llama.cpp generation server as the ai/generate capability on the airc grid (5090 compute-lease facility)"
+publish = false
+
+[[bin]]
+name = "airc-generate-bridge"
+path = "src/main.rs"
+
+[dependencies]
+airc-lib = { path = "../../../crates/airc-lib" }
+airc-core = { path = "../../../crates/airc-core" }
+consumer-shapes = { path = "../../../crates/examples/consumer_shapes" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+futures = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "json"] }

--- a/integrations/generate-facility/bridge/src/llamacpp.rs
+++ b/integrations/generate-facility/bridge/src/llamacpp.rs
@@ -1,0 +1,235 @@
+//! llama.cpp chat-completion client — the generate facility's link to the GPU.
+//!
+//! Speaks the OpenAI-compatible `/v1/chat/completions` endpoint llama.cpp's
+//! server exposes (the same server shape the embedding facility uses, minus
+//! `--embedding`). The request build and the response parse are PURE functions,
+//! unit-tested against representative JSON, so the wire contract is locked
+//! without a live model. `complete` is the thin async call that joins them.
+//!
+//! Sibling to `integrations/embedding-facility/bridge/src/llamacpp.rs`: the two
+//! facilities share a pattern (airc citizen + capability advert + a thin
+//! llama.cpp HTTP client). Once both are proven live, the shared citizen-loop is
+//! the natural extraction target — but build the second instance first (the
+//! outlier-validation discipline), then compress.
+
+use serde_json::{json, Value};
+
+/// Failure modes of a completion round-trip. Loud: a generate facility that
+/// silently returned empty text would make a remote persona turn look like a
+/// model that chose to say nothing — indistinguishable from a real Pass. So a
+/// malformed/empty response is an error the caller surfaces, never a default.
+#[derive(Debug)]
+pub enum LlamaCppError {
+    /// The HTTP request itself failed (connect, timeout, transport).
+    Http(reqwest::Error),
+    /// The server answered with a non-success status.
+    Status { code: u16, body: String },
+    /// The body was not the expected `{ choices: [{ message: { content } }] }`
+    /// shape, or carried no choices. Carries a human reason.
+    Schema(String),
+}
+
+impl std::fmt::Display for LlamaCppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "llama.cpp completion HTTP error: {e}"),
+            Self::Status { code, body } => {
+                write!(f, "llama.cpp completion returned status {code}: {body}")
+            }
+            Self::Schema(reason) => write!(f, "llama.cpp completion response malformed: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for LlamaCppError {}
+
+impl From<reqwest::Error> for LlamaCppError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Http(e)
+    }
+}
+
+/// Build the JSON body for `POST /v1/chat/completions`. The turn `prompt` rides
+/// as a single user message so the server applies the model's chat template
+/// (correct for instruct models — a raw `/completion` would skip the template
+/// and degrade instruct output). `model` is included when set; llama.cpp serves
+/// one loaded model and ignores it, but a multi-model server / proxy routes on
+/// it and it makes the requested model explicit on the wire.
+pub fn build_request_body(
+    prompt: &str,
+    model: Option<&str>,
+    max_tokens: u32,
+    temperature: f32,
+) -> Value {
+    let mut body = json!({
+        "messages": [ { "role": "user", "content": prompt } ],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": false,
+    });
+    if let Some(model) = model {
+        body["model"] = json!(model);
+    }
+    body
+}
+
+/// Parse the OpenAI-shaped chat response into the assistant text. Errors loudly
+/// on any deviation rather than returning empty (see `LlamaCppError`).
+pub fn parse_response(value: &Value) -> Result<String, LlamaCppError> {
+    let choices = value
+        .get("choices")
+        .and_then(Value::as_array)
+        .ok_or_else(|| LlamaCppError::Schema("missing `choices` array".into()))?;
+    let first = choices
+        .first()
+        .ok_or_else(|| LlamaCppError::Schema("`choices` array is empty".into()))?;
+    let message = first
+        .get("message")
+        .ok_or_else(|| LlamaCppError::Schema("choice 0 missing `message`".into()))?;
+    let content = message.get("content").and_then(Value::as_str).unwrap_or("");
+    if content.is_empty() {
+        // Known limitation, surfaced clearly rather than as a vague "empty":
+        // the cross-grid `TurnEmitted` wire is text-only, so a model that emits
+        // structured tool calls (and no text) can't be carried over the grid
+        // yet. Tool-call-preserving remote inference needs a structured
+        // `TurnEmitted` (ContentParts / tool_calls) — a wire extension, not a
+        // bug here. Name it so a future debugger isn't chasing "empty content".
+        if message.get("tool_calls").is_some() {
+            return Err(LlamaCppError::Schema(
+                "choice 0 produced tool_calls with no text — remote tool-call inference needs a \
+                 structured TurnEmitted (text-only wire today); see README limitations"
+                    .into(),
+            ));
+        }
+        return Err(LlamaCppError::Schema(
+            "choice 0 `message.content` is empty".into(),
+        ));
+    }
+    Ok(content.to_string())
+}
+
+/// Generate a completion for `prompt` against the llama.cpp server at
+/// `base_url`. Thin: builds the body, POSTs, checks status, parses — the
+/// contract logic is in the two pure functions above.
+pub async fn complete(
+    client: &reqwest::Client,
+    base_url: &str,
+    prompt: &str,
+    model: Option<&str>,
+    max_tokens: u32,
+    temperature: f32,
+) -> Result<String, LlamaCppError> {
+    let url = format!("{}/v1/chat/completions", base_url.trim_end_matches('/'));
+    let resp = client
+        .post(url)
+        .json(&build_request_body(prompt, model, max_tokens, temperature))
+        .send()
+        .await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(LlamaCppError::Status {
+            code: status.as_u16(),
+            body,
+        });
+    }
+    let value: Value = resp.json().await?;
+    parse_response(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_body_sends_prompt_as_user_message_with_params() {
+        // what this catches: the turn prompt must ride as a user message (so the
+        // chat template applies) with the gen params + the model echoed.
+        let body = build_request_body("hello", Some("qwen3-coder"), 256, 0.7);
+        assert_eq!(body["messages"][0]["role"], json!("user"));
+        assert_eq!(body["messages"][0]["content"], json!("hello"));
+        assert_eq!(body["max_tokens"], json!(256));
+        assert_eq!(body["model"], json!("qwen3-coder"));
+        assert_eq!(body["stream"], json!(false));
+    }
+
+    #[test]
+    fn request_body_omits_model_when_absent() {
+        let body = build_request_body("hi", None, 128, 0.0);
+        assert!(body.get("model").is_none(), "no model key when unset");
+    }
+
+    #[test]
+    fn parses_openai_chat_response_content() {
+        // what this catches: a real /v1/chat/completions body must decode to the
+        // assistant's content string.
+        let value = json!({
+            "choices": [
+                { "index": 0, "message": { "role": "assistant", "content": "the answer" }, "finish_reason": "stop" }
+            ]
+        });
+        assert_eq!(parse_response(&value).unwrap(), "the answer");
+    }
+
+    #[test]
+    fn empty_choices_is_a_loud_error() {
+        // what this catches: empty choices must NOT decode to "" — that would be
+        // indistinguishable from the model deliberately saying nothing.
+        let value = json!({ "choices": [] });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+
+    #[test]
+    fn missing_content_is_a_loud_error() {
+        let value = json!({ "choices": [ { "message": { "role": "assistant" } } ] });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+
+    #[test]
+    fn empty_content_string_is_rejected() {
+        let value = json!({ "choices": [ { "message": { "content": "" } } ] });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+
+    #[test]
+    fn missing_choices_array_is_a_schema_error() {
+        let value = json!({ "object": "chat.completion" });
+        assert!(matches!(
+            parse_response(&value),
+            Err(LlamaCppError::Schema(_))
+        ));
+    }
+
+    #[test]
+    fn tool_calls_with_no_text_is_a_clear_named_error() {
+        // what this catches: a model emitting structured tool_calls + no text
+        // must fail with the SPECIFIC text-only-wire limitation message, not a
+        // vague "empty content" — so the wire-extension follow-up is obvious.
+        let value = json!({
+            "choices": [ { "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [ { "id": "c1", "type": "function",
+                    "function": { "name": "read", "arguments": "{}" } } ]
+            } } ]
+        });
+        match parse_response(&value) {
+            Err(LlamaCppError::Schema(msg)) => {
+                assert!(
+                    msg.contains("tool_calls"),
+                    "names the tool-call limitation: {msg}"
+                )
+            }
+            other => panic!("expected a Schema error naming tool_calls, got {other:?}"),
+        }
+    }
+}

--- a/integrations/generate-facility/bridge/src/main.rs
+++ b/integrations/generate-facility/bridge/src/main.rs
@@ -1,0 +1,329 @@
+//! airc-generate-bridge — the 5090 generation facility's presence on the grid.
+//!
+//! The compute-lease provider: a GPU node that serves text generation to the
+//! mesh as the `ai/generate` capability, so a GPU-less persona can keep its
+//! cognition LOCAL and escalate only the model call ("remote grid inference").
+//! Sibling to `integrations/embedding-facility` — same pattern (airc citizen +
+//! capability advert + a thin llama.cpp HTTP client), different capability.
+//!
+//! Unlike the embedding facility, this needs NO new wire types: it answers the
+//! EXISTING `TurnRequested` → `TurnEmitted` command-bus pair
+//! (`consumer_shapes::continuum`), the same one `request_inference_remote`
+//! already drives. A consumer (continuum's `AircRemoteInferenceAdapter` /
+//! `GridInferenceProvider`) routes a turn to this facility by `model_hint`; the
+//! facility runs the model and replies the text.
+//!
+//! Refuses (loud) a turn whose `model_hint` names a model it does not host —
+//! never silently answers with a different model's output.
+
+mod llamacpp;
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use airc_core::PersonaCapabilities;
+use airc_core::{PeerId, TranscriptEvent};
+use airc_lib::Airc;
+use consumer_shapes::continuum::{
+    decode_persona_event, encode_capability_offer, reply_turn_emitted, CapabilityOffer,
+    PersonaEvent, TurnEmitted, HEADER_FORGE_PERSONA_KIND,
+};
+use futures::StreamExt;
+
+/// Re-advertise cadence — under the registry freshness TTL (cross-grid spine
+/// uses 180s) so a live facility never flaps stale and gets skipped by
+/// `resolve_inference_target` (the cadence-flap lesson, supply side).
+const READVERTISE_EVERY: Duration = Duration::from_secs(60);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let name = std::env::var("GEN_BRIDGE_NAME").unwrap_or_else(|_| "generate-facility".into());
+    let room = std::env::var("GEN_BRIDGE_ROOM").unwrap_or_else(|_| "general".into());
+    let base_url =
+        std::env::var("GEN_BRIDGE_LLAMACPP_URL").unwrap_or_else(|_| "http://127.0.0.1:8081".into());
+    let model = std::env::var("GEN_BRIDGE_MODEL").unwrap_or_else(|_| "qwen3-coder-30b".into());
+    let max_tokens: u32 = std::env::var("GEN_BRIDGE_MAX_TOKENS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    let temperature: f32 = std::env::var("GEN_BRIDGE_TEMPERATURE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.7);
+    let home = std::env::var("AIRC_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let base = std::env::var("USERPROFILE")
+                .or_else(|_| std::env::var("HOME"))
+                .unwrap_or_else(|_| ".".into());
+            std::path::Path::new(&base).join(".airc")
+        });
+
+    let airc = match std::env::var("AIRC_SOCKET").ok() {
+        Some(socket) => Airc::attach_as(home, &name, socket).await?,
+        None => Airc::open_as(home, &name).await?,
+    };
+    airc.publish_identity().await?;
+    airc.join(&room).await?;
+    let me = airc.peer_id();
+
+    let offer = capability_offer(me, &name, &model);
+    advertise(&airc, &offer).await?;
+    eprintln!(
+        "airc-generate-bridge: '{name}' joined #{room} as {me}; advertising {:?} (model={model}, llama.cpp={base_url})",
+        offer.capabilities.capability_tags,
+    );
+
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(120)) // generation is slower than embedding
+        .build()?;
+
+    let cfg = GenConfig {
+        model,
+        max_tokens,
+        temperature,
+    };
+    run_bridge(&airc, me, &offer, &http, &base_url, &cfg).await
+}
+
+/// Generation knobs resolved once at startup and threaded into the handler.
+struct GenConfig {
+    model: String,
+    max_tokens: u32,
+    temperature: f32,
+}
+
+/// Build the standing capability advert. Advertises `ai/generate` (coarse),
+/// `ai/generate/<slug>` (parallel to the embedding facility), AND the raw model
+/// string — because a `TurnRequested.model_hint` is matched against
+/// `capability_tags` verbatim by `resolve_inference_target`, so the raw model
+/// name must be a tag for hint-routing to find this facility.
+fn capability_offer(me: PeerId, name: &str, model: &str) -> CapabilityOffer {
+    CapabilityOffer {
+        peer_id: me,
+        capabilities: PersonaCapabilities {
+            persona_id: name.to_string(),
+            capability_tags: vec![
+                "ai/generate".to_string(),
+                model_tag(model),
+                model.to_string(),
+            ],
+            model: model.to_string(),
+            context_window_tokens: 32768,
+        },
+        offered_at_ms: now_ms(),
+    }
+}
+
+/// `ai/generate/<model-slug>` — lowercased, non-alphanumeric → `-`, `.` kept.
+fn model_tag(model: &str) -> String {
+    let slug: String = model
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("ai/generate/{slug}")
+}
+
+async fn advertise(airc: &Airc, offer: &CapabilityOffer) -> Result<(), Box<dyn std::error::Error>> {
+    let mut fresh = offer.clone();
+    fresh.offered_at_ms = now_ms();
+    let (headers, body) = encode_capability_offer(&fresh)?;
+    airc.send(body, headers).await?;
+    Ok(())
+}
+
+/// The citizen loop: re-advertise on a cadence, and answer each inbound
+/// `TurnRequested` from another peer by running the model and replying
+/// `TurnEmitted`. Everything else is left alone.
+async fn run_bridge(
+    airc: &Airc,
+    me: PeerId,
+    offer: &CapabilityOffer,
+    http: &reqwest::Client,
+    base_url: &str,
+    cfg: &GenConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = airc.subscribe().await?;
+    let mut readvertise = tokio::time::interval(READVERTISE_EVERY);
+    readvertise.tick().await; // first tick is immediate; already advertised at startup
+
+    loop {
+        tokio::select! {
+            _ = readvertise.tick() => {
+                if let Err(e) = advertise(airc, offer).await {
+                    eprintln!("airc-generate-bridge: re-advertise failed: {e}");
+                }
+            }
+            item = stream.next() => {
+                let Some(item) = item else { break };
+                match item {
+                    Ok(event) => {
+                        if is_turn_request(&event, me) {
+                            handle_turn_request(airc, &event, http, base_url, cfg).await;
+                        }
+                    }
+                    Err(lag) => eprintln!("airc-generate-bridge: live stream lagged: {lag}"),
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// True iff this event is a persona `TurnRequested` from another peer. Cheap:
+/// keys off the projected `forge.persona.kind = turn_requested` header (the
+/// wire kind matching `PersonaEvent::TurnRequested`), no body decode.
+fn is_turn_request(event: &TranscriptEvent, me: PeerId) -> bool {
+    event.peer_id != me
+        && event
+            .headers
+            .get(HEADER_FORGE_PERSONA_KIND)
+            .map(String::as_str)
+            == Some("turn_requested")
+}
+
+/// Answer a `TurnRequested`: decode, refuse loud if it names a model we do not
+/// host, run the model, reply `TurnEmitted` correlating the command bus. Errors
+/// are logged not propagated — one bad turn must not kill the facility; the
+/// requester's `await_reply` deadlines loudly on a non-reply.
+async fn handle_turn_request(
+    airc: &Airc,
+    event: &TranscriptEvent,
+    http: &reqwest::Client,
+    base_url: &str,
+    cfg: &GenConfig,
+) {
+    let req = match decode_persona_event(&event.headers, event.body.as_ref()) {
+        Ok(PersonaEvent::TurnRequested(r)) => r,
+        Ok(_) => return, // some other persona event; not ours to answer
+        Err(e) => {
+            eprintln!("airc-generate-bridge: undecodable turn request: {e}");
+            return;
+        }
+    };
+    if let Some(hint) = req.model_hint.as_deref() {
+        if hint != cfg.model {
+            eprintln!(
+                "airc-generate-bridge: refusing turn {} for model '{}' — this facility serves '{}'",
+                req.turn_id, hint, cfg.model
+            );
+            return;
+        }
+    }
+    let text = match llamacpp::complete(
+        http,
+        base_url,
+        &req.prompt,
+        Some(&cfg.model),
+        cfg.max_tokens,
+        cfg.temperature,
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!(
+                "airc-generate-bridge: generate failed for {}: {e}",
+                req.turn_id
+            );
+            return;
+        }
+    };
+    let emitted = TurnEmitted {
+        persona_id: req.persona_id.clone(),
+        activity_id: req.activity_id.clone(),
+        turn_id: req.turn_id.clone(),
+        text,
+        emitted_at_ms: now_ms(),
+    };
+    if let Err(e) = reply_turn_emitted(airc, &event.headers, &emitted).await {
+        eprintln!(
+            "airc-generate-bridge: reply failed for {}: {e}",
+            req.turn_id
+        );
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{Body, EventId, RoomId, TranscriptKind};
+
+    fn turn_event(peer: PeerId, kind: &str) -> TranscriptEvent {
+        let mut headers = airc_core::headers::Headers::new();
+        headers.insert(HEADER_FORGE_PERSONA_KIND.to_string(), kind.to_string());
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: RoomId::from_u128(1),
+            peer_id: peer,
+            client_id: airc_core::ClientId::new(),
+            kind: TranscriptKind::Message,
+            occurred_at_ms: 1,
+            lamport: 1,
+            target: airc_core::transcript::MentionTarget::All,
+            headers,
+            body: Some(Body::text("{}")),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn detects_turn_request_from_another_peer() {
+        // what this catches: the facility answers TurnRequested from other peers
+        // — the command-bus turn a GridInferenceProvider escalates.
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert!(is_turn_request(&turn_event(other, "turn_requested"), me));
+    }
+
+    #[test]
+    fn turn_emitted_is_not_a_request() {
+        // what this catches: the facility answers requests, not replies — a
+        // turn_emitted (its own or another's) must not be treated as inbound work.
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        assert!(!is_turn_request(&turn_event(other, "turn_emitted"), me));
+    }
+
+    #[test]
+    fn own_turn_request_is_ignored() {
+        let me = PeerId::from_u128(1);
+        assert!(!is_turn_request(&turn_event(me, "turn_requested"), me));
+    }
+
+    #[test]
+    fn capability_offer_advertises_coarse_slug_and_raw_model() {
+        // what this catches: model_hint routing matches the RAW model string as
+        // a tag, so the raw model must be advertised alongside the coarse +
+        // slug tags or hint-routed turns never find this facility.
+        let me = PeerId::from_u128(9);
+        let offer = capability_offer(me, "generate-facility", "qwen3-coder-30b");
+        let tags = &offer.capabilities.capability_tags;
+        assert!(tags.contains(&"ai/generate".to_string()));
+        assert!(tags.contains(&"ai/generate/qwen3-coder-30b".to_string()));
+        assert!(tags.contains(&"qwen3-coder-30b".to_string()));
+        assert_eq!(offer.capabilities.model, "qwen3-coder-30b");
+    }
+
+    #[test]
+    fn model_tag_slugifies() {
+        assert_eq!(model_tag("Qwen3-Coder-30B"), "ai/generate/qwen3-coder-30b");
+        assert_eq!(model_tag("llama 3.1 8b"), "ai/generate/llama-3.1-8b");
+    }
+}

--- a/integrations/generate-facility/docker-compose.yml
+++ b/integrations/generate-facility/docker-compose.yml
@@ -1,0 +1,65 @@
+# airc generate facility — the GPU generation server.
+#
+# llama.cpp server (chat/completions, NOT --embedding) on the RTX 5090, serving
+# a capable model over the OpenAI `/v1/chat/completions` endpoint. The
+# airc-generate-bridge advertises it as `ai/generate` so GPU-less personas lease
+# the model call over the grid (cognition stays local — "remote grid inference").
+#
+# Sibling to ../embedding-facility/docker-compose.yml; same llama.cpp CUDA image,
+# different mode (generation, not embedding) and a larger model.
+#
+# Validate standalone (Docker engine up):
+#   cd integrations/generate-facility
+#   docker compose up
+#   curl -s localhost:8081/v1/chat/completions -H 'content-type: application/json' \
+#     -d '{"messages":[{"role":"user","content":"say hi in 3 words"}],"max_tokens":16}' \
+#     | jq -r '.choices[0].message.content'
+#
+# The model + server are ADAPTERS: override GEN_HF_REPO / GEN_HF_FILE to serve a
+# different capable model. (Generation does NOT need the embedding facility's
+# one-vector-space lockstep — a persona routes by model_hint, and the bridge
+# refuses a turn whose model_hint it doesn't host.)
+
+services:
+  generator:
+    image: ${GEN_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
+    container_name: airc-generator
+    restart: unless-stopped
+    # The capable model the 5090 serves. Default is a real public coding model
+    # that fits the 5090's 32GB VRAM (Qwen2.5-Coder-32B-Instruct, Q4_K_M ~20GB);
+    # override GEN_HF_REPO/GEN_HF_FILE with the project's forged qwen3-coder once
+    # it's published. Pin a digest once Blackwell sm_120 is verified (same caveat
+    # as the embedding facility).
+    command: >
+      --hf-repo ${GEN_HF_REPO:-Qwen/Qwen2.5-Coder-32B-Instruct-GGUF}
+      --hf-file ${GEN_HF_FILE:-qwen2.5-coder-32b-instruct-q4_k_m.gguf}
+      --ctx-size ${GEN_CTX:-32768}
+      --host 0.0.0.0
+      --port 8081
+      --n-gpu-layers 99
+      --jinja
+    ports:
+      # Loopback only — the airc-generate-bridge (the sole client) runs on this
+      # host; the grid reaches generation via airc + the capability ACL, never an
+      # exposed HTTP port. Port 8081 (8080 is the embedding facility).
+      - "127.0.0.1:8081:8081"
+    volumes:
+      # Model cache on the 16TB foundry drive (HDD fine: sequential load, VRAM
+      # inference). Named-volume fallback for boxes without the drive.
+      - ${GEN_MODEL_CACHE:-llama-gen-cache}:/root/.cache/llama.cpp
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8081/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 300s # large model load
+
+volumes:
+  llama-gen-cache:

--- a/integrations/generate-facility/smoke.sh
+++ b/integrations/generate-facility/smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Live smoke for the 5090 generate facility's GPU server (slice 1).
+#
+# Validates the piece unit tests + `docker compose config` can't: that llama.cpp
+# actually loads the capable model on this GPU (notably Blackwell / sm_120 on the
+# RTX 5090) and returns a real chat completion over `/v1/chat/completions`. The
+# bridge + wire are covered by `cargo test`; THIS covers the GPU generation.
+#
+# Usage (from this directory, Docker engine up):
+#   ./smoke.sh
+# Env overrides mirror docker-compose.yml: GEN_HF_REPO, GEN_HF_FILE, etc.
+# First run pulls the (large) GGUF to the model cache — allow many minutes.
+#
+# Exit 0 = a non-empty completion came back; the facility's GPU half is proven.
+# Leaves the stack running unless KEEP_UP=0.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+PORT="${GEN_SMOKE_PORT:-8081}"
+BASE="http://127.0.0.1:${PORT}"
+HEALTH_TIMEOUT="${GEN_SMOKE_HEALTH_TIMEOUT:-900}" # large model: long first load
+KEEP_UP="${KEEP_UP:-1}"
+
+log() { printf '\n\033[1m[smoke]\033[0m %s\n' "$*"; }
+fail() { printf '\n\033[31m[smoke FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v docker >/dev/null 2>&1 || fail "docker not on PATH"
+docker info >/dev/null 2>&1 || fail "docker engine not responding (start Docker Desktop / the daemon)"
+
+cleanup() {
+  if [ "${KEEP_UP}" = "0" ]; then
+    log "tearing down (KEEP_UP=0)"
+    docker compose down >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+log "starting the generation server (docker compose up -d) ..."
+docker compose up -d
+
+log "waiting for /health (up to ${HEALTH_TIMEOUT}s — first run pulls a large GGUF) ..."
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+until curl -fsS "${BASE}/health" >/dev/null 2>&1; do
+  if [ "$(date +%s)" -ge "${deadline}" ]; then
+    log "server did not become healthy; last 40 log lines:"
+    docker compose logs --tail=40 || true
+    fail "timed out waiting for ${BASE}/health (sm_120/Blackwell kernel miss? see ../embedding-facility/README fallback)"
+  fi
+  sleep 3
+done
+log "server healthy."
+
+log "requesting a chat completion ..."
+resp="$(curl -fsS "${BASE}/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{"messages":[{"role":"user","content":"Reply with exactly: grid online"}],"max_tokens":16,"temperature":0}')" \
+  || fail "POST /v1/chat/completions failed"
+
+# Assert a non-empty assistant message came back, and echo it.
+text=""
+if command -v python3 >/dev/null 2>&1; then
+  text="$(printf '%s' "$resp" | python3 -c \
+    'import sys,json; c=json.load(sys.stdin)["choices"][0]["message"]["content"]; assert c.strip(); print(c.strip())' \
+    2>/dev/null)" || fail "response had no completion content: ${resp:0:200}"
+else
+  printf '%s' "$resp" | grep -Eq '"content"[[:space:]]*:[[:space:]]*"[^"]' \
+    || fail "response had no completion content: ${resp:0:200}"
+  text="(install python3 to echo the text)"
+fi
+
+log "OK — completion returned: \"${text}\". The 5090 generate facility GPU half is PROVEN. 🚀"
+log "advertise it on the grid:  cargo run -p airc-generate-bridge   (needs a running airc daemon)"


### PR DESCRIPTION
## What

The **(a) deliverable** from the fleet's remote-grid-inference cut: a GPU node serving text generation to the mesh as the `ai/generate` capability, so a **GPU-less persona keeps its cognition local and escalates only the model call**. Sibling to `integrations/embedding-facility` — same pattern (airc citizen + capability advertisement + thin llama.cpp HTTP client), different capability. Embedding was the dress rehearsal; this is the headline ("remote grid inference").

## No new wire types

It answers the **existing** `TurnRequested` → `TurnEmitted` command-bus pair (`crates/examples/consumer_shapes`), the same one `request_inference_remote` already drives. The consumer is continuum's `GridInferenceProvider` (Intel Mac, slice 3) — swaps the deliberation faculty's local `AIProviderAdapter` for one routing the model call to this facility, by `model_hint`.

## Pieces

- **`bridge/` (`airc-generate-bridge`):** grounded citizen advertising `ai/generate` + `ai/generate/<slug>` + the **raw model string** (because `resolve_inference_target` matches `model_hint` against `capability_tags` verbatim — the raw model must be a tag or hint-routed turns never find it). Re-adverts every 60s vs the registry TTL. On `TurnRequested`: **refuses loud** if `model_hint` names a model it doesn't host (never wrong-model output) → runs llama.cpp → replies `TurnEmitted` correlating the bus.
- **`llamacpp.rs`:** pure `/v1/chat/completions` build + parse (prompt as a user message so the chat template applies), loud on malformed.
- **`docker-compose.yml`:** llama.cpp chat server on the 5090 (port 8081, loopback-bound), capable coding-model default (override with the forge output), model cache on the 16TB drive.

## Known limitation (documented, not a bug)

The cross-grid `TurnEmitted` wire is **text-only** (`text: String`). A model emitting structured `tool_calls` with no text fails with a **clear named error** rather than a vague "empty content" — tool-call-preserving remote inference needs a **structured `TurnEmitted`** (ContentParts), the natural follow-up once tool-using personas run remote (composes with M5's structured `NativeToolCall` contract). Until then: tool execution stays where cognition runs (local); this facility serves the text-generation half.

## Validation

`cargo fmt` + `cargo clippy -D warnings` + `cargo test` — **13 tests** green. Live 5090 generation pending the Docker engine (BIGMAMA's Docker Desktop **service** is stopped — needs an elevated restart; same blocker as the embedding/​#1661 live proofs).

## Compression follow-up

Two facilities now share one pattern (embedding + generate). Per the outlier-validation discipline, that's the signal to extract a shared **facility-core** (citizen loop + advert + cadence + a handler seam) — a clean follow-up once both are proven live, not a preemptive abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)