### PR TITLE
fix(monitor): dedup own outbound by peer, not just client_id — the loopback trap

### DIFF
--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::Write;
 use std::path::Path;
 
-use airc_core::{Body, MentionTarget, RoomId, TranscriptEvent, TranscriptKind};
+use airc_core::{Body, MentionTarget, PeerId, RoomId, TranscriptEvent, TranscriptKind};
 use airc_ipc::{codec::read_frame, AttachRequest, AttachStart, DaemonClient, Response};
 use airc_lib::{decode_wire_event, Airc};
 use airc_protocol::HEADER_AIRC_CLIENT;
@@ -54,6 +54,12 @@ pub(crate) async fn run(
     coalesce_backlog: bool,
 ) -> Result<(), Box<dyn Error>> {
     let airc = Airc::open(home).await?;
+    // This monitoring scope's OWN peer. Its outbound echoes back through
+    // the room transcript; matching the frame's sender peer against this
+    // is how we keep own sends from reading as inbound (the loopback
+    // trap). Peer-level — not just client_id — because a separate `airc
+    // send` invocation is a different client but the SAME peer.
+    let my_peer = airc.peer_id();
     let client_id = current_client_id().ok().flatten();
     let socket = crate::cli::default_socket_path_in(home);
     let set = airc.subscription_set().await?;
@@ -178,7 +184,7 @@ pub(crate) async fn run(
                     sandbox.emit_contract_once();
                     render_text_event(&event, client_id.as_deref(), &text, &mut sandbox);
                 } else if matches!(event.kind, TranscriptKind::Message | TranscriptKind::System) {
-                    render_event(&event, client_id.as_deref(), &mut sandbox);
+                    render_event(&event, &my_peer, client_id.as_deref(), &mut sandbox);
                 }
             }
             MonitorFrame::CatchUpSummary { channel, skipped } => {
@@ -199,8 +205,13 @@ pub(crate) async fn run(
     Ok(())
 }
 
-fn render_event(event: &TranscriptEvent, client_id: Option<&str>, sandbox: &mut Sandbox) {
-    if is_own_runtime_event(event, client_id) {
+fn render_event(
+    event: &TranscriptEvent,
+    my_peer: &PeerId,
+    client_id: Option<&str>,
+    sandbox: &mut Sandbox,
+) {
+    if is_own_runtime_event(event, my_peer, client_id) {
         return;
     }
 
@@ -243,7 +254,22 @@ fn render_text_event(
     );
 }
 
-fn is_own_runtime_event(event: &TranscriptEvent, client_id: Option<&str>) -> bool {
+fn is_own_runtime_event(
+    event: &TranscriptEvent,
+    my_peer: &PeerId,
+    client_id: Option<&str>,
+) -> bool {
+    // PEER-level first: the monitoring scope's own outbound carries its
+    // peer id, and a separate `airc send` invocation is a different
+    // client_id but the SAME peer — so the prior client-id-only check
+    // let own sends echo back as if inbound (the loopback trap). This
+    // mirrors `TranscriptEvent::is_self_echo(.., ExcludeSamePeer)`.
+    if event.peer_id == *my_peer {
+        return true;
+    }
+    // Defensive retain: a runtime client header (or client_id) marking
+    // the frame as ours even when the peer differs — rare cross-identity
+    // CLI paths where one scope drives another's client surface.
     let Some(client_id) = client_id else {
         return false;
     };
@@ -304,9 +330,16 @@ mod tests {
     #[test]
     fn render_event_filters_same_client() {
         let event = event("hello");
+        // A different monitor peer, so the client-id path is what's exercised.
+        let other_peer = PeerId::new();
         let mut sandbox = Sandbox::new();
 
-        render_event(&event, Some(&event.client_id.to_string()), &mut sandbox);
+        render_event(
+            &event,
+            &other_peer,
+            Some(&event.client_id.to_string()),
+            &mut sandbox,
+        );
 
         assert!(!sandbox.has_emitted());
     }
@@ -317,9 +350,10 @@ mod tests {
         event
             .headers
             .insert(HEADER_AIRC_CLIENT.to_string(), "codex:thread-1".to_string());
+        let other_peer = PeerId::new();
         let mut sandbox = Sandbox::new();
 
-        render_event(&event, Some("codex:thread-1"), &mut sandbox);
+        render_event(&event, &other_peer, Some("codex:thread-1"), &mut sandbox);
 
         assert!(!sandbox.has_emitted());
     }
@@ -331,11 +365,35 @@ mod tests {
             HEADER_AIRC_CLIENT.to_string(),
             "claude:session-1".to_string(),
         );
+        let other_peer = PeerId::new();
         let mut sandbox = Sandbox::new();
 
-        render_event(&event, Some("codex:thread-1"), &mut sandbox);
+        render_event(&event, &other_peer, Some("codex:thread-1"), &mut sandbox);
 
         assert!(sandbox.has_emitted());
+    }
+
+    /// what this catches (the loopback trap, 2026-06-17): the monitoring
+    /// scope's OWN outbound — same peer, but a SEPARATE `airc send`
+    /// invocation with a different client_id and NO matching client
+    /// header — must be filtered. The prior client-id-only check let it
+    /// through, so a sender saw its own messages as inbound and dismissed
+    /// real peer traffic as echo.
+    #[test]
+    fn render_event_filters_own_peer_echo_from_a_different_client() {
+        let mut event = event("my own send");
+        let my_peer = event.peer_id; // the monitor IS this peer…
+        event.client_id = ClientId::new(); // …but a different client instance sent it
+        let mut sandbox = Sandbox::new();
+
+        // No client_id match available and no matching header — only the
+        // peer identifies it as ours.
+        render_event(&event, &my_peer, Some("monitor:other-client"), &mut sandbox);
+
+        assert!(
+            !sandbox.has_emitted(),
+            "own-peer outbound must be filtered even from a different client"
+        );
     }
 
     fn event(text: &str) -> TranscriptEvent {


### PR DESCRIPTION
## Problem

`airc monitor`'s `is_own_runtime_event` filtered the operator's own outbound by **client_id only**, and returned `false` entirely when the monitor had no client_id. A separate `airc send` invocation carries a **different client_id but the same peer**, so own sends echoed back through the room transcript and rendered as **inbound peer messages**.

This is the loopback trap that masked real cross-peer delivery for an hour (alongside the #1243 fan-out diagnosis): a sender saw only its own traffic looping back and dismissed genuine peer messages as echo.

## Fix

Match the frame's sender peer against the monitoring scope's own `airc.peer_id()` first — mirroring `TranscriptEvent::is_self_echo(.., ExcludeSamePeer)` — then fall back to the existing client-id / `HEADER_AIRC_CLIENT` check for rare cross-identity CLI paths. The peer is always available from the open handle, so the previously-unfiltered no-client_id case is now covered too.

## Test

- New regression `render_event_filters_own_peer_echo_from_a_different_client`: an own-peer frame from a **different client** (no client-id match, no matching header) is filtered — exactly the case that leaked before.
- The three existing client-id tests still hold (they pass a distinct monitor peer, so the client-id path is what's exercised).
- `cargo clippy -p airc-cli --all-targets -- -D warnings` + `cargo fmt --check` clean.

Part of the "fix every airc bug" backbone sweep. Independent of #1244/#1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)