### PR TITLE
feat(relay): self-elected relay advertises routable IPs, not 0.0.0.0 (#1247 slice 4c)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1550,18 +1550,38 @@ async fn refresh_routes_once(airc: &Airc, connected_lan_peers: &std::sync::atomi
             // durable pointer stays valid across restarts.
             let enrolled = airc.peers().await.map(|peers| peers.len()).unwrap_or(0);
             if snapshot.should_self_elect_as_relay(enrolled) {
-                match airc
-                    .become_relay(std::net::SocketAddr::from(([0, 0, 0, 0], 0)))
-                    .await
-                {
-                    Ok(addr) => eprintln!(
-                        "airc daemon: no reachable peer or relay (enrolled={enrolled}) — \
-                         self-elected as a relay on {addr} and advertised it (#1247)"
-                    ),
-                    Err(error) => eprintln!(
-                        "airc daemon: relay self-election failed ({error}); \
-                         retrying next interval"
-                    ),
+                // Slice 4c: advertise the relay under our ROUTABLE IP(s)
+                // (LAN + Tailscale), never the 0.0.0.0 bind — peers can't
+                // dial a wildcard. Same detection the LAN-listener
+                // advertisement uses. With neither IP, we'd be an
+                // un-dialable relay, so stay a client + say why (loud).
+                let lan_ip = crate::network_commands::advertise_lan_ip();
+                let tailscale_ip = crate::network_commands::detect_tailscale_ip();
+                if lan_ip.is_none() && tailscale_ip.is_none() {
+                    eprintln!(
+                        "airc daemon: would self-elect as a relay (no reachable peer/relay, \
+                         enrolled={enrolled}) but no routable LAN/Tailscale IPv4 to advertise \
+                         — staying a client (open a routable interface to host a relay)"
+                    );
+                } else {
+                    match airc
+                        .become_relay(
+                            std::net::SocketAddr::from(([0, 0, 0, 0], 0)),
+                            lan_ip,
+                            tailscale_ip,
+                        )
+                        .await
+                    {
+                        Ok(addr) => eprintln!(
+                            "airc daemon: no reachable peer or relay (enrolled={enrolled}) — \
+                             self-elected as a relay (listening {addr}) and advertised it on \
+                             this node's routable IP(s) (#1247)"
+                        ),
+                        Err(error) => eprintln!(
+                            "airc daemon: relay self-election failed ({error}); \
+                             retrying next interval"
+                        ),
+                    }
                 }
             }
         }

--- a/crates/airc-lib/src/relay.rs
+++ b/crates/airc-lib/src/relay.rs
@@ -5,7 +5,7 @@
 //! and frame ingestion; consumers only provide the relay endpoint and
 //! pinned relay identity.
 
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 
 use airc_core::PeerId;
 use airc_relay::{RelayServer, RelayServerConfig};
@@ -75,14 +75,24 @@ impl Airc {
     ///
     /// Idempotent: a node already relaying re-advertises and returns its
     /// existing bound address.
-    pub async fn become_relay(&self, bind_addr: SocketAddr) -> Result<SocketAddr, AircError> {
+    /// `bind_addr` is where the relay LISTENS (typically `0.0.0.0:0` — all
+    /// interfaces, OS-assigned port). `lan_ip` / `tailscale_ip` are the
+    /// ROUTABLE addresses this node advertises the relay under (the caller
+    /// detects them, exactly as for [`Airc::listen_lan_advertising`]); the
+    /// wildcard bind address is NEVER advertised, since peers can't dial it.
+    pub async fn become_relay(
+        &self,
+        bind_addr: SocketAddr,
+        lan_ip: Option<Ipv4Addr>,
+        tailscale_ip: Option<Ipv4Addr>,
+    ) -> Result<SocketAddr, AircError> {
         // Fast path: already relaying — re-advertise (idempotent) + return.
         {
             let guard = self.inner.relay_server.lock().await;
             if let Some(server) = guard.as_ref() {
                 let addr = server.local_addr();
                 drop(guard);
-                self.advertise_self_relay(addr)?;
+                self.advertise_self_relay(addr.port(), lan_ip, tailscale_ip)?;
                 return Ok(addr);
             }
         }
@@ -113,15 +123,33 @@ impl Airc {
                 }
             }
         };
-        self.advertise_self_relay(final_addr)?;
+        self.advertise_self_relay(final_addr.port(), lan_ip, tailscale_ip)?;
         Ok(final_addr)
     }
 
-    /// Record THIS node's own relay endpoint (peer-id-bearing) on the
-    /// route table so it propagates into the gist directory. Distinct from
-    /// `upsert_relay_health`, which marks a relay this node is a CLIENT of.
-    fn advertise_self_relay(&self, addr: SocketAddr) -> Result<(), AircError> {
-        self.upsert_route_endpoint(RouteEndpoint::relay(self.inner.identity.peer_id, addr))?;
+    /// Advertise THIS node's relay under each ROUTABLE address it owns —
+    /// its LAN IP and/or its Tailscale IP — NEVER the wildcard `0.0.0.0`
+    /// bind, which peers can't dial (#1247 slice 4c). Mirrors
+    /// [`Airc::listen_lan_advertising`]: bind all interfaces once, publish
+    /// the specific dialable IPs; the dialer tries whichever it can reach
+    /// (same-subnet → LAN IP; cross-subnet → Tailscale). With NEITHER IP
+    /// known (e.g. a container with no routable address) the relay runs but
+    /// advertises nothing — an un-dialable relay is useless, so we never
+    /// publish a dead `0.0.0.0` endpoint. Distinct from `upsert_relay_health`,
+    /// which marks a relay this node is a CLIENT of.
+    fn advertise_self_relay(
+        &self,
+        port: u16,
+        lan_ip: Option<Ipv4Addr>,
+        tailscale_ip: Option<Ipv4Addr>,
+    ) -> Result<(), AircError> {
+        let me = self.inner.identity.peer_id;
+        if let Some(ip) = lan_ip {
+            self.upsert_route_endpoint(RouteEndpoint::relay(me, SocketAddr::from((ip, port))))?;
+        }
+        if let Some(ip) = tailscale_ip {
+            self.upsert_route_endpoint(RouteEndpoint::relay(me, SocketAddr::from((ip, port))))?;
+        }
         Ok(())
     }
 

--- a/crates/airc-lib/tests/relay_discovery.rs
+++ b/crates/airc-lib/tests/relay_discovery.rs
@@ -16,7 +16,7 @@
 //!   - a successful connect yields a Healthy `Relay` transport in the
 //!     route-health snapshot.
 
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use airc_core::PeerId;
@@ -134,9 +134,15 @@ async fn a_node_becomes_a_relay_and_a_client_discovers_it() {
         .await
         .expect("client trusts relay node");
 
-    // The relay node promotes itself.
+    // The relay node promotes itself, advertising under loopback (the
+    // routable address for this same-machine test; in production the daemon
+    // passes the node's detected LAN/Tailscale IPs).
     let relay_addr = relay_node
-        .become_relay("127.0.0.1:0".parse().unwrap())
+        .become_relay(
+            "127.0.0.1:0".parse().unwrap(),
+            Some(Ipv4Addr::LOCALHOST),
+            None,
+        )
         .await
         .expect("relay node becomes a relay");
 


### PR DESCRIPTION
The piece that makes self-election (#1251/#1252) actually bite for the cross-subnet fleet.

## Problem

`become_relay` advertised `RelayServer::local_addr()` — for a `0.0.0.0:0` bind that's the **wildcard**, which peers can't dial. So a self-elected relay was discoverable in-process (loopback is routable) but **un-dialable** for real cross-subnet peers.

## Fix (mirrors the LAN listener's existing solution)

- **`become_relay(bind_addr, lan_ip, tailscale_ip)`** advertises the relay under each **routable** address the node owns (LAN IP and/or Tailscale IP), never the wildcard bind — exactly as `Airc::listen_lan_advertising` already does. Bind all interfaces once (`0.0.0.0:0`), publish the specific dialable IPs; the dialer tries whichever it reaches (same-subnet → LAN, cross-subnet → Tailscale). With neither IP, the relay runs but advertises nothing — an un-dialable relay is useless, so we never publish a dead `0.0.0.0` endpoint.
- **The daemon's election trigger** detects IPs with the same `advertise_lan_ip()` + `detect_tailscale_ip()` the LAN advertisement uses, and **skips election (loudly)** when neither exists — a node with no routable interface can't host a relay anyone reaches, so it stays a client.

## Test

The node-becomes-a-relay test advertises under loopback (the routable address for a same-machine test) and asserts the advertised endpoint is the connectable `(peer, addr)` a client then discovers + connects to. clippy `-D warnings` + fmt clean; existing relay tests green.

## Net

Self-election is now real for cross-subnet: a node that accepts inbound self-elects and advertises a **Tailscale-reachable** relay, which a firewalled-inbound peer (e.g. BigMama, which can still dial OUT) connects to — the mesh re-forms **without opening every node's firewall**. Completes slice 4. Remaining polish: #1247 slices 8 (federation), 9 (durable mailbox), 10 (room directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)