### PR TITLE
fix(install): make airc reachable inbound on Windows — no signing, clean + idempotent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -754,6 +754,38 @@ _airc_target_dir() {
 
 # user surface. Copy the built binary into BIN_DIR so PATH never points
 # at mutable target artifacts inside the source checkout.
+# Windows-only: make airc reachable INBOUND without code-signing. Defender
+# blocks unknown programs' inbound by default, and repeated `airc daemon`
+# binds leave contradictory auto-created rules (a Block beats an Allow), so
+# inbound silently dies. We install ONE canonical inbound-allow rule for the
+# binary. Changing firewall rules requires elevation (signing wouldn't help —
+# firewall != SmartScreen), so we CHECK first (read-only, no prompt) and only
+# UAC-prompt when a fix is actually needed — every later update stays silent.
+_setup_windows_firewall() {
+  local ps1="$CLONE_DIR/windows/firewall-allow.ps1"
+  [ -f "$ps1" ] || return 0   # tolerate older checkouts
+  local airc_win ps1_win
+  airc_win="$(_to_win_path "$BIN_DIR/airc.exe")"
+  ps1_win="$(_to_win_path "$ps1")"
+  # Read-only state check — no admin, no prompt.
+  if powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+       -File "$ps1_win" -AircPath "$airc_win" -CheckOnly >/dev/null 2>&1; then
+    ok "Windows Firewall: airc inbound already allowed"
+    return 0
+  fi
+  info "Windows Firewall: allowing airc inbound (one UAC prompt — so LAN peers can reach this node)…"
+  powershell.exe -NoProfile -Command \
+    "Start-Process powershell -Verb RunAs -Wait -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File','$ps1_win','-AircPath','$airc_win')" \
+    >/dev/null 2>&1 || true
+  if powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+       -File "$ps1_win" -AircPath "$airc_win" -CheckOnly >/dev/null 2>&1; then
+    ok "Windows Firewall: airc inbound allowed"
+  else
+    warn "Windows Firewall rule not set (elevation declined?). airc inbound may be blocked. \
+Re-run setup, or as admin: powershell -ExecutionPolicy Bypass -File '$ps1_win' -AircPath '$airc_win'"
+  fi
+}
+
 _install_airc_binary() {
   [ "${AIRC_SKIP_RUST_BUILD:-0}" = "1" ] && { info "AIRC_SKIP_RUST_BUILD=1 -- skipping airc build"; return 0; }
   if ! command -v cargo >/dev/null 2>&1; then
@@ -773,6 +805,9 @@ _install_airc_binary() {
       [ -x "$built" ] || fail "airc build completed but binary is missing: $built (target dir: $target_dir)"
       cp -f "$built" "$BIN_DIR/airc.exe"
       ok "Installed airc: $BIN_DIR/airc.exe"
+      # Reachable-inbound on a typical Windows box (idempotent; prompts for
+      # elevation only when the firewall rule is missing/broken).
+      _setup_windows_firewall
       ;;
     *)
       local built="$target_dir/release/airc"

--- a/windows/firewall-allow.ps1
+++ b/windows/firewall-allow.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+  Make airc reachable inbound on Windows — the firewall half of setup.
+
+.DESCRIPTION
+  On a typical Windows box, Defender Firewall blocks INBOUND for unknown
+  programs by default, so airc's LAN listener is unreachable until a rule
+  exists — and code-signing does NOT help (firewall != SmartScreen; the
+  rule is required regardless of signature). Worse, each `airc daemon` bind
+  trips Defender's "allow access?" prompt, and one "Cancel"/Block click (or
+  repeated launches) leaves a pile of contradictory auto-created rules — and
+  a BLOCK rule beats an ALLOW, so inbound stays dead (observed live: 8 Allow
+  + 2 Block for airc.exe).
+
+  Two modes so setup only ever prompts for elevation WHEN NEEDED:
+    -CheckOnly : read-only, no admin. Exit 0 if the canonical allow rule is
+                 present and there are no Block rules; exit 1 if a fix is
+                 needed. install.sh runs this first (no UAC) and only elevates
+                 to apply when it returns 1 — so steady-state updates are silent.
+    (default)  : apply mode (needs admin). Removes every existing airc rule
+                 (by display name AND by program path), then adds ONE
+                 canonical inbound-allow rule for the binary. Idempotent.
+
+  Invoked by install.sh; can also be re-run standalone (as admin):
+    powershell -ExecutionPolicy Bypass -File windows\firewall-allow.ps1 -AircPath "C:\Users\<you>\.local\bin\airc.exe"
+
+.PARAMETER AircPath
+  Full path to the installed airc.exe the rule should allow.
+.PARAMETER CheckOnly
+  Report state via exit code without changing anything (no admin required).
+#>
+param(
+  [Parameter(Mandatory = $true)][string]$AircPath,
+  [switch]$CheckOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $AircPath)) {
+  Write-Error "airc binary not found at: $AircPath"
+  exit 2
+}
+$AircPath = (Resolve-Path -LiteralPath $AircPath).Path
+
+function Test-AircFirewallOk {
+  # OK = a live inbound ALLOW rule for THIS binary exists AND there are no
+  # airc Block rules (a Block would win and silently kill inbound).
+  $blocks = Get-NetFirewallRule -DisplayName 'airc*' -ErrorAction SilentlyContinue |
+    Where-Object { $_.Action -eq 'Block' }
+  $allow = Get-NetFirewallApplicationFilter -Program $AircPath -ErrorAction SilentlyContinue |
+    Get-NetFirewallRule -ErrorAction SilentlyContinue |
+    Where-Object { $_.Direction -eq 'Inbound' -and $_.Action -eq 'Allow' -and $_.Enabled -eq 'True' }
+  return ([bool]$allow -and -not [bool]$blocks)
+}
+
+if ($CheckOnly) {
+  if (Test-AircFirewallOk) { exit 0 } else { exit 1 }
+}
+
+# Apply mode — changing firewall rules requires elevation.
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+  ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+  Write-Error 'firewall-allow.ps1 (apply mode) must run as Administrator.'
+  exit 3
+}
+
+# 1) Drop the contradictory pile by display name (auto-created rules are
+#    named after the program, e.g. "airc.exe").
+Get-NetFirewallRule -DisplayName 'airc*' -ErrorAction SilentlyContinue |
+  Remove-NetFirewallRule -ErrorAction SilentlyContinue
+
+# 2) Belt-and-suspenders: remove ANY rule whose program filter points at this
+#    exact binary, regardless of display name.
+Get-NetFirewallApplicationFilter -Program $AircPath -ErrorAction SilentlyContinue |
+  ForEach-Object {
+    $_ | Get-NetFirewallRule -ErrorAction SilentlyContinue |
+      Remove-NetFirewallRule -ErrorAction SilentlyContinue
+  }
+
+# 3) Add the single canonical inbound-allow rule (TCP, all profiles).
+New-NetFirewallRule `
+  -DisplayName 'airc (inbound)' `
+  -Description 'Allow inbound LAN connections to the airc daemon (added by airc setup).' `
+  -Direction Inbound `
+  -Program $AircPath `
+  -Action Allow `
+  -Profile Any `
+  -Protocol TCP | Out-Null
+
+Write-Host "airc: firewall inbound-allow rule installed for $AircPath"


### PR DESCRIPTION
## The problem (a typical Windows box, not a Joel-box quirk)

LAN peers can't reach a Windows airc node because **Defender Firewall blocks INBOUND for unknown programs by default** — and **code-signing does not fix this** (firewall ≠ SmartScreen; the rule is required regardless of signature). So "become a registered Microsoft publisher" was never the answer. Worse: every `airc daemon` bind trips Defender's "allow access?" prompt, and one "Cancel"/Block click (or repeated launches) leaves a pile of contradictory auto-created rules — and a **BLOCK rule beats an ALLOW**. Observed live on BigMama: **8 Allow + 2 Block** for `airc.exe` → inbound silently dead, which is why peer→node dials time out.

## Fix — setup owns it, no hand-run commands

- **`windows/firewall-allow.ps1`** — removes every existing airc rule (by display name AND by program path, to catch the auto-created ones) and adds **one canonical inbound-allow** rule for the binary. Two modes:
  - `-CheckOnly` — read-only, **no admin**, exit `0`=ok / `1`=needs-fix.
  - apply (default) — asserts admin, does the cleanup + add. Idempotent.
- **`install.sh::_setup_windows_firewall`** runs the read-only check first (**no prompt**); only when a fix is needed does it self-elevate (**one UAC**) to apply. So first install asks once; every `airc update` after is **silent** because the rule persists. Declined elevation → loud warning with the exact re-run, never a hard fail. Wired into the Windows binary-install path → covers **install and update**.

## Why this shape

Clean + easy (the bar): no signing, no hand-pasted commands, one UAC only when something's actually wrong, silent thereafter.

## Validation

- `bash -n install.sh` clean.
- `-CheckOnly` correctly returns **exit 1** against the live 8-Allow/2-Block mess (detects the broken state, no prompt).

(Apply path needs the UAC click, so it's validated by the check logic + the script's structure; happy to run it live to fix BigMama's rules and confirm end-to-end.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)