### PR TITLE
feat(relay): Airc::become_relay — a node promotes itself to a relay (#1247 slice 4a)

### DIFF
--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -33,6 +33,10 @@ airc-wire = { path = "../airc-wire" }
 airc-store = { path = "../airc-store" }
 airc-trust = { path = "../airc-trust" }
 airc-transport = { path = "../airc-transport" }
+# Promoted from dev-dep: a node can ALSO BE a relay (`Airc::become_relay`,
+# #1247 slice 4 self-election). No cycle — airc-relay depends only on
+# core/protocol/transport, never on airc-lib.
+airc-relay = { path = "../airc-relay" }
 airc-work = { path = "../airc-work" }
 airc-work-store = { path = "../airc-work-store" }
 
@@ -62,7 +66,6 @@ mock = []
 
 [dev-dependencies]
 airc-daemon = { path = "../airc-daemon" }
-airc-relay = { path = "../airc-relay" }
 airc-protocol = { path = "../airc-protocol" }
 bytes = "1"
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -177,6 +177,11 @@ pub(crate) struct AircInner {
     pub(crate) lan_subscriber: Mutex<Option<FrameSubscriber>>,
     pub(crate) relay: Mutex<Option<RelayAdapter>>,
     pub(crate) relay_subscriber: Mutex<Option<FrameSubscriber>>,
+    /// When this node has promoted itself to ALSO be a relay
+    /// (`Airc::become_relay`, #1247 slice 4), the running relay server is
+    /// held here so it stays alive for the node's lifetime. `None` = this
+    /// node is a relay CLIENT only (the common case).
+    pub(crate) relay_server: Mutex<Option<airc_relay::RelayServer>>,
     pub(crate) udp: Mutex<Option<UdpAdapter>>,
     pub(crate) udp_subscriber: Mutex<Option<FrameSubscriber>>,
     /// Per-peer WebRTC DataChannel adapters, keyed by the remote
@@ -442,6 +447,7 @@ impl Airc {
                 lan_subscriber: Mutex::new(None),
                 relay: Mutex::new(None),
                 relay_subscriber: Mutex::new(None),
+                relay_server: Mutex::new(None),
                 udp: Mutex::new(None),
                 udp_subscriber: Mutex::new(None),
                 webrtc_channels: Mutex::new(HashMap::new()),
@@ -1018,6 +1024,7 @@ impl Airc {
             lan_subscriber: Mutex::new(None),
             relay: Mutex::new(None),
             relay_subscriber: Mutex::new(None),
+            relay_server: Mutex::new(None),
             udp: Mutex::new(None),
             udp_subscriber: Mutex::new(None),
             webrtc_channels: Mutex::new(HashMap::new()),

--- a/crates/airc-lib/src/relay.rs
+++ b/crates/airc-lib/src/relay.rs
@@ -8,6 +8,7 @@
 use std::net::SocketAddr;
 
 use airc_core::PeerId;
+use airc_relay::{RelayServer, RelayServerConfig};
 use airc_transport::relay::{RelayAdapter, RelayClientConfig};
 
 use crate::error::AircError;
@@ -53,6 +54,74 @@ impl Airc {
         }
         self.ensure_relay_subscriber().await?;
         self.upsert_relay_health(relay_addr, relay_peer)?;
+        Ok(())
+    }
+
+    /// Promote this node to ALSO be a relay: bind a relay listener on
+    /// `bind_addr` (port 0 = OS-assigned) serving this node's enrolled
+    /// peers, and advertise the relay endpoint (peer-id-bearing, so it's
+    /// pinnable) on this node's route table — which flows into the gist
+    /// directory, so peers that import this node's card connect through it
+    /// (discovery → [`Airc::connect_relay`], #1247 slice 2).
+    ///
+    /// This is the "be a relay" half of self-election (#1247 slice 4): a
+    /// node that can bind a reachable listener can host the relay the
+    /// cross-subnet mesh needs. Reachability is EMPIRICAL — promoting
+    /// yourself just binds + advertises; whether peers actually reach you
+    /// decides whether your relay matters (an unreachable self-elected
+    /// relay accumulates no connections and its gist entry goes stale).
+    /// The election TRIGGER (when to call this) lives in the daemon's
+    /// route-refresh loop; this is the mechanism it invokes.
+    ///
+    /// Idempotent: a node already relaying re-advertises and returns its
+    /// existing bound address.
+    pub async fn become_relay(&self, bind_addr: SocketAddr) -> Result<SocketAddr, AircError> {
+        // Fast path: already relaying — re-advertise (idempotent) + return.
+        {
+            let guard = self.inner.relay_server.lock().await;
+            if let Some(server) = guard.as_ref() {
+                let addr = server.local_addr();
+                drop(guard);
+                self.advertise_self_relay(addr)?;
+                return Ok(addr);
+            }
+        }
+        // Bind a fresh relay server OUTSIDE the lock (no await under the
+        // guard), serving exactly this node's enrolled peers.
+        let server = RelayServer::start(RelayServerConfig {
+            peer_id: self.inner.identity.peer_id,
+            keypair: self.inner.identity.keypair.clone(),
+            registry: self.inner.registry.clone(),
+            bind: bind_addr,
+        })
+        .await
+        .map_err(|error| AircError::Transport(error.to_string()))?;
+        let addr = server.local_addr();
+        // Install — unless a concurrent caller won the race, in which case
+        // shut ours down and adopt the winner's address (one relay/node).
+        let final_addr = {
+            let mut guard = self.inner.relay_server.lock().await;
+            match guard.as_ref() {
+                Some(existing) => {
+                    let existing_addr = existing.local_addr();
+                    server.shutdown();
+                    existing_addr
+                }
+                None => {
+                    *guard = Some(server);
+                    addr
+                }
+            }
+        };
+        self.advertise_self_relay(final_addr)?;
+        Ok(final_addr)
+    }
+
+    /// Record THIS node's own relay endpoint (peer-id-bearing) on the
+    /// route table so it propagates into the gist directory. Distinct from
+    /// `upsert_relay_health`, which marks a relay this node is a CLIENT of.
+    fn advertise_self_relay(&self, addr: SocketAddr) -> Result<(), AircError> {
+        self.upsert_route_endpoint(RouteEndpoint::relay(self.inner.identity.peer_id, addr))?;
         Ok(())
     }
 

--- a/crates/airc-lib/tests/relay_discovery.rs
+++ b/crates/airc-lib/tests/relay_discovery.rs
@@ -101,3 +101,75 @@ async fn discovery_connects_stored_relay_endpoint_and_marks_it_healthy() {
 
     server.shutdown();
 }
+
+/// #1247 slice 4 — self-election mechanism: a NODE promotes itself to a
+/// relay (`become_relay`), advertises its own peer-id-bearing relay
+/// endpoint, and a client that imports that endpoint (as it would from the
+/// gist directory) discovers + connects to it. Proves the advertise →
+/// discover → connect loop with a node-as-relay (no standalone server),
+/// which is what the daemon's election trigger will drive.
+#[tokio::test]
+async fn a_node_becomes_a_relay_and_a_client_discovers_it() {
+    use airc_lib::{TransportHealthState, TransportKind};
+
+    let tmp_r = TempDir::new().expect("relay-node tempdir");
+    let relay_node = Airc::open(tmp_r.path().join(".airc"))
+        .await
+        .expect("relay node open");
+    let tmp_c = TempDir::new().expect("client tempdir");
+    let client = Airc::open(tmp_c.path().join(".airc"))
+        .await
+        .expect("client open");
+
+    // Mutual trust: the relay node allowlists the client (its relay server
+    // serves enrolled peers), and the client pins the relay node.
+    let relay_spec: PeerSpec = relay_node.peer_spec().parse().expect("relay spec");
+    let client_spec: PeerSpec = client.peer_spec().parse().expect("client spec");
+    relay_node
+        .add_peer(client_spec)
+        .await
+        .expect("relay node trusts client");
+    client
+        .add_peer(relay_spec)
+        .await
+        .expect("client trusts relay node");
+
+    // The relay node promotes itself.
+    let relay_addr = relay_node
+        .become_relay("127.0.0.1:0".parse().unwrap())
+        .await
+        .expect("relay node becomes a relay");
+
+    // It advertised its OWN connectable relay endpoint.
+    let advertised = relay_node.route_endpoints().expect("relay endpoints");
+    assert!(
+        advertised
+            .iter()
+            .any(|e| e.connectable_relay() == Some((relay_node.peer_id(), relay_addr))),
+        "a self-elected relay must advertise its own connectable endpoint; got: {advertised:?}"
+    );
+
+    // The client imports that endpoint (the gist-directory path) and
+    // discovery connects to the node-hosted relay.
+    let endpoints_json =
+        endpoints_to_json(&[RouteEndpoint::relay(relay_node.peer_id(), relay_addr)])
+            .expect("encode");
+    airc_trust::set_endpoints_json(client.home(), relay_node.peer_id(), Some(endpoints_json))
+        .await
+        .expect("store relay endpoint")
+        .expect("relay node enrolled on client");
+
+    let snapshot = client
+        .refresh_route_discovery()
+        .await
+        .expect("client discovery refresh");
+    assert!(
+        snapshot
+            .health
+            .iter()
+            .any(|h| h.kind == TransportKind::Relay && h.state == TransportHealthState::Healthy),
+        "client must discover + connect the node-hosted relay (Relay Healthy); \
+         health: {:?}",
+        snapshot.health
+    );
+}


### PR DESCRIPTION
The "be a relay" half of **self-election** (#1247 slice 4) — the leaderless model where a reachable node hosts the relay the cross-subnet mesh needs, instead of a fixed VPS.

## Change

`Airc::become_relay(bind_addr)`:
- Starts a `RelayServer` with **this node's** identity + trust registry → it serves exactly this node's enrolled peers; holds it on the handle (new `relay_server: Mutex<Option<RelayServer>>`) for the node's lifetime.
- Advertises this node's **own** peer-id-bearing relay endpoint (`RouteEndpoint::relay(self, addr)`) on the route table → flows into the gist directory → peers that import this node's card discover + connect (slice 2) and carry traffic (slice 3).
- **Reachability stays empirical** (Joel's model): promoting yourself just binds + advertises; whether peers actually reach you decides whether the relay matters. An unreachable self-elected relay accumulates no connections and its gist entry goes stale — harmless.
- **Idempotent**: already-relaying node re-advertises + returns its addr; a lost start-race shuts the extra server down (one relay per node). No lock held across the bind/await.

`airc-relay` promoted from dev-dep → real dep of `airc-lib` (no cycle — it depends only on core/protocol/transport).

## Test

`a_node_becomes_a_relay_and_a_client_discovers_it`: a node `become_relay`s, advertises its own connectable endpoint, and a client that imports it (the gist-directory path) discovers + connects via `refresh_route_discovery` → **Relay Healthy**. Proves the advertise → discover → connect loop with a **node-as-relay** (no standalone server). clippy `-D warnings` + fmt clean; the slice-2 test still green.

## Next (slice 4b)

The election **trigger** in the daemon's route-refresh loop: call `become_relay` when no reachable relay exists and this node can bind one. With 4a+4b the fleet reconnects itself with zero ops — a node that's reachable self-elects, the rest find it through the gist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)