### PR TITLE
fix(install): clearer firewall step + purge Python from the live path

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -103,13 +103,13 @@ function Test-WingetAvailable {
         Write-Host '    # chocolatey (recommended for Server):'
         Write-Host '    Set-ExecutionPolicy Bypass -Scope Process -Force'
         Write-Host "    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
-        Write-Host '    choco install -y python git gh jq'
+        Write-Host '    choco install -y git gh rust'
         Write-Host ''
         Write-Host '    # OR scoop (user-scope, no admin needed):'
         Write-Host "    iwr -useb https://get.scoop.sh | iex"
-        Write-Host '    scoop install python git gh jq'
+        Write-Host '    scoop install git gh rust'
         Write-Host ''
-        Write-Host '  After installing python, git, gh, jq manually, re-run this script;'
+        Write-Host '  After installing git, gh, rust manually, re-run this script;'
         Write-Host '  it will detect them and skip winget.'
     } else {
         Write-Host '  winget ships with App Installer (Microsoft Store). Install or update it:'
@@ -125,12 +125,12 @@ function Test-WingetAvailable {
 
 # -- Install one winget package, idempotent ------------------------------
 # Test-Cmd: a callable that returns $true when the package is already
-# usable (e.g. {Get-Command python} or a custom probe). Skips winget on
+# usable (e.g. {Get-Command cargo} or a custom probe). Skips winget on
 # hits -- saves the 30s+ download/install round trip.
 function Install-IfMissing {
     param(
         [string]$Name,        # human label for messages
-        [string]$WingetId,    # winget package id (e.g. Python.Python.3.12)
+        [string]$WingetId,    # winget package id (e.g. Rustlang.Rustup)
         [scriptblock]$TestCmd # returns truthy when already installed
     )
     if (& $TestCmd) {
@@ -181,8 +181,8 @@ Test-WingetAvailable
 
 Install-IfMissing -Name 'Git for Windows'    -WingetId 'Git.Git'             -TestCmd { Get-Command git -ErrorAction SilentlyContinue }
 Install-IfMissing -Name 'GitHub CLI (gh)'    -WingetId 'GitHub.cli'          -TestCmd { Get-Command gh -ErrorAction SilentlyContinue }
-# Python + jq dropped as prereqs (parity with install.sh, issue #341):
-# identity, signing, hooks, config, and JSON handling are Rust-owned.
+# git + gh are the only non-Rust prereqs (plus the Rust toolchain below).
+# Identity, signing, hooks, config, and JSON handling are all Rust-owned.
 
 # -- Rust toolchain ------------------------------------------------------
 # airc IS a Rust binary; cargo is a hard prereq. install.sh auto-installs

--- a/install.sh
+++ b/install.sh
@@ -66,8 +66,8 @@ _to_bash_path() {
 #
 # Required: git, gh, ssh-keygen, cargo (to build the Rust substrate CLI).
 # Optional: tailscale (only needed for cross-LAN mesh; LAN works without)
-# Deliberately not required: openssl or Python. Identity, signing, hooks,
-# config, and message parsing are Rust-owned.
+# Everything else — identity, signing, hooks, config, message parsing,
+# JSON handling — is Rust-owned, so there are no other runtime prereqs.
 #
 # AIRC_SKIP_PREREQS=1 short-circuits the whole block (CI, dev installs,
 # users who manage their own packages).
@@ -327,8 +327,8 @@ ensure_prereqs() {
   fi
 
   local missing=() pkgs=() unmappable=()
-  # jq, openssl, and Python are not install prereqs. JSON handling,
-  # Ed25519 identity/signing, hooks, and config mutation are Rust-owned.
+  # The full prereq set is exactly these four. JSON handling, Ed25519
+  # identity/signing, hooks, and config mutation are all Rust-owned.
   for cmd in git gh ssh-keygen cargo; do
     # Strict probe: presence on PATH AND a successful --version invocation.
     # git/gh/cargo support --version cleanly. ssh-keygen does NOT have a version
@@ -396,11 +396,10 @@ ensure_prereqs() {
   _ensure_windows_msvc_toolchain "$mgr"
   _ensure_macos_build_toolchain
 
-  # Issue #341 follow-up: openssl/Python crypto bootstrap removed.
-  # Identity gen + signing live in Rust, so system OpenSSL and Python
-  # package state are irrelevant to airc install correctness.
+  # Identity gen + signing live in Rust — there is no crypto bootstrap to
+  # do here; system package state is irrelevant to airc install correctness.
 
-  # Post-3c: sshd setup + Tailscale install fully removed from install.
+  # sshd setup + Tailscale install are not part of install.
   # Cross-network messaging is owned by Rust transports/discovery, while
   # GitHub remains rendezvous/control-plane only. The earlier sshd-on-
   # by-default block (with sudo/UAC prompt + AIRC_SKIP_SSHD escape +

--- a/install.sh
+++ b/install.sh
@@ -773,16 +773,29 @@ _setup_windows_firewall() {
     ok "Windows Firewall: airc inbound already allowed"
     return 0
   fi
-  info "Windows Firewall: allowing airc inbound (one UAC prompt — so LAN peers can reach this node)…"
+  # Tell the user WHAT we're about to do and WHY before the UAC prompt pops —
+  # same spirit as an app asking for notification permission. Then it's an
+  # informed click, not a mystery elevation request.
+  info ""
+  info "Windows Firewall — one-time setup (needs your approval):"
+  info "  WHAT: add a single rule allowing inbound TCP to this airc binary."
+  info "  WHY:  Windows blocks inbound connections from unknown programs by"
+  info "        default, so other machines on your LAN can't reach this node"
+  info "        until the rule exists. This is the airc grid's front door."
+  info "  HOW:  Windows will show ONE UAC prompt — click Yes to allow it."
+  info "        (Updates stay silent afterward; nothing to re-approve.)"
   powershell.exe -NoProfile -Command \
     "Start-Process powershell -Verb RunAs -Wait -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File','$ps1_win','-AircPath','$airc_win')" \
     >/dev/null 2>&1 || true
   if powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass \
        -File "$ps1_win" -AircPath "$airc_win" -CheckOnly >/dev/null 2>&1; then
-    ok "Windows Firewall: airc inbound allowed"
+    ok "Windows Firewall: airc inbound allowed — LAN peers can now reach this node."
   else
-    warn "Windows Firewall rule not set (elevation declined?). airc inbound may be blocked. \
-Re-run setup, or as admin: powershell -ExecutionPolicy Bypass -File '$ps1_win' -AircPath '$airc_win'"
+    warn "Windows Firewall rule was NOT set (UAC declined or cancelled)."
+    warn "  ⚠️  LAN connectivity will NOT work — other machines can't reach this"
+    warn "      node inbound, so the grid can't form over your local network."
+    warn "  Fix it any time by re-running setup, or as admin:"
+    warn "      powershell -ExecutionPolicy Bypass -File '$ps1_win' -AircPath '$airc_win'"
   fi
 }
 

--- a/integrations/embedding-facility/smoke.sh
+++ b/integrations/embedding-facility/smoke.sh
@@ -61,17 +61,13 @@ resp="$(curl -fsS "${BASE}/v1/embeddings" \
   || fail "POST /v1/embeddings failed"
 
 # Assert a non-empty numeric embedding came back, and report its dimension.
-dim=""
-if command -v python3 >/dev/null 2>&1; then
-  dim="$(printf '%s' "$resp" | python3 -c \
-    'import sys,json; d=json.load(sys.stdin)["data"][0]["embedding"]; assert d and all(isinstance(x,(int,float)) for x in d); print(len(d))' \
-    2>/dev/null)" || fail "response had no valid embedding array: ${resp:0:200}"
-else
-  # No python3: heuristic check that an embedding array with numbers is present.
-  printf '%s' "$resp" | grep -Eq '"embedding"[[:space:]]*:[[:space:]]*\[[[:space:]]*-?[0-9]' \
-    || fail "response had no embedding array: ${resp:0:200}"
-  dim="(install python3 for exact dim)"
-fi
+# Pure sed/tr/grep — no Python runtime (the repo is Rust-cutover; the guard
+# forbids a Python dependency on the live path). Pull the first embedding
+# array out of the JSON and count its numeric elements.
+emb="$(printf '%s' "$resp" | sed -n 's/.*"embedding"[[:space:]]*:[[:space:]]*\[\([^]]*\)\].*/\1/p')"
+printf '%s' "$emb" | grep -Eq '\-?[0-9]' \
+  || fail "response had no embedding array: ${resp:0:200}"
+dim="$(printf '%s' "$emb" | tr ',' '\n' | grep -Ec '\-?[0-9]')"
 
 log "OK — embedding returned. dim=${dim}. The 5090 facility GPU half is PROVEN on this box. 🚀"
 log "advertise it on the grid:  cargo run -p airc-embedding-bridge   (needs a running airc daemon)"

--- a/integrations/generate-facility/smoke.sh
+++ b/integrations/generate-facility/smoke.sh
@@ -58,17 +58,12 @@ resp="$(curl -fsS "${BASE}/v1/chat/completions" \
   -d '{"messages":[{"role":"user","content":"Reply with exactly: grid online"}],"max_tokens":16,"temperature":0}')" \
   || fail "POST /v1/chat/completions failed"
 
-# Assert a non-empty assistant message came back, and echo it.
-text=""
-if command -v python3 >/dev/null 2>&1; then
-  text="$(printf '%s' "$resp" | python3 -c \
-    'import sys,json; c=json.load(sys.stdin)["choices"][0]["message"]["content"]; assert c.strip(); print(c.strip())' \
-    2>/dev/null)" || fail "response had no completion content: ${resp:0:200}"
-else
-  printf '%s' "$resp" | grep -Eq '"content"[[:space:]]*:[[:space:]]*"[^"]' \
-    || fail "response had no completion content: ${resp:0:200}"
-  text="(install python3 to echo the text)"
-fi
+# Assert a non-empty assistant message came back, and echo it. Pure sed/grep —
+# no Python runtime (Rust-cutover guard forbids a Python dependency on the
+# live path). Pull the first "content":"..." string out of the JSON.
+text="$(printf '%s' "$resp" | sed -n 's/.*"content"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+[ -n "$text" ] \
+  || fail "response had no completion content: ${resp:0:200}"
 
 log "OK — completion returned: \"${text}\". The 5090 generate facility GPU half is PROVEN. 🚀"
 log "advertise it on the grid:  cargo run -p airc-generate-bridge   (needs a running airc daemon)"


### PR DESCRIPTION
Two install-path cleanups, both UX/correctness — no behavior change to the airc binary itself.

## 1. Explain the Windows firewall step (and that LAN breaks if declined)
On Windows, Defender blocks inbound from unknown programs by default, so airc's LAN listener is unreachable until a firewall rule exists (signing doesn't help — firewall ≠ SmartScreen). Setup already adds the rule and only UAC-prompts when needed, but it fired the prompt with a one-line aside, so the elevation read as a mystery.
- Before the prompt, setup now prints a short **WHAT / WHY / HOW** block — same spirit as an app explaining a notification-permission request.
- If the user **declines/cancels**, setup says plainly that **LAN connectivity will NOT work** and shows the exact command to fix it later.

## 2. Purge Python from the live path (Rust-only, no fallbacks)
The `rust_cutover_guard` was **red on canary** (blocking every PR):
- `integrations/{embedding,generate}-facility/smoke.sh` shelled out to `python3` to pretty-print a JSON field. Dropped the python branch entirely — single pure `sed`/`tr`/`grep` path that still asserts the array/content and reports exact dim / echoes the text. No degraded "install python3 for…" fallback.
- `install.ps1` Windows-Server fallback told users to `choco/scoop install python … jq`. Now `git gh rust` (the real prereqs). `jq` was never needed — `gh api --jq` is gh's built-in flag.
- Collapsed the "we dropped Python (issue #341)" legacy-archaeology comments in `install.sh` into plain statements of what IS required.

Guard now green; both installers parse-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)