### PR TITLE
fix(daemon): self-heal advertised endpoint on network change (no manual restart)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1526,7 +1526,10 @@ async fn refresh_routes_once(
     // happens exactly once per tick.
     let lan_ip = crate::network_commands::advertise_lan_ip();
     let tailscale_ip = crate::network_commands::detect_tailscale_ip();
-    match airc.refresh_advertised_endpoints(lan_ip, tailscale_ip).await {
+    match airc
+        .refresh_advertised_endpoints(lan_ip, tailscale_ip)
+        .await
+    {
         Ok(true) => {
             // Changed → nudge the registry loop to republish the corrected
             // card NOW (edge-triggered; steady-state stays on cadence, so
@@ -1549,7 +1552,9 @@ async fn refresh_routes_once(
         }
         Ok(false) => {}
         Err(error) => {
-            eprintln!("airc daemon: advertised-endpoint refresh failed ({error}); retrying next tick");
+            eprintln!(
+                "airc daemon: advertised-endpoint refresh failed ({error}); retrying next tick"
+            );
         }
     }
     match airc.refresh_route_discovery().await {

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1456,6 +1456,7 @@ pub async fn run_daemon(
             store,
             gate,
             airc_lib::RegistryRefreshConfig::default(),
+            &registry_state.endpoint_resync,
             registry_state.shutdown.notified(),
         )
         .await;
@@ -1497,9 +1498,10 @@ pub async fn run_daemon(
 /// `run_daemon` before this spawns.
 fn spawn_route_refresh(state: Arc<DaemonState>, airc: Airc) -> tokio::task::JoinHandle<()> {
     let connected = state.connected_lan_peers.clone();
+    let endpoint_resync = state.endpoint_resync.clone();
     tokio::spawn(async move {
         airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
-            refresh_routes_once(&airc, &connected)
+            refresh_routes_once(&airc, &connected, &endpoint_resync)
         })
         .await;
     })
@@ -1510,7 +1512,46 @@ fn spawn_route_refresh(state: Arc<DaemonState>, airc: Airc) -> tokio::task::Join
 /// surface every failure through the diagnostic sink — loud, never
 /// silent. Failures never propagate: the loop's next tick is the retry
 /// path (self-heal doctrine, card 625abe6d).
-async fn refresh_routes_once(airc: &Airc, connected_lan_peers: &std::sync::atomic::AtomicUsize) {
+async fn refresh_routes_once(
+    airc: &Airc,
+    connected_lan_peers: &std::sync::atomic::AtomicUsize,
+    endpoint_resync: &tokio::sync::Notify,
+) {
+    // Adaptable-router reflex: re-detect this node's own routable LAN +
+    // Tailscale IPv4 every tick (cheap, local — no network) and re-advertise
+    // if it moved (router swap, DHCP renew, Tailscale toggle). Without this
+    // the endpoint computed once at daemon start is frozen, so a node that
+    // changes IP keeps advertising a stale, undialable address until it is
+    // manually restarted. Reused below for relay self-election so detection
+    // happens exactly once per tick.
+    let lan_ip = crate::network_commands::advertise_lan_ip();
+    let tailscale_ip = crate::network_commands::detect_tailscale_ip();
+    match airc.refresh_advertised_endpoints(lan_ip, tailscale_ip).await {
+        Ok(true) => {
+            // Changed → nudge the registry loop to republish the corrected
+            // card NOW (edge-triggered; steady-state stays on cadence, so
+            // no spam). Loud: a reachability-affecting change is not silent.
+            let summary = airc
+                .route_endpoints()
+                .map(|endpoints| {
+                    endpoints
+                        .iter()
+                        .map(|endpoint| format!("{endpoint:?}"))
+                        .collect::<Vec<_>>()
+                        .join(" + ")
+                })
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+            eprintln!(
+                "airc daemon: advertised endpoint changed (LAN/Tailscale IP moved) — \
+                 now advertising [{summary}]; resyncing the account-registry card"
+            );
+            endpoint_resync.notify_one();
+        }
+        Ok(false) => {}
+        Err(error) => {
+            eprintln!("airc daemon: advertised-endpoint refresh failed ({error}); retrying next tick");
+        }
+    }
     match airc.refresh_route_discovery().await {
         Ok(snapshot) => {
             // Publish the live LAN-peer count for `Status` to report —
@@ -1552,11 +1593,10 @@ async fn refresh_routes_once(airc: &Airc, connected_lan_peers: &std::sync::atomi
             if snapshot.should_self_elect_as_relay(enrolled) {
                 // Slice 4c: advertise the relay under our ROUTABLE IP(s)
                 // (LAN + Tailscale), never the 0.0.0.0 bind — peers can't
-                // dial a wildcard. Same detection the LAN-listener
-                // advertisement uses. With neither IP, we'd be an
-                // un-dialable relay, so stay a client + say why (loud).
-                let lan_ip = crate::network_commands::advertise_lan_ip();
-                let tailscale_ip = crate::network_commands::detect_tailscale_ip();
+                // dial a wildcard. Reuses the IPs detected once at the top
+                // of this tick (same source the endpoint self-heal uses).
+                // With neither IP, we'd be an un-dialable relay, so stay a
+                // client + say why (loud).
                 if lan_ip.is_none() && tailscale_ip.is_none() {
                     eprintln!(
                         "airc daemon: would self-elect as a relay (no reachable peer/relay, \

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -75,6 +75,16 @@ pub struct DaemonState {
     /// counter each tick — exactly the wiring split used for
     /// `route_endpoints`. `0` until the first refresh completes.
     pub connected_lan_peers: Arc<AtomicUsize>,
+    /// Edge-triggered resync nudge for the account-registry loop. The
+    /// route-refresh loop detects this node's own LAN/Tailscale IP
+    /// changing (router swap, DHCP renew, Tailscale toggle) and, ONLY when
+    /// the advertised endpoint actually changed, notifies this so the
+    /// registry loop republishes the corrected gist card immediately
+    /// instead of waiting up to a full cadence. No change ⇒ no notify ⇒ no
+    /// extra gist write (no spam). Shared like `connected_lan_peers`: the
+    /// airc-lib-owning host loops hold the `Airc` handle, this crate does
+    /// not depend on airc-lib.
+    pub endpoint_resync: Arc<Notify>,
 }
 
 impl DaemonState {
@@ -119,6 +129,7 @@ impl DaemonState {
             runtime,
             route_endpoints: RwLock::new(Vec::new()),
             connected_lan_peers: Arc::new(AtomicUsize::new(0)),
+            endpoint_resync: Arc::new(Notify::new()),
         })
     }
 

--- a/crates/airc-lib/src/lan.rs
+++ b/crates/airc-lib/src/lan.rs
@@ -104,13 +104,22 @@ impl Airc {
         tailscale_ip: Option<Ipv4Addr>,
     ) -> Result<bool, AircError> {
         let current = self.route_endpoints()?;
-        let current_lan = current.iter().find_map(|endpoint| match endpoint {
-            RouteEndpoint::LanTcp { addr } => Some(*addr),
-            _ => None,
+        // `if let` (not a `_ =>` match) so the production no-silent-fallback
+        // gate's `wildcard_enum_match_arm` deny stays satisfied without
+        // enumerating every other RouteEndpoint variant.
+        let current_lan = current.iter().find_map(|endpoint| {
+            if let RouteEndpoint::LanTcp { addr } = endpoint {
+                Some(*addr)
+            } else {
+                None
+            }
         });
-        let current_tailscale = current.iter().find_map(|endpoint| match endpoint {
-            RouteEndpoint::TailscaleTcp { addr } => Some(*addr),
-            _ => None,
+        let current_tailscale = current.iter().find_map(|endpoint| {
+            if let RouteEndpoint::TailscaleTcp { addr } = endpoint {
+                Some(*addr)
+            } else {
+                None
+            }
         });
 
         // The one wildcard listener's port is shared by both rungs. If

--- a/crates/airc-lib/src/lan.rs
+++ b/crates/airc-lib/src/lan.rs
@@ -4,7 +4,7 @@
 //! methods; they do not own socket setup, adapter state, route health,
 //! or frame ingestion.
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use airc_core::PeerId;
 use airc_transport::LanTcpAdapter;
@@ -77,6 +77,87 @@ impl Airc {
         Ok(advertised)
     }
 
+    /// Re-evaluate the dialable endpoints this daemon advertises against
+    /// the CURRENTLY detected LAN / Tailscale IPv4, and apply any change
+    /// in place — the self-heal for a roaming / router-swap / DHCP-renew /
+    /// Tailscale-toggle network change. Without this the endpoint computed
+    /// once at daemon start is frozen, so a node that changes IP keeps
+    /// advertising a stale, undialable address until it is manually
+    /// restarted (the bug this fixes).
+    ///
+    /// The wildcard `0.0.0.0` listener bound by [`Self::listen_lan_advertising`]
+    /// accepts on whatever interfaces the host currently has, so an IP
+    /// change needs NO rebind — rebinding would sever live connections
+    /// (the adapter holds ONE listener for accept + dial + forward). Only
+    /// the ADVERTISED address must follow the new IP, so we reuse the
+    /// already-bound port and upsert / withdraw the `LanTcp` /
+    /// `TailscaleTcp` endpoints to match `lan_ip` / `tailscale_ip`.
+    ///
+    /// Returns `true` iff the advertised set changed — the caller resyncs
+    /// the account-registry card ONLY then (no change ⇒ no gist write ⇒ no
+    /// spam). Edge case: if no listener is bound yet (the daemon started
+    /// with no routable IP) and an IP has since appeared, this binds once
+    /// via [`Self::listen_lan_advertising`].
+    pub async fn refresh_advertised_endpoints(
+        &self,
+        lan_ip: Option<Ipv4Addr>,
+        tailscale_ip: Option<Ipv4Addr>,
+    ) -> Result<bool, AircError> {
+        let current = self.route_endpoints()?;
+        let current_lan = current.iter().find_map(|endpoint| match endpoint {
+            RouteEndpoint::LanTcp { addr } => Some(*addr),
+            _ => None,
+        });
+        let current_tailscale = current.iter().find_map(|endpoint| match endpoint {
+            RouteEndpoint::TailscaleTcp { addr } => Some(*addr),
+            _ => None,
+        });
+
+        // The one wildcard listener's port is shared by both rungs. If
+        // neither rung is advertised, no listener is bound yet.
+        let Some(port) = current_lan.or(current_tailscale).map(|addr| addr.port()) else {
+            if lan_ip.is_some() || tailscale_ip.is_some() {
+                let advertised = self.listen_lan_advertising(lan_ip, tailscale_ip).await?;
+                return Ok(!advertised.is_empty());
+            }
+            return Ok(false);
+        };
+
+        let mut changed = false;
+
+        // LAN rung: upsert on IP change/appearance, withdraw on disappearance.
+        match (lan_ip, current_lan) {
+            (Some(ip), current) if current.map(|addr| addr.ip()) != Some(IpAddr::V4(ip)) => {
+                self.upsert_route_endpoint(RouteEndpoint::LanTcp {
+                    addr: SocketAddr::from((ip, port)),
+                })?;
+                changed = true;
+            }
+            (None, Some(_)) => {
+                self.inner.route_endpoints.remove_lan();
+                changed = true;
+            }
+            _ => {}
+        }
+
+        // Tailscale rung: same diff, so toggling Tailscale on/off heals too.
+        match (tailscale_ip, current_tailscale) {
+            (Some(ip), current) if current.map(|addr| addr.ip()) != Some(IpAddr::V4(ip)) => {
+                self.upsert_route_endpoint(RouteEndpoint::TailscaleTcp {
+                    addr: SocketAddr::from((ip, port)),
+                })?;
+                changed = true;
+            }
+            (None, Some(_)) => {
+                self.inner.route_endpoints.remove_tailscale();
+                changed = true;
+            }
+            _ => {}
+        }
+
+        Ok(changed)
+    }
+
     /// Connect to a TLS-pinned LAN peer and make LAN-TCP the active
     /// direct route for subsequent sends on this handle.
     pub async fn connect_lan(
@@ -107,5 +188,122 @@ impl Airc {
         .map_err(|error| AircError::Transport(error.to_string()))?;
         *guard = Some(adapter.clone());
         Ok(adapter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Network-change self-heal: `refresh_advertised_endpoints` must
+    //! follow this node's LAN/Tailscale IP without a rebind, and report a
+    //! change ONLY when the advertised set actually moved (so the caller
+    //! resyncs the gist card edge-triggered, never on every tick).
+    use super::*;
+    use crate::route::RouteEndpoint;
+    use tempfile::tempdir;
+
+    async fn test_airc() -> (tempfile::TempDir, Airc) {
+        let dir = tempdir().unwrap();
+        let airc = Airc::open_with_wire_root_for_test(
+            dir.path().join("machine/.airc"),
+            dir.path().join("wire"),
+        )
+        .await
+        .unwrap();
+        (dir, airc)
+    }
+
+    fn lan_addr(endpoints: &[RouteEndpoint]) -> Option<SocketAddr> {
+        endpoints.iter().find_map(|e| match e {
+            RouteEndpoint::LanTcp { addr } => Some(*addr),
+            _ => None,
+        })
+    }
+    fn tailscale_addr(endpoints: &[RouteEndpoint]) -> Option<SocketAddr> {
+        endpoints.iter().find_map(|e| match e {
+            RouteEndpoint::TailscaleTcp { addr } => Some(*addr),
+            _ => None,
+        })
+    }
+
+    // what this catches: the frozen-endpoint bug — a node whose LAN IP
+    // moved kept advertising the stale address. The new IP must replace
+    // the old on the SAME port, and the call must report `changed`.
+    #[tokio::test]
+    async fn lan_ip_change_readvertises_same_port_and_reports_changed() {
+        let (_dir, airc) = test_airc().await;
+        // Seed an already-advertised LAN endpoint on a known port.
+        airc.upsert_route_endpoint(RouteEndpoint::LanTcp {
+            addr: SocketAddr::from((Ipv4Addr::new(10, 0, 1, 16), 7777)),
+        })
+        .unwrap();
+
+        let changed = airc
+            .refresh_advertised_endpoints(Some(Ipv4Addr::new(192, 168, 1, 232)), None)
+            .await
+            .unwrap();
+
+        assert!(changed, "an IP move must be reported as a change");
+        let endpoints = airc.route_endpoints().unwrap();
+        assert_eq!(
+            lan_addr(&endpoints),
+            Some(SocketAddr::from((Ipv4Addr::new(192, 168, 1, 232), 7777))),
+            "new IP must be advertised on the SAME bound port (no rebind)"
+        );
+    }
+
+    // what this catches: spam. A tick where nothing moved must NOT report
+    // a change, or the registry loop would rewrite the gist every tick.
+    #[tokio::test]
+    async fn unchanged_ip_reports_no_change() {
+        let (_dir, airc) = test_airc().await;
+        airc.upsert_route_endpoint(RouteEndpoint::LanTcp {
+            addr: SocketAddr::from((Ipv4Addr::new(10, 0, 1, 16), 7777)),
+        })
+        .unwrap();
+
+        let changed = airc
+            .refresh_advertised_endpoints(Some(Ipv4Addr::new(10, 0, 1, 16)), None)
+            .await
+            .unwrap();
+        assert!(!changed, "same IP ⇒ no change ⇒ no resync (no spam)");
+    }
+
+    // what this catches: Tailscale toggle. Turning Tailscale on adds the
+    // rung on the same port; turning it off withdraws it — both reported.
+    #[tokio::test]
+    async fn tailscale_toggle_adds_then_withdraws() {
+        let (_dir, airc) = test_airc().await;
+        airc.upsert_route_endpoint(RouteEndpoint::LanTcp {
+            addr: SocketAddr::from((Ipv4Addr::new(192, 168, 1, 232), 7777)),
+        })
+        .unwrap();
+
+        // Tailscale comes up.
+        let changed = airc
+            .refresh_advertised_endpoints(
+                Some(Ipv4Addr::new(192, 168, 1, 232)),
+                Some(Ipv4Addr::new(100, 79, 156, 3)),
+            )
+            .await
+            .unwrap();
+        assert!(changed);
+        let endpoints = airc.route_endpoints().unwrap();
+        assert_eq!(
+            tailscale_addr(&endpoints),
+            Some(SocketAddr::from((Ipv4Addr::new(100, 79, 156, 3), 7777))),
+            "Tailscale rung shares the one wildcard port"
+        );
+
+        // Tailscale goes away → withdrawn.
+        let changed = airc
+            .refresh_advertised_endpoints(Some(Ipv4Addr::new(192, 168, 1, 232)), None)
+            .await
+            .unwrap();
+        assert!(changed);
+        assert_eq!(
+            tailscale_addr(&airc.route_endpoints().unwrap()),
+            None,
+            "Tailscale off must withdraw the stale rung"
+        );
     }
 }

--- a/crates/airc-lib/src/registry_refresh.rs
+++ b/crates/airc-lib/src/registry_refresh.rs
@@ -287,6 +287,7 @@ pub async fn run_loop<S>(
     store: S,
     gate: RegistryRefreshGate,
     config: RegistryRefreshConfig,
+    resync: &tokio::sync::Notify,
     shutdown: impl Future<Output = ()>,
 ) where
     S: AccountRegistryStore,
@@ -303,29 +304,49 @@ pub async fn run_loop<S>(
         tokio::select! {
             biased;
             _ = &mut shutdown => break,
+            // Edge-triggered resync: the route-refresh loop detected this
+            // node's advertised endpoint change (IP move / Tailscale
+            // toggle) and nudged us to republish the corrected card NOW,
+            // rather than waiting up to a full cadence. Only fires on an
+            // actual change, so it adds no steady-state gist writes (no
+            // spam). `Notify` stores one permit if the nudge lands during
+            // a tick, so the wakeup is never lost.
+            _ = resync.notified() => {
+                gated_tick(&gate, &airc, &store, &sink).await;
+            }
             _ = ticker.tick() => {
-                if let Some(block) = gate.block().await {
-                    let code = match &block {
-                        GateBlock::Hermetic(_) => DiagnosticCode::AccountRegistryHermeticSkip,
-                        GateBlock::GhNotReady => DiagnosticCode::AccountRegistryPublishFailed,
-                    };
-                    sink.emit(
-                        DiagnosticEvent::warn(
-                            DiagnosticComponent::Daemon,
-                            code,
-                            format!("account registry tick skipped: {block}"),
-                        ),
-                    );
-                    continue;
-                }
-                // run_tick already emits typed diagnostics on failure;
-                // the loop deliberately swallows the Err and keeps
-                // ticking (self-heal: a transient gh failure must not
-                // kill discovery for the daemon's lifetime).
-                let _ = run_tick(&airc, &store, &sink).await;
+                gated_tick(&gate, &airc, &store, &sink).await;
             }
         }
     }
+}
+
+/// One gated publish/refresh tick: skip LOUDLY if the transport gate
+/// blocks, else run the tick. `run_tick` already emits typed diagnostics
+/// on failure; callers deliberately swallow the `Err` and keep ticking
+/// (self-heal: a transient gh failure must not kill discovery for the
+/// daemon's lifetime).
+async fn gated_tick<S>(
+    gate: &RegistryRefreshGate,
+    airc: &Airc,
+    store: &S,
+    sink: &StderrJsonDiagnosticSink,
+) where
+    S: AccountRegistryStore,
+{
+    if let Some(block) = gate.block().await {
+        let code = match &block {
+            GateBlock::Hermetic(_) => DiagnosticCode::AccountRegistryHermeticSkip,
+            GateBlock::GhNotReady => DiagnosticCode::AccountRegistryPublishFailed,
+        };
+        sink.emit(DiagnosticEvent::warn(
+            DiagnosticComponent::Daemon,
+            code,
+            format!("account registry tick skipped: {block}"),
+        ));
+        return;
+    }
+    let _ = run_tick(airc, store, sink).await;
 }
 
 #[cfg(test)]
@@ -640,11 +661,13 @@ exit 1
             cadence: Duration::from_secs(3600),
         };
         let handle = tokio::spawn(async move {
+            let resync = tokio::sync::Notify::new();
             run_loop(
                 airc,
                 store,
                 RegistryRefreshGate::Always,
                 config,
+                &resync,
                 async move {
                     let _ = rx.await;
                 },

--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -155,6 +155,19 @@ impl RouteEndpointTable {
         endpoints.sort_by_key(|endpoint| RouteEndpointKind::from(endpoint));
         endpoints
     }
+
+    /// Withdraw the advertised LAN endpoint (network-change self-heal:
+    /// the host lost its routable LAN IP). Idempotent — a no-op if none
+    /// is advertised.
+    pub(crate) fn remove_lan(&self) {
+        self.endpoints.remove(&RouteEndpointKind::LanTcp);
+    }
+
+    /// Withdraw the advertised Tailscale endpoint (e.g. Tailscale was
+    /// turned off). Idempotent.
+    pub(crate) fn remove_tailscale(&self) {
+        self.endpoints.remove(&RouteEndpointKind::TailscaleTcp);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/integrations/grid-resiliency/Dockerfile
+++ b/integrations/grid-resiliency/Dockerfile
@@ -1,0 +1,35 @@
+# airc node image for the grid-resiliency harness.
+#
+# A minimal, real airc daemon node — the unit the resiliency scenarios spin
+# up N of, on controllable Docker networks, to test the grid forming,
+# delivering, and self-healing (partition, node death, relay re-election)
+# the way it must in real life.
+#
+# Build context is the airc repo root (so the workspace is available):
+#   docker build -f integrations/grid-resiliency/Dockerfile -t airc-node:test .
+# CI builds airc on stock ubuntu with only the Rust toolchain, so the
+# official rust image (which ships a C toolchain) needs no extra apt deps.
+
+FROM rust:1-bookworm AS build
+WORKDIR /src
+COPY . .
+# Release build of just the CLI — the `airc` binary is the whole node.
+RUN cargo build --release -p airc-cli
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/airc /usr/local/bin/airc
+# Each node owns its own home (identity + ORM + sockets) under /data, so
+# containers never share mesh state.
+ENV AIRC_HOME=/data/.airc
+RUN useradd --create-home --uid 10001 airc && mkdir -p /data && chown -R airc /data
+USER airc
+WORKDIR /data
+# The scenario runner drives lifecycle (init / enrol / send / read) via
+# `docker exec`; the container's job is just to BE a reachable node. The
+# entrypoint is the airc binary so `docker run airc-node <verb>` works and
+# the scenario can override the command per node.
+ENTRYPOINT ["airc"]
+CMD ["--help"]


### PR DESCRIPTION
## The bug (our own fleet hit it today)
The dialable LAN/Tailscale endpoint a daemon advertises in its account-registry gist card was computed **once at startup** and frozen. When the host's IP moved — router swap, DHCP renew, roaming, Tailscale on/off — the daemon kept advertising the **stale, undialable address** until someone manually `airc stop && airc daemon`'d it.

Today BigMama moved `10.0.1.x → 192.168.1.x` (onto the Macs' subnet) and the only way to pick it up was a manual restart. That manual step **is** the bug: with machines going on/offline all the time, the daemon must re-advertise itself with no human in the loop.

## The fix — first reflex of the adaptable router
- **`Airc::refresh_advertised_endpoints(lan_ip, tailscale_ip)`** diffs detected IPs vs the currently-advertised `LanTcp`/`TailscaleTcp` endpoints and applies any change **in place**. The wildcard `0.0.0.0` listener already accepts on whatever interfaces the host has, so an IP move needs **no rebind** (rebinding would sever live connections) — we reuse the bound port and upsert the new IP / withdraw a vanished one. Returns whether anything changed.
- The **route-refresh loop** (every 60s, already detects LAN+Tailscale IPs for relay election) calls this each tick — cheap, local, no network.
- On an **actual change only**, it nudges the registry loop (new edge-triggered `endpoint_resync` `Notify` on `DaemonState`) to republish the corrected gist card **immediately** rather than waiting up to the 120s cadence.

### Smart / organized / efficient / no spam
- Detection is cheap + frequent (60s, local). The expensive gist write happens **only when the endpoint actually moved** (edge-triggered). No change ⇒ no notify ⇒ no extra write. Steady state is unchanged.
- Covers **LAN IP move AND Tailscale on/off** (withdrawal added: `RouteEndpointTable::remove_lan`/`remove_tailscale`).

## Tests
`airc-lib lan::tests`:
- IP move → re-advertises on the **same port** + reports `changed`.
- Unchanged IP → reports **no change** (anti-spam guard).
- Tailscale toggle → adds then withdraws the rung.

`registry_refresh::run_loop` gains the resync `select!` arm; existing acceptance + shutdown tests still green. Full `airc-lib` clippy + targeted tests pass.

## Note
An untracked `integrations/grid-resiliency/Dockerfile` (the airc-node image for the upcoming resiliency harness) got included — it's a minimal rust→debian build, no behavior impact, on-theme for this resiliency work. Can split out if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)