### PR TITLE
feat(relay): relay endpoint carries its peer id — connectable from the gist (#1247 slice 1)

### DIFF
--- a/crates/airc-lib/src/relay.rs
+++ b/crates/airc-lib/src/relay.rs
@@ -29,7 +29,7 @@ impl Airc {
             if guard.is_some() {
                 drop(guard);
                 self.ensure_relay_subscriber().await?;
-                self.upsert_relay_health(relay_addr)?;
+                self.upsert_relay_health(relay_addr, relay_peer)?;
                 return Ok(());
             }
         }
@@ -52,11 +52,15 @@ impl Airc {
             }
         }
         self.ensure_relay_subscriber().await?;
-        self.upsert_relay_health(relay_addr)?;
+        self.upsert_relay_health(relay_addr, relay_peer)?;
         Ok(())
     }
 
-    fn upsert_relay_health(&self, relay_addr: SocketAddr) -> Result<(), AircError> {
+    fn upsert_relay_health(
+        &self,
+        relay_addr: SocketAddr,
+        relay_peer: PeerId,
+    ) -> Result<(), AircError> {
         self.upsert_transport_health(TransportHealthSample {
             kind: TransportKind::Relay,
             role: TransportRole::Relay,
@@ -64,9 +68,13 @@ impl Airc {
             rtt_ms: None,
             success_ppm: None,
         })?;
-        self.upsert_route_endpoint(RouteEndpoint::Relay {
-            url: format!("airc-relay://{relay_addr}"),
-        })?;
+        // Record the relay endpoint with its peer id baked into the URL
+        // (`airc-relay://<peer>@<addr>`) so when this is advertised through
+        // the gist rendezvous, an importing peer can both dial AND pin the
+        // relay (mTLS) with no out-of-band credential exchange — the
+        // self-electing-relay model (#1247). A bare `airc-relay://<addr>`
+        // would be advertised un-connectable.
+        self.upsert_route_endpoint(RouteEndpoint::relay(relay_peer, relay_addr))?;
         Ok(())
     }
 

--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -83,6 +83,37 @@ impl RouteEndpoint {
             )),
         }
     }
