### PR TITLE
feat(relay): RoutedForwarder carries room traffic over the relay (#1247 slice 3)

### DIFF
--- a/crates/airc-lib/src/route_forwarder.rs
+++ b/crates/airc-lib/src/route_forwarder.rs
@@ -79,6 +79,7 @@ use airc_protocol::{
     DeliveryOutcome, Envelope as ProtoEnvelope, Frame, FrameKind, Signature, UndeliverableReason,
     DELIVERY_ACK_REQUEST, HEADER_AIRC_DELIVERY_ACK,
 };
+use airc_transport::transport::Transport;
 use airc_transport::LanTcpAdapter;
 use tokio::sync::mpsc;
 
@@ -231,6 +232,13 @@ struct PeerItem {
 /// minus the item's origin), spawning workers on demand.
 async fn drain_loop(inner: Weak<ForwarderInner>, mut rx: mpsc::Receiver<ForwardItem>) {
     let mut workers: HashMap<PeerId, mpsc::Sender<PeerItem>> = HashMap::new();
+    // #1247 slice 3: the relay tier. A connected relay is a SINGLE pipe
+    // (it fans out by target), not a per-peer link, so it gets ONE worker
+    // — lazily spawned the first time a relay is actually connected, so a
+    // LAN-only daemon pays nothing. Kept off the drain's hot path for the
+    // same reason the per-peer workers are: relay I/O must never stall the
+    // tap drain.
+    let mut relay_worker: Option<mpsc::Sender<Arc<Envelope>>> = None;
     while let Some(item) = rx.recv().await {
         let Some(inner) = inner.upgrade() else {
             return;
@@ -288,7 +296,140 @@ async fn drain_loop(inner: Weak<ForwarderInner>, mut rx: mpsc::Receiver<ForwardI
                 }
             }
         }
+
+        // #1247 slice 3 — relay tier. After the per-peer LAN fan-out, hand
+        // the SAME durable envelope to the relay worker ONCE per item when a
+        // relay is connected: the relay is a single pipe that fans out by
+        // target, not a per-peer link. Loop termination is the existing
+        // `publish_if_new` dedup upstream (a frame that returns via the
+        // relay is a `Duplicate` and never re-reaches this tap), so the
+        // relay tier needs NO new loop logic — it's the LAN forwarder's
+        // terminating flood, one tier up. The worker is lazily spawned the
+        // first time a relay is actually connected, so a LAN-only daemon
+        // pays nothing, and relay I/O stays off the drain's hot path.
+        if any_relay_connected(&inner).await {
+            if relay_worker.is_none() {
+                relay_worker = Some(spawn_relay_worker(Arc::downgrade(&inner), &inner.config));
+            }
+            let send_result = relay_worker
+                .as_ref()
+                .map(|queue| queue.try_send(Arc::clone(&item.env)));
+            match send_result {
+                None | Some(Ok(())) => {}
+                Some(Err(mpsc::error::TrySendError::Full(_))) => emit(
+                    &inner,
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Daemon,
+                        DiagnosticCode::RoutedForwardQueueSaturated,
+                        "relay forward queue is FULL — durable event is delivered \
+                         locally but will NOT be forwarded over the relay",
+                    )
+                    .with_field("event_id", item.env.event_id)
+                    .with_field("channel", item.env.channel),
+                ),
+                Some(Err(mpsc::error::TrySendError::Closed(_))) => {
+                    // Worker exited (only at teardown); respawn once + retry.
+                    let queue = spawn_relay_worker(Arc::downgrade(&inner), &inner.config);
+                    let retry = queue.try_send(Arc::clone(&item.env));
+                    relay_worker = Some(queue);
+                    if retry.is_err() {
+                        emit(
+                            &inner,
+                            DiagnosticEvent::error(
+                                DiagnosticComponent::Daemon,
+                                DiagnosticCode::RoutedForwardFailed,
+                                "relay forward worker unavailable — durable event \
+                                 will NOT be forwarded over the relay",
+                            )
+                            .with_field("event_id", item.env.event_id),
+                        );
+                    }
+                }
+            }
+        }
     }
+}
+
+/// One relay worker drains envelopes and forwards each over every
+/// connected relay. Single worker (not per-peer): a relay is one pipe
+/// that fans out by target. Mirrors [`spawn_peer_worker`]'s shape so relay
+/// sends never block the tap drain.
+fn spawn_relay_worker(
+    inner: Weak<ForwarderInner>,
+    config: &RoutedForwarderConfig,
+) -> mpsc::Sender<Arc<Envelope>> {
+    let (tx, mut rx) = mpsc::channel::<Arc<Envelope>>(config.peer_queue_capacity.max(1));
+    tokio::spawn(async move {
+        while let Some(env) = rx.recv().await {
+            let Some(inner) = inner.upgrade() else {
+                return;
+            };
+            forward_one_to_relay(&inner, env).await;
+        }
+    });
+    tx
+}
+
+/// Forward one durable envelope over every connected relay link. The relay
+/// fans out to its peers by target, so this is ONE send per relay (never
+/// per peer). Loop termination lives upstream in `publish_if_new` (a frame
+/// that returns via the relay is a `Duplicate` and never re-reaches the
+/// tap), so this path carries no per-frame loop bookkeeping.
+async fn forward_one_to_relay(inner: &ForwarderInner, env: Arc<Envelope>) {
+    let links = inner.links.read().await.clone();
+    for link in &links {
+        let relay = link.inner.relay.lock().await.clone();
+        let Some(relay) = relay else { continue };
+        let frame = match build_forward_frame(link, &env, false) {
+            Ok(Some(frame)) => frame,
+            Ok(None) => return, // machine-local kind — no wire FrameKind
+            Err(reason) => {
+                emit(
+                    inner,
+                    DiagnosticEvent::warn(
+                        DiagnosticComponent::Daemon,
+                        DiagnosticCode::RoutedForwardFailed,
+                        "durable event could not be projected onto the wire frame \
+                         shape for relay — it will stay machine-local",
+                    )
+                    .with_field("event_id", env.event_id)
+                    .with_field("channel", env.channel)
+                    .with_field("error", reason),
+                );
+                return;
+            }
+        };
+        match relay.send(frame).await {
+            Ok(()) => {
+                inner.forwarded.fetch_add(1, Ordering::SeqCst);
+            }
+            Err(error) => emit(
+                inner,
+                DiagnosticEvent::error(
+                    DiagnosticComponent::Daemon,
+                    DiagnosticCode::RoutedForwardFailed,
+                    "relay send failed — durable event delivered locally but NOT \
+                     forwarded over this relay",
+                )
+                .with_field("event_id", env.event_id)
+                .with_field("channel", env.channel)
+                .with_field("error", format!("{error}")),
+            ),
+        }
+    }
+}
+
+/// Whether any registered link currently holds a connected relay adapter.
+/// Cheap pre-check so the relay worker is spawned + fed only when a relay
+/// exists (a LAN-only daemon never pays for the relay tier).
+async fn any_relay_connected(inner: &ForwarderInner) -> bool {
+    let links = inner.links.read().await.clone();
+    for link in &links {
+        if link.inner.relay.lock().await.is_some() {
+            return true;
+        }
+    }
+    false
 }
 
 /// Snapshot of currently-connected LAN peers across all registered
