### PR TITLE
fix(install): honor cargo's real target-dir so airc update finds the binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -732,6 +732,26 @@ ensure_cargo_recent() {
 
 # Build the Rust binary and place it on PATH as `airc`. No shell
 # wrapper, no .shim/.cmd/.ps1 trampolines — the Rust binary is the
+# Resolve cargo's ACTUAL target directory rather than assuming
+# "$CLONE_DIR/target". Cargo honors `CARGO_TARGET_DIR` AND a `[build]
+# target-dir` in `~/.cargo/config.toml` / `.cargo/config.toml`, which a
+# shared-build-cache setup commonly redirects (disk discipline). When it
+# does, the binary lands outside `$CLONE_DIR/target`, and the old
+# hard-coded path made `airc update` build successfully then "lose" the
+# binary and bail. `cargo metadata` reports the resolved dir (same
+# precedence the build used), so we always look where the binary actually
+# is. JSON backslash-escapes / Windows backslashes are normalized to
+# forward slashes so the path is usable in this (MSYS/git-bash) shell;
+# falls back to the historical default if `cargo metadata` is unavailable.
+_airc_target_dir() {
+  local dir
+  dir="$( (cd "$CLONE_DIR" && cargo metadata --format-version 1 --no-deps 2>/dev/null) \
+          | grep -o '"target_directory":"[^"]*"' | head -1 \
+          | sed 's/^"target_directory":"//; s/"$//' )"
+  dir="$(printf '%s' "$dir" | sed 's#\\\\#/#g; s#\\#/#g')"
+  if [ -n "$dir" ]; then printf '%s\n' "$dir"; else printf '%s\n' "$CLONE_DIR/target"; fi
+}
+
 # user surface. Copy the built binary into BIN_DIR so PATH never points
 # at mutable target artifacts inside the source checkout.
 _install_airc_binary() {
@@ -744,16 +764,19 @@ _install_airc_binary() {
   (cd "$CLONE_DIR" && cargo build --release -p airc-cli)
   mkdir -p "$BIN_DIR"
 
+  # Where cargo ACTUALLY put it (honors CARGO_TARGET_DIR + cargo config),
+  # not the assumed "$CLONE_DIR/target" — see `_airc_target_dir`.
+  local target_dir; target_dir="$(_airc_target_dir)"
   case "$(uname -s 2>/dev/null)" in
     MINGW*|MSYS*|CYGWIN*)
-      local built="$CLONE_DIR/target/release/airc.exe"
-      [ -x "$built" ] || fail "airc build completed but binary is missing: $built"
+      local built="$target_dir/release/airc.exe"
+      [ -x "$built" ] || fail "airc build completed but binary is missing: $built (target dir: $target_dir)"
       cp -f "$built" "$BIN_DIR/airc.exe"
       ok "Installed airc: $BIN_DIR/airc.exe"
       ;;
     *)
-      local built="$CLONE_DIR/target/release/airc"
-      [ -x "$built" ] || fail "airc build completed but binary is missing: $built"
+      local built="$target_dir/release/airc"
+      [ -x "$built" ] || fail "airc build completed but binary is missing: $built (target dir: $target_dir)"
       local tmp="$BIN_DIR/.airc.tmp.$$"
       cp -f "$built" "$tmp"
       chmod +x "$tmp"
@@ -1003,10 +1026,11 @@ _install_airc_codex_hooks() {
   [ -f "$HOME/.codex/config.toml" ] || return 0
 
   local _airc=""
-  if [ -x "$CLONE_DIR/target/release/airc" ]; then
-    _airc="$CLONE_DIR/target/release/airc"
-  elif [ -x "$CLONE_DIR/target/debug/airc" ]; then
-    _airc="$CLONE_DIR/target/debug/airc"
+  local _tdir; _tdir="$(_airc_target_dir)"
+  if [ -x "$_tdir/release/airc" ]; then
+    _airc="$_tdir/release/airc"
+  elif [ -x "$_tdir/debug/airc" ]; then
+    _airc="$_tdir/debug/airc"
   elif command -v airc >/dev/null 2>&1; then
     _airc=$(command -v airc)
   else


### PR DESCRIPTION
## Problem (hit live on BigMama)

`airc update` builds airc fine, then fails:
```
✗ airc build completed but binary is missing: <CLONE_DIR>/target/release/airc.exe
airc: install.sh failed: exit status exit code: 1
```
…on any machine that redirects cargo's target directory — which a **shared-build-cache** setup commonly does via `[build] target-dir` in `~/.cargo/config.toml` (or `CARGO_TARGET_DIR`). The build lands in the redirected dir; `install.sh` hard-coded `$CLONE_DIR/target/release` and bailed. So `airc update` was broken for every operator with a redirected target-dir — exactly the kind of update-friction that blocks the fleet (#1225 class).

## Fix

`_airc_target_dir` resolves the **actual** target directory via `cargo metadata` (same env + config precedence the build used), normalizing JSON/Windows backslashes to forward slashes for MSYS/git-bash, falling back to the historical `$CLONE_DIR/target` if metadata is unavailable. Both the binary install and the Codex-hook binary lookup use it now instead of the assumed path.

## Validation

- `bash -n install.sh` clean.
- The resolver, run verbatim from the file on a redirected-target-dir machine, resolves to the real build dir and locates the freshly-built `airc.exe` there — where the old hard-coded path could not.

Fixing this **before** M5/IntelMac run `airc update` onto the new relay binaries, so they get a one-command upgrade instead of the manual build-and-swap dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)