+
+    /// Build a relay endpoint whose URL carries BOTH the relay's dialable
+    /// address AND its pinned peer id — `airc-relay://<peer>@<addr>`. A
+    /// peer importing this endpoint can then dial AND authenticate the
+    /// relay (the mTLS pin in `connect_relay`) with no separate
+    /// out-of-band credential exchange — closing the gap that left
+    /// `Relay { url }` un-connectable from discovery (#1247 slice 1).
+    pub fn relay(relay_peer: PeerId, relay_addr: SocketAddr) -> Self {
+        RouteEndpoint::Relay {
+            url: format!("airc-relay://{relay_peer}@{relay_addr}"),
+        }
+    }
+
+    /// If this is a relay endpoint whose URL carries a pinned peer id and
+    /// a dialable address, return the `(peer, addr)` pair
+    /// [`Airc::connect_relay`](crate::Airc::connect_relay) needs.
+    ///
+    /// `None` for a non-relay endpoint OR a relay URL missing either half
+    /// (e.g. a legacy `airc-relay://<addr>` with no peer id) — discovery
+    /// surfaces that as "relay advertised but not connectable" rather
+    /// than dialing an unauthenticated relay.
+    pub fn connectable_relay(&self) -> Option<(PeerId, SocketAddr)> {
+        let RouteEndpoint::Relay { url } = self else {
+            return None;
+        };
+        let rest = url.strip_prefix("airc-relay://")?;
+        let (peer, addr) = rest.rsplit_once('@')?;
+        let peer = PeerId::from_uuid(uuid::Uuid::parse_str(peer).ok()?);
+        let addr = addr.parse::<SocketAddr>().ok()?;
+        Some((peer, addr))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -268,6 +299,45 @@ mod tests {
         assert!(json.contains("lan_tcp"));
         assert!(json.contains("127.0.0.1:7474"));
         assert!(!json.contains("message"));
+    }
+
+    /// what this catches (#1247 slice 1): a relay endpoint built with a
+    /// pinned peer id round-trips back to the exact `(peer, addr)` pair
+    /// `connect_relay` needs — so a relay advertised through the gist is
+    /// dialable AND pinnable with no out-of-band credential exchange.
+    #[test]
+    fn relay_endpoint_carries_peer_id_and_round_trips() {
+        let relay_peer = PeerId::new();
+        let relay_addr = SocketAddr::from(([10, 0, 1, 16], 65458));
+        let endpoint = RouteEndpoint::relay(relay_peer, relay_addr);
+
+        let (peer, addr) = endpoint
+            .connectable_relay()
+            .expect("relay endpoint with a peer id must be connectable");
+        assert_eq!(peer, relay_peer);
+        assert_eq!(addr, relay_addr);
+
+        // Survives JSON (the gist/trust-store boundary).
+        let json = endpoints_to_json(std::slice::from_ref(&endpoint)).expect("json");
+        let back = endpoints_from_json(&json).expect("decode");
+        assert_eq!(back[0].connectable_relay(), Some((relay_peer, relay_addr)));
+    }
+
+    /// what this catches: a legacy `airc-relay://<addr>` URL (no peer id)
+    /// is NOT connectable — discovery must surface "advertised but not
+    /// pinnable" rather than dial an unauthenticated relay. Likewise a
+    /// non-relay endpoint yields `None`.
+    #[test]
+    fn relay_without_peer_id_or_non_relay_is_not_connectable() {
+        let legacy = RouteEndpoint::Relay {
+            url: "airc-relay://10.0.1.16:65458".to_string(),
+        };
+        assert_eq!(legacy.connectable_relay(), None);
+
+        let lan = RouteEndpoint::LanTcp {
+            addr: SocketAddr::from(([127, 0, 0, 1], 7474)),
+        };
+        assert_eq!(lan.connectable_relay(), None);
     }
 
     #[test]


### PR DESCRIPTION
First slice of the relay integration (#1247) — the durable cross-subnet fix for #1243.

## Why

The relay deployment model is **leaderless self-election via the account-registry gist** (Joel): whoever is reachable advertises a relay endpoint there; peers that can't reach each other directly ride it; an unreachable candidate is simply ignored (reachability proven empirically by who actually connects). For that, a relay endpoint pulled from the gist must be **dialable AND pinnable** with no out-of-band credential exchange — but `RouteEndpoint::Relay` recorded only `airc-relay://<addr>`, with **no relay peer id**, so an importing peer had nothing to mTLS-pin and couldn't connect. This slice closes that.

## Change (additive — zero blast radius on the ~12 existing `Relay { url }` sites)

- `RouteEndpoint::relay(peer, addr)` → builds `airc-relay://<peer>@<addr>`.
- `RouteEndpoint::connectable_relay() -> Option<(PeerId, SocketAddr)>` → the pair `Airc::connect_relay` needs; `None` for a non-relay endpoint or a legacy peer-id-less URL (surfaced as "advertised but not pinnable", never a silent dial to an unauthenticated relay).
- `upsert_relay_health` records the peer-id-bearing URL.

## Tests

- `relay_endpoint_carries_peer_id_and_round_trips` — round-trips through JSON (the gist/trust-store boundary) back to the exact `(peer, addr)`.
- `relay_without_peer_id_or_non_relay_is_not_connectable` — legacy `airc-relay://<addr>` and non-relay endpoints yield `None`.
- `cargo clippy -p airc-lib --all-targets -- -D warnings` + `cargo fmt --check` clean.

## Next (tracked in #1247)

2. discovery auto-connects advertised relays → marks relay health
3. `RoutedForwarder` send-once-to-relay path (relay is a single pipe, not per-peer)
4. relay self-election + liveness via the gist (the leaderless model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)