@@ -358,7 +499,7 @@ async fn forward_one(inner: &ForwarderInner, peer: PeerId, env: Arc<Envelope>) {
             last_failure = "no live LAN connection to peer".to_string();
             continue;
         };
-        let frame = match build_forward_frame(&link, &env) {
+        let frame = match build_forward_frame(&link, &env, true) {
             Ok(Some(frame)) => frame,
             Ok(None) => return, // unmappable kind — machine-local by design
             Err(reason) => {
@@ -481,7 +622,18 @@ async fn wait_for_ack(
 /// `Ok(None)` = this envelope kind is machine-local by design
 /// (Command / CommandResult / Signal / StreamChunk — RPC shapes with
 /// no wire `FrameKind`).
-fn build_forward_frame(link: &Airc, env: &Envelope) -> Result<Option<Frame>, String> {
+///
+/// `request_ack` stamps the [`HEADER_AIRC_DELIVERY_ACK`] header. The LAN
+/// forwarder sets it (it awaits the typed ack to confirm delivery); the
+/// relay tier does NOT — a relay send is fire-and-forget today, and the
+/// remote can't route a LAN ack back over the relay anyway (it would emit
+/// a spurious `delivery_ack_send_failed`). Relay delivery confirmation
+/// lands with the relay's durable mailbox (#1247 slice 9).
+fn build_forward_frame(
+    link: &Airc,
+    env: &Envelope,
+    request_ack: bool,
+) -> Result<Option<Frame>, String> {
     let kind = match env.kind {
         Kind::Message => FrameKind::Message,
         Kind::Event => FrameKind::Event,
@@ -499,10 +651,12 @@ fn build_forward_frame(link: &Airc, env: &Envelope) -> Result<Option<Frame>, Str
         )
     };
     let mut headers = env.headers.clone();
-    headers.insert(
-        HEADER_AIRC_DELIVERY_ACK.to_string(),
-        DELIVERY_ACK_REQUEST.to_string(),
-    );
+    if request_ack {
+        headers.insert(
+            HEADER_AIRC_DELIVERY_ACK.to_string(),
+            DELIVERY_ACK_REQUEST.to_string(),
+        );
+    }
     let mut frame = Frame {
         kind,
         envelope: ProtoEnvelope {

--- a/crates/airc-lib/tests/daemon_routed_forward.rs
+++ b/crates/airc-lib/tests/daemon_routed_forward.rs
@@ -38,13 +38,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use airc_core::{Body, EventId};
+use airc_core::{Body, EventId, PeerId};
 use airc_diagnostics::{DiagnosticCode, MemoryDiagnosticSink};
 use airc_lib::{
     Airc, InboundDeliveryVerdict, InboundFrameSink, PeerSpec, RoutedForwarder,
     RoutedForwarderConfig, RouterInboundBridge,
 };
 use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair};
+use airc_relay::{RelayServer, RelayServerConfig};
 use airc_store::{EventStore, SqliteEventStore};
 use airc_transport::LanTcpAdapter;
 use async_trait::async_trait;
@@ -502,4 +503,97 @@ async fn saturated_forward_queue_and_unconfirmed_forwards_are_loud() {
 
     // And nothing was ever confirmed: the ack vocabulary stayed truthful.
     assert_eq!(a.forwarder.confirmed_count(), 0);
+}
+
+/// #1247 slice 3 — a room send traverses a RELAY, not LAN. This is the
+/// cross-subnet path (#1243): A and B that cannot dial each other directly
+/// both reach one relay, and a send on A appears in B's transcript via the
+/// relay's fan-out. Loop termination is the SAME `publish_if_new` dedup the
+/// LAN flood uses — exactly once at B, no echo doubling at the source even
+/// though B re-floods the frame back through the relay.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn routed_room_send_traverses_relay() {
+    let a = boot_linked(RoutedForwarderConfig::default()).await;
+    let b = boot_linked(RoutedForwarderConfig::default()).await;
+
+    // A and B never LAN-link (the cross-subnet case); their only shared
+    // reachability is the relay. They still trust each other so B can
+    // verify A's end-to-end-signed frame — the relay never re-signs.
+    common::trust(&a.gateway, &b.gateway).await;
+
+    // In-process relay that allowlists both gateways; each gateway pins the
+    // relay's identity, then connects to it.
+    let relay_peer = PeerId::from_u128(0x5e1a3);
+    let relay_keypair = PeerKeypair::generate();
+    let a_spec: PeerSpec = a.gateway.peer_spec().parse().expect("a gateway spec");
+    let b_spec: PeerSpec = b.gateway.peer_spec().parse().expect("b gateway spec");
+    let server_registry = Arc::new(PeerKeyRegistry::new());
+    server_registry
+        .enrol(a_spec.peer_id, 1, a_spec.pubkey)
+        .expect("relay enrols gateway A");
+    server_registry
+        .enrol(b_spec.peer_id, 1, b_spec.pubkey)
+        .expect("relay enrols gateway B");
+    let server = RelayServer::start(RelayServerConfig {
+        peer_id: relay_peer,
+        keypair: relay_keypair.clone(),
+        registry: server_registry,
+        bind: "127.0.0.1:0".parse().unwrap(),
+    })
+    .await
+    .expect("relay starts");
+    let relay_addr = server.local_addr();
+
+    for gw in [&a.gateway, &b.gateway] {
+        gw.add_peer(PeerSpec {
+            peer_id: relay_peer,
+            pubkey: relay_keypair.public_bytes(),
+        })
+        .await
+        .expect("gateway trusts relay");
+        gw.connect_relay(relay_addr, relay_peer)
+            .await
+            .expect("gateway connects relay");
+    }
+
+    // Both gateways must be REGISTERED at the relay before A sends, or the
+    // relay has no one to fan B's copy to (the round_trip registration
+    // race). Poll the server's connected set.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let connected = server.connected_peers().await;
+        if connected.contains(&a_spec.peer_id) && connected.contains(&b_spec.peer_id) {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "relay never registered both gateways: {connected:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+    let op_b = b.machine.attach("op-b").await;
+    op_b.join(ROOM).await.expect("op-b joins");
+
+    let id = op_a
+        .say("room message A→B over the relay")
+        .await
+        .expect("op-a says");
+    assert_eq!(
+        wait_for_copies(&op_b, id).await,
+        1,
+        "A's room send must reach B exactly once via the relay"
+    );
+    // No echo doubling at the source despite B re-flooding back through the
+    // relay — the publish_if_new dedup terminates it.
+    let recent_a = op_a.page_recent(64).await.expect("page op-a");
+    assert_eq!(
+        copies_in(&recent_a, id),
+        1,
+        "exactly one copy at the source — the relay round-trip must not echo"
+    );
+
+    server.shutdown();
 }


### PR DESCRIPTION
Slice 3 of the relay integration (#1247) — the piece that makes the relay actually **carry traffic**, reconnecting peers that can't dial each other directly (#1243: BigMama `10.0.1.x` ↔ Macs `192.168.1.x`, SYN dropped both ways). Slices 1–2 connected the relay; this routes room sends over it.

## Change

The `RoutedForwarder` fanned out only over per-peer LAN connections. A relay is a **single pipe** (fans out by target), not a per-peer link — so `drain_loop` now also hands each durable envelope to a **dedicated relay worker**: one send per item when a relay is connected.

- **Lazily spawned** the first time a relay is actually connected → a LAN-only daemon pays nothing.
- **Off the drain's hot path** (relay I/O never stalls the tap), mirroring the per-peer-worker shape.
- **Loop termination = the existing `publish_if_new` dedup** ("terminating flood") — a frame returning via the relay is a `Duplicate` and never re-reaches the tap. No new loop logic; it's the LAN flood one tier up. A node receiving via the relay still re-fans to its **local LAN peers** (the mesh behavior) and re-sends once to the relay (dedup'd; one redundant round, optimizable later via a relay-origin marker).
- Relay-forwarded frames **no longer request a LAN delivery-ack** (`build_forward_frame(request_ack=false)`) — the remote can't route a LAN ack back over the relay, which emitted a spurious `delivery_ack_send_failed` per frame. LAN path unchanged (`request_ack=true`, still ack-confirmed). Relay delivery confirmation lands with the relay's durable mailbox (slice 9).

## Test

`routed_room_send_traverses_relay`: A and B never LAN-link; both connect to one in-process `RelayServer`; a room send on A appears in B's transcript **exactly once** via the relay, with **no echo doubling** at the source despite B re-flooding back through the relay (proves loop termination). All 6 existing forwarder tests still green; clippy `-D warnings` + fmt clean.

## Where this leaves #1243

The relay now **connects AND carries traffic** cross-subnet. What remains for the fleet to actually reconnect: a reachable relay must exist + be advertised — slice 4 (self-election via the gist) automates that, or one is run manually. Then BigMama↔M5↔IntelMac (and continuum's grid, which rides the same transport) route over the relay.

## Next (#1247)

4. relay self-election via the gist · 8. relay↔relay federation · 9. relay durable ORM (mailbox + delivery confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)