### PR TITLE
feat(relay): discovery auto-connects advertised relay endpoints (#1247 slice 2)

### DIFF
--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -276,80 +276,144 @@ impl Airc {
         let mut failures = Vec::new();
         let mut skips = Vec::new();
         for endpoint in &endpoints {
-            let addr = match endpoint {
-                RouteEndpoint::LanTcp { addr } | RouteEndpoint::TailscaleTcp { addr } => *addr,
-                // Relay/UDP/WebRTC/Reticulum dialing lands in later
-                // slices; recording them as failures here would be noise
-                // about unimplemented transports, not signal about
-                // unreachable peers. Variants enumerated, not wildcarded,
-                // per the production no-silent-fallback clippy gate: a
-                // FUTURE endpoint variant must force this match to be
-                // revisited, not silently fall into "skip" (the wildcard
-                // slipped past #1120's review because the merge-push CI
-                // run was hand-cancelled — caught by the #1121 sentinel).
+            match endpoint {
+                RouteEndpoint::LanTcp { addr } | RouteEndpoint::TailscaleTcp { addr } => {
+                    let addr = *addr;
+                    // Card 7e3c9a1f: skip endpoints still inside their dial-
+                    // failure backoff window. A daemon that restarted on a new
+                    // port leaves its old `addr` in every peer's trust store
+                    // until the registry re-converges; without this skip each
+                    // refresh re-pays PEER_DIAL_TIMEOUT on that corpse, starving
+                    // the dial to the live endpoint. The freshest (most likely
+                    // live) endpoint is listed first and is never quarantined
+                    // unless it itself just failed, so this never blocks a
+                    // genuinely reachable peer.
+                    //
+                    // The skip is SURFACED, not silent — but on the SEPARATE
+                    // `peer_dial_skips` channel, NOT as a `PeerDialFailure`. No
+                    // dial was attempted, so reporting it as a failure would emit
+                    // false `PeerDialFailed` warnings every refresh and inflate
+                    // `airc transport health`'s failure count. The operator still
+                    // sees "in backoff" via the skips channel — honest, not a
+                    // clean-list lie and not an over-report.
+                    if let Some(remaining_ms) =
+                        self.dial_quarantine_remaining_ms(peer_id, addr, now_ms)
+                    {
+                        skips.push(PeerDialSkip {
+                            peer_id,
+                            endpoint: endpoint.clone(),
+                            remaining_ms,
+                        });
+                        continue;
+                    }
+                    // #1120 sentinel blocking-2: connect_lan has no inner
+                    // timeout, and a SYN-dropping firewall (the default posture
+                    // of the NATs this card exists to cross) hangs the OS connect
+                    // for ~21-130s per endpoint. Bound every dial; a timeout is a
+                    // recorded failure like any other.
+                    match tokio::time::timeout(PEER_DIAL_TIMEOUT, self.connect_lan(addr, peer_id))
+                        .await
+                    {
+                        Ok(Ok(())) => {
+                            // Card 7e3c9a1f: a live connect lifts any prior
+                            // quarantine so a flapped-but-recovered endpoint is
+                            // immediately eligible again next refresh.
+                            self.dial_quarantine_record_success(peer_id, addr);
+                            break;
+                        }
+                        Ok(Err(error)) => {
+                            self.dial_quarantine_record_failure(peer_id, addr, now_ms);
+                            failures.push(PeerDialFailure {
+                                peer_id,
+                                endpoint: endpoint.clone(),
+                                error: error.to_string(),
+                            });
+                        }
+                        Err(_elapsed) => {
+                            self.dial_quarantine_record_failure(peer_id, addr, now_ms);
+                            failures.push(PeerDialFailure {
+                                peer_id,
+                                endpoint: endpoint.clone(),
+                                error: format!(
+                                    "dial timed out after {}s (endpoint unreachable or \
+                                     firewall drops SYN)",
+                                    PEER_DIAL_TIMEOUT.as_secs()
+                                ),
+                            });
+                        }
+                    }
+                }
+                // #1247 slice 2: a peer advertising a relay means "reach me
+                // (and others) through it." Connect to the relay as a
+                // cross-boundary route — direct LAN/tailscale endpoints are
+                // listed first (cost order), so we reach here only after they
+                // failed. `connect_relay` is idempotent, so a relay advertised
+                // by several peers connects once; its identity is mTLS-pinned
+                // (enrolled by the `sync_account_peer_registry` at the top of
+                // refresh for a self-advertised relay). Same dial-failure
+                // backoff as direct endpoints, keyed on the RELAY's identity so
+                // a dead relay isn't re-dialed every refresh. A legacy
+                // peer-id-less URL is not connectable — skipped here (surfaced
+                // upstream as not-pinnable), never a silent dial to an
+                // unauthenticated relay.
+                RouteEndpoint::Relay { .. } => {
+                    let Some((relay_peer, relay_addr)) = endpoint.connectable_relay() else {
+                        continue;
+                    };
+                    if let Some(remaining_ms) =
+                        self.dial_quarantine_remaining_ms(relay_peer, relay_addr, now_ms)
+                    {
+                        skips.push(PeerDialSkip {
+                            peer_id,
+                            endpoint: endpoint.clone(),
+                            remaining_ms,
+                        });
+                        continue;
+                    }
+                    match tokio::time::timeout(
+                        PEER_DIAL_TIMEOUT,
+                        self.connect_relay(relay_addr, relay_peer),
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => {
+                            self.dial_quarantine_record_success(relay_peer, relay_addr);
+                            // A relay route to this peer is established; stop
+                            // walking this peer's remaining (lower-priority)
+                            // endpoints.
+                            break;
+                        }
+                        Ok(Err(error)) => {
+                            self.dial_quarantine_record_failure(relay_peer, relay_addr, now_ms);
+                            failures.push(PeerDialFailure {
+                                peer_id,
+                                endpoint: endpoint.clone(),
+                                error: format!("relay connect: {error}"),
+                            });
+                        }
+                        Err(_elapsed) => {
+                            self.dial_quarantine_record_failure(relay_peer, relay_addr, now_ms);
+                            failures.push(PeerDialFailure {
+                                peer_id,
+                                endpoint: endpoint.clone(),
+                                error: format!(
+                                    "relay dial timed out after {}s (relay unreachable or \
+                                     firewall drops SYN)",
+                                    PEER_DIAL_TIMEOUT.as_secs()
+                                ),
+                            });
+                        }
+                    }
+                }
+                // UDP/WebRTC/Reticulum dialing lands in later slices.
+                // Variants enumerated, not wildcarded, per the production
+                // no-silent-fallback clippy gate: a FUTURE endpoint variant
+                // must force this match to be revisited, not silently fall
+                // into "skip" (the wildcard slipped past #1120's review when
+                // the merge-push CI run was hand-cancelled — caught by #1121).
                 RouteEndpoint::Udp { .. }
-                | RouteEndpoint::Relay { .. }
                 | RouteEndpoint::Reticulum { .. }
                 | RouteEndpoint::WebRtcSignaling { .. } => continue,
-            };
-            // Card 7e3c9a1f: skip endpoints still inside their dial-
-            // failure backoff window. A daemon that restarted on a new
-            // port leaves its old `addr` in every peer's trust store
-            // until the registry re-converges; without this skip each
-            // refresh re-pays PEER_DIAL_TIMEOUT on that corpse, starving
-            // the dial to the live endpoint. The freshest (most likely
-            // live) endpoint is listed first and is never quarantined
-            // unless it itself just failed, so this never blocks a
-            // genuinely reachable peer.
-            //
-            // The skip is SURFACED, not silent — but on the SEPARATE
-            // `peer_dial_skips` channel, NOT as a `PeerDialFailure`. No
-            // dial was attempted, so reporting it as a failure would emit
-            // false `PeerDialFailed` warnings every refresh and inflate
-            // `airc transport health`'s failure count. The operator still
-            // sees "in backoff" via the skips channel — honest, not a
-            // clean-list lie and not an over-report.
-            if let Some(remaining_ms) = self.dial_quarantine_remaining_ms(peer_id, addr, now_ms) {
-                skips.push(PeerDialSkip {
-                    peer_id,
-                    endpoint: endpoint.clone(),
-                    remaining_ms,
-                });
-                continue;
-            }
-            // #1120 sentinel blocking-2: connect_lan has no inner
-            // timeout, and a SYN-dropping firewall (the default posture
-            // of the NATs this card exists to cross) hangs the OS connect
-            // for ~21-130s per endpoint. Bound every dial; a timeout is a
-            // recorded failure like any other.
-            match tokio::time::timeout(PEER_DIAL_TIMEOUT, self.connect_lan(addr, peer_id)).await {
-                Ok(Ok(())) => {
-                    // Card 7e3c9a1f: a live connect lifts any prior
-                    // quarantine so a flapped-but-recovered endpoint is
-                    // immediately eligible again next refresh.
-                    self.dial_quarantine_record_success(peer_id, addr);
-                    break;
-                }
-                Ok(Err(error)) => {
-                    self.dial_quarantine_record_failure(peer_id, addr, now_ms);
-                    failures.push(PeerDialFailure {
-                        peer_id,
-                        endpoint: endpoint.clone(),
-                        error: error.to_string(),
-                    });
-                }
-                Err(_elapsed) => {
-                    self.dial_quarantine_record_failure(peer_id, addr, now_ms);
-                    failures.push(PeerDialFailure {
-                        peer_id,
-                        endpoint: endpoint.clone(),
-                        error: format!(
-                            "dial timed out after {}s (endpoint unreachable or \
-                             firewall drops SYN)",
-                            PEER_DIAL_TIMEOUT.as_secs()
-                        ),
-                    });
-                }
             }
         }
         (failures, skips)

--- a/crates/airc-lib/tests/relay_discovery.rs
+++ b/crates/airc-lib/tests/relay_discovery.rs
@@ -1,0 +1,103 @@
+//! #1247 slice 2 — a relay endpoint stored on a peer's trust record
+//! becomes an outbound relay CONNECTION at route-discovery time, and the
+//! relay route is marked Healthy.
+//!
+//! This is the cross-subnet half of the #1243 fix: BigMama (10.0.1.x) and
+//! the Macs (192.168.1.x) cannot dial each other directly (firewall drops
+//! SYN), so room broadcast must traverse a relay both can reach. Slice 1
+//! made the relay endpoint carry its peer id (dialable + pinnable from the
+//! gist); this slice makes `refresh_route_discovery` actually connect it.
+//!
+//! Contract proven here:
+//!   - a `RouteEndpoint::relay(relay_peer, relay_addr)` persisted on a
+//!     trust record (what the account-registry gist import would store)
+//!     is connected OUTBOUND by `refresh_route_discovery`, mTLS-pinned to
+//!     the relay's enrolled identity — no manual `connect_relay` call;
+//!   - a successful connect yields a Healthy `Relay` transport in the
+//!     route-health snapshot.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use airc_core::PeerId;
+use airc_lib::{endpoints_to_json, Airc, PeerSpec, RouteEndpoint};
+use airc_protocol::{PeerKeyRegistry, PeerKeypair};
+use airc_relay::{RelayServer, RelayServerConfig};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn discovery_connects_stored_relay_endpoint_and_marks_it_healthy() {
+    use airc_lib::{TransportHealthState, TransportKind};
+
+    // The relay's own identity (the node clients pin + dial).
+    let relay_peer = PeerId::from_u128(0x_3e_1a);
+    let relay_keypair = PeerKeypair::generate();
+
+    let tmp_b = TempDir::new().expect("bob tempdir");
+    let bob = Airc::open(tmp_b.path().join(".airc"))
+        .await
+        .expect("bob open");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob spec");
+
+    // The relay server allowlists its clients (bob); bob in turn pins the
+    // relay's identity (enrolled below via `add_peer`).
+    let server_registry = Arc::new(PeerKeyRegistry::new());
+    server_registry
+        .enrol(bob_spec.peer_id, 1, bob_spec.pubkey)
+        .expect("relay server enrols bob");
+
+    let server = RelayServer::start(RelayServerConfig {
+        peer_id: relay_peer,
+        keypair: relay_keypair.clone(),
+        registry: server_registry,
+        bind: "127.0.0.1:0".parse().unwrap(),
+    })
+    .await
+    .expect("start relay");
+    let relay_addr: SocketAddr = server.local_addr();
+
+    // Enrol the relay as a trusted peer on bob (pins its pubkey for the
+    // mTLS handshake) — exactly what importing the relay's gist beacon
+    // would do.
+    bob.add_peer(PeerSpec {
+        peer_id: relay_peer,
+        pubkey: relay_keypair.public_bytes(),
+    })
+    .await
+    .expect("bob trusts the relay");
+
+    // What the account-registry gist import (slice 4) would persist: the
+    // relay's endpoint, carrying its peer id so it's connectable + pinnable.
+    let endpoints_json =
+        endpoints_to_json(&[RouteEndpoint::relay(relay_peer, relay_addr)]).expect("encode");
+    airc_trust::set_endpoints_json(bob.home(), relay_peer, Some(endpoints_json))
+        .await
+        .expect("store relay endpoint")
+        .expect("relay must be enrolled on bob");
+
+    let snapshot = bob
+        .refresh_route_discovery()
+        .await
+        .expect("bob discovery refresh");
+
+    assert!(
+        snapshot.peer_dial_failures.is_empty(),
+        "relay connect must not fail when the relay is up: {:?}",
+        snapshot.peer_dial_failures
+    );
+    let relay_health = snapshot
+        .health
+        .iter()
+        .find(|h| h.kind == TransportKind::Relay);
+    assert!(
+        matches!(
+            relay_health.map(|h| h.state),
+            Some(TransportHealthState::Healthy)
+        ),
+        "discovery must connect the stored relay endpoint and mark Relay Healthy; \
+         health table: {:?}",
+        snapshot.health
+    );
+
+    server.shutdown();
+}


### PR DESCRIPTION
Slice 2 of the relay integration (#1247) — the cross-subnet connect half of #1243.

## Why

Route discovery dialed only LAN/Tailscale endpoints; relay endpoints were explicitly skipped (`continue` in `dial_one_peer`). So even after slice 1 (#1248) made relay endpoints connectable, nothing connected them — cross-subnet peers (BigMama 10.0.1.x ↔ Macs 192.168.1.x, direct dials drop SYN) stayed dark.

## Change

`dial_one_peer`'s endpoint loop becomes a full match. When a stored endpoint is a `connectable_relay()` (peer-id-bearing `airc-relay://<peer>@<addr>`), discovery calls `connect_relay(addr, relay_peer)` with the **same dial-failure backoff + 3s timeout** discipline as direct dials, keyed on the **relay's** identity so a dead relay isn't re-dialed every refresh.

- Direct LAN/Tailscale endpoints are cost-ordered first → the relay is a **fallback** reached only after they fail.
- `connect_relay` is idempotent → a relay advertised by several peers connects once.
- mTLS-pinned via the registry `sync_account_peer_registry` (at refresh-start) populated.
- A legacy peer-id-less relay URL is skipped (not pinnable) — never a silent dial to an unauthenticated relay.
- UDP/WebRTC/Reticulum stay **enumerated** (not wildcarded), per the no-silent-fallback clippy gate.

## Test

`tests/relay_discovery.rs` — stands up an in-process `RelayServer`, persists a `RouteEndpoint::relay(relay_peer, relay_addr)` on bob's trust record (what the gist import will store), calls `refresh_route_discovery`, and asserts the `Relay` transport comes back **Healthy** with no dial failures — no manual `connect_relay`. clippy `-D warnings` + fmt clean.

## Next (#1247)

3. `RoutedForwarder` send-once-to-relay — so room broadcast actually traverses the connected relay (relay is a single pipe, not per-peer)
4. relay self-election via the gist · 8. relay↔relay federation

🤖 Generated with [Claude Code](https://claude.com/claude-code)