### PR TITLE
feat(relay): self-election trigger — isolated node auto-becomes a relay (#1247 slice 4b)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1534,6 +1534,36 @@ async fn refresh_routes_once(airc: &Airc, connected_lan_peers: &std::sync::atomi
                     .with_field("error", &failure.error),
                 );
             }
+
+            // #1247 slice 4b — relay self-election. When this node can
+            // reach no peer directly AND has no live relay yet, but knows
+            // enrolled peers exist, it promotes itself to a relay (the
+            // "be a relay" mechanism is `Airc::become_relay`, slice 4a).
+            // The next account-registry publish carries the advertised
+            // relay endpoint into the gist, so reachable peers discover +
+            // connect to it (slices 2-3). Idempotent + empirical: a node
+            // already relaying just re-advertises, and an unreachable
+            // self-elected relay is harmlessly ignored (no connections →
+            // stale gist entry), so no need to predict our own
+            // reachability. Binds all interfaces on an OS-assigned port —
+            // the gist advertises whatever port the OS gave, so the
+            // durable pointer stays valid across restarts.
+            let enrolled = airc.peers().await.map(|peers| peers.len()).unwrap_or(0);
+            if snapshot.should_self_elect_as_relay(enrolled) {
+                match airc
+                    .become_relay(std::net::SocketAddr::from(([0, 0, 0, 0], 0)))
+                    .await
+                {
+                    Ok(addr) => eprintln!(
+                        "airc daemon: no reachable peer or relay (enrolled={enrolled}) — \
+                         self-elected as a relay on {addr} and advertised it (#1247)"
+                    ),
+                    Err(error) => eprintln!(
+                        "airc daemon: relay self-election failed ({error}); \
+                         retrying next interval"
+                    ),
+                }
+            }
         }
         Err(error) => {
             StderrJsonDiagnosticSink.emit(

--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -8,7 +8,7 @@ use airc_core::PeerId;
 use futures::stream::StreamExt;
 
 use crate::error::AircError;
-use crate::route::health::TransportHealthSample;
+use crate::route::health::{TransportHealthSample, TransportHealthState};
 use crate::route::invite::RouteEndpoint;
 use crate::route::policy::TransportKind;
 use crate::Airc;
@@ -80,6 +80,29 @@ pub struct RouteDiscoverySnapshot {
     /// `peer_dial_failures` so it is never miscounted/mislabelled as a
     /// failed dial.
     pub peer_dial_skips: Vec<PeerDialSkip>,
+}
+
+impl RouteDiscoverySnapshot {
+    /// #1247 slice 4b — the relay self-election DECISION (pure, so the
+    /// daemon's trigger is unit-tested independent of the loop).
+    ///
+    /// A node should promote itself to a relay when it knows peers exist
+    /// but can reach NONE of them right now: no live relay route AND no
+    /// directly-connected LAN peer. That's an isolated node that could be
+    /// a meeting point for other isolated peers.
+    ///
+    /// The rule stays deliberately simple because slice 4a made
+    /// reachability EMPIRICAL — a wrong "yes" is harmless (an unreachable
+    /// self-elected relay accumulates no connections and its gist entry
+    /// goes stale), so there's no need to predict our own reachability.
+    /// `become_relay` is idempotent, so re-evaluating "yes" every refresh
+    /// just re-advertises.
+    pub fn should_self_elect_as_relay(&self, enrolled_peers: usize) -> bool {
+        let has_live_relay = self.health.iter().any(|sample| {
+            sample.kind == TransportKind::Relay && sample.state == TransportHealthState::Healthy
+        });
+        enrolled_peers > 0 && self.connected_lan_peers.is_empty() && !has_live_relay
+    }
 }
 
 impl Airc {
@@ -482,5 +505,54 @@ impl Airc {
             Some(adapter) => adapter.connected_peers().await,
             None => Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(
+        health: Vec<TransportHealthSample>,
+        connected_lan_peers: Vec<PeerId>,
+    ) -> RouteDiscoverySnapshot {
+        RouteDiscoverySnapshot {
+            health,
+            endpoints: Vec::new(),
+            connected_lan_peers,
+            peer_dial_failures: Vec::new(),
+            peer_dial_skips: Vec::new(),
+        }
+    }
+
+    /// what this catches (#1247 slice 4b): a node that knows peers exist
+    /// but can reach NONE of them (no relay, no LAN peer) self-elects as a
+    /// relay — the isolated-node-becomes-a-meeting-point case.
+    #[test]
+    fn isolated_node_with_enrolled_peers_self_elects() {
+        assert!(snapshot(Vec::new(), Vec::new()).should_self_elect_as_relay(2));
+    }
+
+    /// A directly-connected LAN peer means the node can already reach the
+    /// mesh — no need to become a relay.
+    #[test]
+    fn a_connected_lan_peer_means_no_election() {
+        assert!(!snapshot(Vec::new(), vec![PeerId::new()]).should_self_elect_as_relay(2));
+    }
+
+    /// A live relay route means the node already has a meeting point —
+    /// don't elect a competing one.
+    #[test]
+    fn a_live_relay_means_no_election() {
+        let health = vec![TransportHealthSample::healthy_direct(TransportKind::Relay)];
+        assert!(!snapshot(health, Vec::new()).should_self_elect_as_relay(2));
+    }
+
+    /// Grid-of-one: no enrolled peers = no mesh to join = nothing to
+    /// relay for. Never elect (else every fresh, peerless node spins up a
+    /// pointless relay).
+    #[test]
+    fn grid_of_one_never_elects() {
+        assert!(!snapshot(Vec::new(), Vec::new()).should_self_elect_as_relay(0));
     }
 }


### PR DESCRIPTION
Completes **self-election** (#1247 slice 4). Slice 4a (#1251) gave a node the *mechanism* to be a relay; this is the daemon *trigger* that decides when. With both, **the fleet reconnects itself with zero ops** — a reachable node self-elects, the rest discover it through the gist directory, and slices 1–3 carry the traffic.

## Change

- **`RouteDiscoverySnapshot::should_self_elect_as_relay(enrolled_peers)`** — the pure decision (unit-tested independent of the loop): become a relay when the node knows peers exist but can reach **none** of them — no live relay route AND no directly-connected LAN peer. Deliberately simple because slice 4a made reachability **empirical**: a wrong "yes" is harmless (an unreachable self-elected relay gets no connections, its gist entry goes stale), so we never predict our own reachability.
- **The daemon's 60s route-refresh loop** evaluates it each tick and calls `become_relay(0.0.0.0:0)` when true — all interfaces (LAN + Tailscale reachable, not loopback), OS-assigned port (the gist advertises the actual port, so the durable pointer survives restarts). Idempotent → re-evaluating "yes" just re-advertises. Election logged loudly; a bind failure logs + retries next tick (self-heal). The next `publish_account_registry` carries the advertised endpoint into the gist automatically (it already includes `route_endpoints()`).

## Tests

4 decision cases: isolated-with-peers elects; a connected LAN peer **or** a live relay suppresses it; grid-of-one (no enrolled peers) never elects. clippy `-D warnings` + fmt clean; existing relay tests still green.

## Where this leaves the backbone

**Self-election is complete.** A node that can't reach anyone becomes a relay and advertises itself; reachable peers find it through the gist and route through it. So for the fleet: once these land and daemons refresh, an isolated-but-reachable node (e.g. a Mac that accepts inbound) will self-elect, and BigMama↔M5↔IntelMac can re-form over the relay — and continuum's grid with them (same transport). Remaining polish: slice 8 (relay↔relay federation), 9 (relay durable mailbox), 10 (gist room directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)