### PR TITLE
fix(send): surface live-connection count so a broken fan-out can't read as success (#1243)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -866,16 +866,41 @@ fn canonical_machine_account_home() -> Option<PathBuf> {
 /// actually received anything. To confirm delivery, the operator runs
 /// `airc doctor --health` (route status), which reads the forwarder's
 /// real ack counters.
-fn format_send_receipt(channel_name: &str, channel_id: &str, peer_count: usize) -> String {
-    if peer_count == 0 {
+///
+/// `connected_lan_peers` (from `Status`, refreshed by the daemon's
+/// route-refresh loop) is the set room broadcast can ACTUALLY reach
+/// right now — the forwarder fans out only over live LAN connections.
+/// When it is `0` while peers are enrolled, the send reached NO remote
+/// machine, and the receipt says so LOUDLY: enrolling a peer is an
+/// address-book entry, not a live route, and a silently-zero connected
+/// set is exactly how a fully-broken fan-out masqueraded as a healthy
+/// channel (issue #1243 — the loopback-only legibility trap).
+fn format_send_receipt(
+    channel_name: &str,
+    channel_id: &str,
+    enrolled_peers: usize,
+    connected_lan_peers: usize,
+) -> String {
+    if enrolled_peers == 0 {
         format!(
             "queued to {channel_name} ({channel_id}) — 0 enrolled remote peer(s); \
              any scope tailing this channel on this machine will receive it."
         )
+    } else if connected_lan_peers == 0 {
+        // LOUD: enrolled peers exist but the daemon holds no live LAN
+        // connection, so room broadcast forwarded to nobody. This is the
+        // signal whose absence let a broken fan-out read as success.
+        format!(
+            "queued to {channel_name} ({channel_id}) — ⚠ reached 0 of {enrolled_peers} \
+             enrolled remote peer(s): NONE are currently connected, so no remote machine \
+             received this (run `airc doctor --health` to see why the routes are down). \
+             Any scope tailing this channel on this machine still has it."
+        )
     } else {
         format!(
-            "queued to {channel_name} ({channel_id}) — addressed {peer_count} enrolled \
-             remote peer(s); delivery is asynchronous and not yet confirmed \
+            "queued to {channel_name} ({channel_id}) — addressed {enrolled_peers} enrolled \
+             remote peer(s), {connected_lan_peers} currently connected; delivery is \
+             asynchronous and not yet confirmed \
              (run `airc doctor --health` to check route delivery). \
              Any scope tailing this channel on this machine also receives it."
         )
@@ -938,9 +963,19 @@ pub async fn run_send(
     // delivery count — see `format_send_receipt` for why the receipt
     // says "queued/addressed" rather than "sent to N peers".
     let peer_count = airc.peers().await?.len();
+    // Ask the daemon how many of those peers it currently holds a LIVE
+    // LAN connection to — the set room broadcast can actually reach.
+    // A cheap Status round-trip; on any failure we fall back to 0,
+    // which the receipt frames as "none currently connected" rather
+    // than inventing reach the daemon can't confirm.
+    let connected_lan_peers = DaemonClient::new(crate::cli::default_socket_path_in(home))
+        .status()
+        .await
+        .map(|status| status.connected_lan_peers)
+        .unwrap_or(0);
     println!(
         "{}",
-        format_send_receipt(&channel_name, &channel_id, peer_count)
+        format_send_receipt(&channel_name, &channel_id, peer_count, connected_lan_peers)
     );
     Ok(())
 }
@@ -1461,9 +1496,10 @@ pub async fn run_daemon(
 /// them. Inbound sink + forwarder link are installed once in
 /// `run_daemon` before this spawns.
 fn spawn_route_refresh(state: Arc<DaemonState>, airc: Airc) -> tokio::task::JoinHandle<()> {
+    let connected = state.connected_lan_peers.clone();
     tokio::spawn(async move {
         airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
-            refresh_routes_once(&airc)
+            refresh_routes_once(&airc, &connected)
         })
         .await;
     })
@@ -1474,9 +1510,18 @@ fn spawn_route_refresh(state: Arc<DaemonState>, airc: Airc) -> tokio::task::Join
 /// surface every failure through the diagnostic sink — loud, never
 /// silent. Failures never propagate: the loop's next tick is the retry
 /// path (self-heal doctrine, card 625abe6d).
-async fn refresh_routes_once(airc: &Airc) {
+async fn refresh_routes_once(airc: &Airc, connected_lan_peers: &std::sync::atomic::AtomicUsize) {
     match airc.refresh_route_discovery().await {
         Ok(snapshot) => {
+            // Publish the live LAN-peer count for `Status` to report —
+            // the set room broadcast actually fans out to. This is the
+            // ONLY writer (the daemon crate can't reach the airc-lib
+            // handle that owns the connections), refreshed every tick so
+            // `airc send` can warn loudly when a broadcast reaches no one.
+            connected_lan_peers.store(
+                snapshot.connected_lan_peers.len(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
             for failure in &snapshot.peer_dial_failures {
                 StderrJsonDiagnosticSink.emit(
                     DiagnosticEvent::warn(
@@ -1596,11 +1641,17 @@ pub async fn run_msg(
     };
     // Same enrolled-vs-delivered honesty fix as run_send, for the
     // daemon-attached send path. `peers()` is the address book, not a
-    // delivery receipt.
+    // delivery receipt; the daemon's live-connection count (Status) is
+    // the set room broadcast can actually reach.
     let peer_count = airc.peers().await?.len();
+    let connected_lan_peers = DaemonClient::new(crate::cli::default_socket_path_in(home))
+        .status()
+        .await
+        .map(|status| status.connected_lan_peers)
+        .unwrap_or(0);
     println!(
         "{}",
-        format_send_receipt(&channel_name, &channel_id, peer_count)
+        format_send_receipt(&channel_name, &channel_id, peer_count, connected_lan_peers)
     );
     Ok(())
 }
@@ -2272,7 +2323,8 @@ mod tests {
     /// operator delivery is asynchronous + how to confirm it.
     #[test]
     fn send_receipt_does_not_imply_confirmed_delivery() {
-        let line = format_send_receipt("general", "cb2e21a1", 41);
+        // 41 enrolled, all currently connected → the healthy branch.
+        let line = format_send_receipt("general", "cb2e21a1", 41, 41);
 
         // The exact misleading phrasing is gone.
         assert!(
@@ -2311,7 +2363,7 @@ mod tests {
     /// reported as enrolled, never as a delivery confirmation.
     #[test]
     fn send_receipt_zero_peers_is_honest_about_local_tailers() {
-        let line = format_send_receipt("general", "cb2e21a1", 0);
+        let line = format_send_receipt("general", "cb2e21a1", 0, 0);
         assert!(!line.starts_with("sent to"), "no delivery verb: {line}");
         assert!(
             !line.contains("paired peer"),
@@ -2325,6 +2377,53 @@ mod tests {
         assert!(
             line.contains("tailing this channel on this machine"),
             "must preserve the same-machine-delivery truth: {line}"
+        );
+    }
+
+    /// what this catches (issue #1243 — the legibility trap): enrolled
+    /// peers exist but the daemon holds ZERO live LAN connections, so
+    /// room broadcast forwarded to nobody. The receipt must say so
+    /// LOUDLY (not report the enrolled "address book" count as if it
+    /// were reach) — the silent-success of this exact case let a fully
+    /// broken fan-out masquerade as a healthy channel for an hour.
+    #[test]
+    fn send_receipt_warns_loudly_when_no_peer_is_connected() {
+        let line = format_send_receipt("general", "cb2e21a1", 42, 0);
+        assert!(line.contains("queued to general"), "honest verb: {line}");
+        // It must NOT frame 42 enrolled as if 42 received it.
+        assert!(
+            line.contains("reached 0 of 42"),
+            "must surface that 0 of 42 enrolled peers were reached: {line}"
+        );
+        assert!(
+            line.contains("NONE are currently connected"),
+            "must name the broken-route cause, not imply delivery: {line}"
+        );
+        assert!(
+            line.contains("airc doctor --health"),
+            "must point the operator at the route diagnostic: {line}"
+        );
+        // The same-machine truth is preserved even when remotes are dark.
+        assert!(
+            line.contains("tailing this channel on this machine"),
+            "local tailers still receive it: {line}"
+        );
+    }
+
+    /// what this catches: the healthy branch reports BOTH counts —
+    /// enrolled (address book) and the live-connected subset — without
+    /// claiming confirmed delivery. Distinguishes "addressed N, M
+    /// connected" from the loud zero-connected case above.
+    #[test]
+    fn send_receipt_reports_connected_subset_when_routes_are_up() {
+        let line = format_send_receipt("general", "cb2e21a1", 42, 3);
+        assert!(
+            line.contains("42 enrolled") && line.contains("3 currently connected"),
+            "must report enrolled total and live-connected subset: {line}"
+        );
+        assert!(
+            line.contains("asynchronous") && line.contains("not yet confirmed"),
+            "still does not claim confirmed delivery: {line}"
         );
     }
 
@@ -2531,6 +2630,7 @@ mod tests {
             build_commit: commit.map(str::to_string),
             build_branch: Some("rust-rewrite".to_string()),
             executable: Some("/tmp/airc".to_string()),
+            connected_lan_peers: 0,
         }
     }
 

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -45,6 +45,9 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
             build_commit: state.runtime.build_commit.clone(),
             build_branch: state.runtime.build_branch.clone(),
             executable: state.runtime.executable.clone(),
+            connected_lan_peers: state
+                .connected_lan_peers
+                .load(std::sync::atomic::Ordering::Relaxed),
         }),
         Request::Send(send) => handle_send(state, send).await,
         Request::Publish(publish) => handle_publish(state, publish).await,

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -15,6 +15,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -63,6 +64,17 @@ pub struct DaemonState {
     /// endpoints instead of an endpoint-less beacon. Empty = this
     /// daemon is not dialable (no listener bound).
     pub route_endpoints: RwLock<Vec<IpcRouteEndpoint>>,
+    /// Count of remote peers the daemon's routing handle currently holds
+    /// a live LAN connection to — the set room broadcast actually fans
+    /// out to. Reported via `Status` so a client can tell whether a room
+    /// send can reach anyone (vs. the enrolled-peer "address book" count,
+    /// which says nothing about live reach). The concrete connection
+    /// state lives on an `airc-lib` `Airc` handle, and this crate must
+    /// not depend on `airc-lib` (same boundary as the route-refresh
+    /// closure), so the host's route-refresh loop writes this shared
+    /// counter each tick — exactly the wiring split used for
+    /// `route_endpoints`. `0` until the first refresh completes.
+    pub connected_lan_peers: Arc<AtomicUsize>,
 }
 
 impl DaemonState {
@@ -106,6 +118,7 @@ impl DaemonState {
             shutdown: Notify::new(),
             runtime,
             route_endpoints: RwLock::new(Vec::new()),
+            connected_lan_peers: Arc::new(AtomicUsize::new(0)),
         })
     }
 

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -95,6 +95,18 @@ pub struct StatusResponse {
     /// only; lifecycle decisions use protocol + build metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executable: Option<String>,
+    /// Count of remote peers this daemon currently holds a LIVE LAN
+    /// connection to — the set room broadcast actually fans out to
+    /// (`RoutedForwarder` forwards only over `connected_peers()`),
+    /// refreshed by the daemon's route-refresh loop. `0` while
+    /// enrolled peers exist means a room send reaches NO remote peer:
+    /// the signal `airc send` surfaces so a broken fan-out can't
+    /// masquerade as success (the enrolled-peer "address book" count
+    /// alone hid this). `#[serde(default)]`: a daemon predating this
+    /// field decodes as `0` — treated as "unknown / none", which the
+    /// receipt frames honestly rather than as confirmed reach.
+    #[serde(default)]
+    pub connected_lan_peers: usize,
 }
 
 /// One entry in the `Peers` response. Mirrors `peers_store::StoredPeer`
@@ -238,6 +250,7 @@ mod tests {
             build_commit: Some("abc123".to_string()),
             build_branch: Some("rust-rewrite".to_string()),
             executable: Some("/tmp/airc".to_string()),
+            connected_lan_peers: 2,
         });
         let encoded = serde_json::to_string(&original).unwrap();
         let decoded: Response = serde_json::from_str(&encoded).unwrap();
@@ -259,7 +272,27 @@ mod tests {
                 build_commit: None,
                 build_branch: None,
                 executable: None,
+                connected_lan_peers: 0,
             })
+        );
+    }
+
+    /// A daemon predating the `connected_lan_peers` field (it carries
+    /// the metadata fields but not the connection count) must decode as
+    /// `0` — "unknown / none", never a crash. Pins the `#[serde(default)]`
+    /// back-compat contract so a newer CLI can read an older daemon.
+    #[test]
+    fn status_defaults_connected_lan_peers_for_pre_field_daemon() {
+        let decoded: Response = serde_json::from_str(
+            r#"{"kind":"status","peer_id":"07e7ad58-ba56-4535-b4e5-a161a110e487","uptime_seconds":42,"ipc_protocol_version":3}"#,
+        )
+        .unwrap();
+        let Response::Status(status) = decoded else {
+            panic!("expected status response");
+        };
+        assert_eq!(
+            status.connected_lan_peers, 0,
+            "a daemon without the field must decode as 0 connected peers, not error"
         );
     }
 


### PR DESCRIPTION
Closes the legibility half of #1243.

## Problem

Cross-grid coordination over `#general` silently degraded to operator-relay. `airc send` reported success —

```
queued to general (…) — addressed 42 enrolled remote peer(s); delivery is
asynchronous and not yet confirmed …
```

— while the daemon held **ZERO live LAN connections**, so room broadcast (`RoutedForwarder`) forwarded to **nobody**. The local loopback always succeeds, so a fully-broken fan-out read as a healthy channel; both BigMama and M5 dismissed each other's real messages as their own echo for ~an hour.

The receipt wasn't dishonest — it said "enrolled", "not yet confirmed", "run doctor". The gap is that it counted `airc.peers()` (the enrolled **address book**, 42) while the forwarder fans out only over `connected_peers()` (live LAN links, here **0**). Enrolling a peer is not a live route, and **nothing surfaced the difference**.

Evidence (`airc transport health` on BigMama): every dial fails — M5/IntelMac "actively refused" (stale advertised ports), ~25 Docker nodes "timed out" on unroutable `172.x` bridge IPs. `doctor` shows `1 route healthy` = local-fs only.

## Fix — report live connections, go loud at zero

- **`StatusResponse.connected_lan_peers`** (`#[serde(default)]` → an older daemon decodes as `0`, never errors).
- **`DaemonState`** carries a host-updated `Arc<AtomicUsize>`. `airc-daemon` must not depend on `airc-lib` (where the connection state lives) — same wiring split already used for `route_endpoints` — so the daemon's 60s **route-refresh loop** writes `snapshot.connected_lan_peers.len()` each tick.
- **`Status`** reports it; **`airc send`/`msg`** read it (one cheap round-trip) and the receipt branches:

| enrolled | connected | receipt |
|---|---|---|
| 0 | — | unchanged (local tailers only) |
| >0 | **0** | `⚠ reached 0 of N enrolled remote peer(s): NONE are currently connected … (run airc doctor --health)` |
| >0 | M>0 | `addressed N enrolled remote peer(s), M currently connected; …` |

## Validation (all green on Windows)

- `cargo check` / `cargo clippy --all-targets -- -D warnings` clean (airc-ipc, airc-daemon, airc-cli)
- airc-ipc: `StatusResponse` round-trip + **pre-field daemon decodes as 0** back-compat test
- airc-cli: loud-zero-connected receipt + connected-subset receipt + existing zero-enrolled / no-false-delivery tests
- airc-daemon: route_refresh tests; airc-cli `events_commands` integration

## Scope

Does **not** fix the underlying dial failures (stale Mac ports, Docker `172.x` endpoints) — those are tracked in #1243 and need cross-machine work. This makes them **visible at send time** instead of silently masquerading as delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)