### PR TITLE
perf(command-bus): debounce per-send peer-registry disk load (-46% LAN RTT)

### DIFF
--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -10,6 +10,7 @@
 //! for to interrogate the running substrate.
 
 pub mod probe;
+pub mod timing;
 
 use std::collections::BTreeMap;
 use std::io::Write;

--- a/crates/airc-diagnostics/src/timing.rs
+++ b/crates/airc-diagnostics/src/timing.rs
@@ -84,6 +84,34 @@ pub fn timed<T>(seam: &'static str, f: impl FnOnce() -> T) -> T {
     value
 }
 
+/// Scoped timer for an `.await` span (where a closure doesn't fit). Captures
+/// the start `Instant` ONLY when recording is enabled — so a disabled hot path
+/// pays a single relaxed atomic load and no `clock_gettime`. Record on `stop`:
+///
+/// ```ignore
+/// let span = timing::start();
+/// do_the_await().await?;
+/// span.stop("airc.append_sent");
+/// ```
+#[must_use]
+pub fn start() -> ScopedTimer {
+    ScopedTimer(is_enabled().then(Instant::now))
+}
+
+/// Returned by [`start`]; call [`ScopedTimer::stop`] after the measured span.
+pub struct ScopedTimer(Option<Instant>);
+
+impl ScopedTimer {
+    /// Record the elapsed time under `seam`. No-op if timing was disabled when
+    /// [`start`] was called (no `Instant` was captured).
+    #[inline]
+    pub fn stop(self, seam: &'static str) {
+        if let Some(start) = self.0 {
+            record(seam, start.elapsed().as_nanos() as u64);
+        }
+    }
+}
+
 /// Snapshot every seam (sorted by name).
 pub fn snapshot() -> Vec<(&'static str, SeamStat)> {
     registry()

--- a/crates/airc-diagnostics/src/timing.rs
+++ b/crates/airc-diagnostics/src/timing.rs
@@ -1,0 +1,134 @@
+//! Seam timing accumulator — summed per-seam latency for mechanic-grade
+//! localization.
+//!
+//! Complements [`probe!`](crate::probe) / [`time_probe!`](crate::time_probe):
+//! those are the span/event channel (one event per hit, routed via `tracing`);
+//! this is the SUMMED channel — aggregate count + total + max per named seam
+//! across many iterations, the shape a latency bench reads to find "where did
+//! the milliseconds go." Sink-free, subscriber-free, std-only.
+//!
+//! **Opt-in, near-zero cost when off.** Recording is gated by an atomic flag
+//! ([`enable`]/[`disable`], default off). A seam call site on a hot path that
+//! isn't being profiled pays one relaxed atomic load and nothing else — no
+//! `Instant`, no lock. A bench calls [`enable`] + [`reset`] around its window
+//! and reads [`snapshot`].
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Aggregated samples for one seam.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct SeamStat {
+    pub count: u64,
+    pub total_ns: u64,
+    pub max_ns: u64,
+}
+
+impl SeamStat {
+    pub fn avg_ns(&self) -> u64 {
+        self.total_ns.checked_div(self.count).unwrap_or(0)
+    }
+    pub fn avg_us(&self) -> u64 {
+        self.avg_ns() / 1_000
+    }
+}
+
+fn registry() -> &'static Mutex<BTreeMap<&'static str, SeamStat>> {
+    static REG: OnceLock<Mutex<BTreeMap<&'static str, SeamStat>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Turn recording on (a bench calls this before its measured window).
+pub fn enable() {
+    ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Turn recording off (the production default).
+pub fn disable() {
+    ENABLED.store(false, Ordering::Relaxed);
+}
+
+#[inline]
+fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// Record one duration sample (nanoseconds) for `seam`. No-op when disabled.
+pub fn record(seam: &'static str, nanos: u64) {
+    if !is_enabled() {
+        return;
+    }
+    let mut map = registry().lock().unwrap_or_else(|p| p.into_inner());
+    let stat = map.entry(seam).or_default();
+    stat.count += 1;
+    stat.total_ns += nanos;
+    if nanos > stat.max_ns {
+        stat.max_ns = nanos;
+    }
+}
+
+/// Time a synchronous closure and record it under `seam`. When disabled, runs
+/// the closure directly — not even an `Instant::now()`.
+#[inline]
+pub fn timed<T>(seam: &'static str, f: impl FnOnce() -> T) -> T {
+    if !is_enabled() {
+        return f();
+    }
+    let start = Instant::now();
+    let value = f();
+    record(seam, start.elapsed().as_nanos() as u64);
+    value
+}
+
+/// Snapshot every seam (sorted by name).
+pub fn snapshot() -> Vec<(&'static str, SeamStat)> {
+    registry()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .iter()
+        .map(|(k, v)| (*k, *v))
+        .collect()
+}
+
+/// Clear all samples (a bench calls this before its measured window).
+pub fn reset() {
+    registry().lock().unwrap_or_else(|p| p.into_inner()).clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: disabled = no-op (the production default costs nothing);
+    // enabled = aggregates count/total/max; reset clears.
+    #[test]
+    fn records_only_when_enabled_and_aggregates() {
+        reset();
+        disable();
+        record("seam.a", 100);
+        assert!(snapshot().is_empty(), "disabled records nothing");
+
+        enable();
+        record("seam.a", 100);
+        record("seam.a", 300);
+        let snap = snapshot();
+        let (name, stat) = snap.iter().find(|(n, _)| *n == "seam.a").expect("seam.a");
+        assert_eq!(*name, "seam.a");
+        assert_eq!(stat.count, 2);
+        assert_eq!(stat.avg_ns(), 200);
+        assert_eq!(stat.max_ns, 300);
+
+        // timed() runs the closure and records when enabled.
+        let out = timed("seam.b", || 7);
+        assert_eq!(out, 7);
+        assert!(snapshot().iter().any(|(n, _)| *n == "seam.b"));
+
+        reset();
+        assert!(snapshot().is_empty(), "reset clears");
+        disable();
+    }
+}

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -173,6 +173,9 @@ pub(crate) struct AircInner {
     /// is unified. See [`crate::route::dial_quarantine`].
     pub(crate) dial_quarantine: Arc<std::sync::Mutex<crate::route::DialQuarantine>>,
     pub(crate) lamport_clock: AtomicU64,
+    /// Epoch-ms of the last send-path peer-registry sync. Debounces the
+    /// per-send disk load (see `sync_account_peer_registry_debounced`).
+    pub(crate) peer_sync_last_ms: AtomicU64,
     pub(crate) lan_tcp: Mutex<Option<LanTcpAdapter>>,
     pub(crate) lan_subscriber: Mutex<Option<FrameSubscriber>>,
     pub(crate) relay: Mutex<Option<RelayAdapter>>,
@@ -443,6 +446,7 @@ impl Airc {
                     crate::route::DialQuarantine::default(),
                 )),
                 lamport_clock: AtomicU64::new(0),
+                peer_sync_last_ms: AtomicU64::new(0),
                 lan_tcp: Mutex::new(None),
                 lan_subscriber: Mutex::new(None),
                 relay: Mutex::new(None),
@@ -1020,6 +1024,7 @@ impl Airc {
             // backoff is unified regardless of which handle runs discovery.
             dial_quarantine: self.inner.dial_quarantine.clone(),
             lamport_clock: AtomicU64::new(self.inner.lamport_clock.load(Ordering::Relaxed)),
+            peer_sync_last_ms: AtomicU64::new(0),
             lan_tcp: Mutex::new(None),
             lan_subscriber: Mutex::new(None),
             relay: Mutex::new(None),
@@ -1108,6 +1113,31 @@ impl Airc {
         }
         let cached = mesh_identity::resolve(self.coordinator_store()).await?;
         Ok(cached.as_mesh_identity())
+    }
+
+    /// Send-path peer-registry sync, DEBOUNCED. `sync_account_peer_registry`
+    /// loads the peer registry from disk on every call; on the hot outbound
+    /// send path that per-message disk load dominated latency (~1ms/send,
+    /// profiled via the LAN latency bench — it was ~95% of `request()`'s send
+    /// leg, vs ~52µs for the actual transport). The verifier registry (peer
+    /// pubkeys, used for INBOUND verification) does not change between most
+    /// sends, so loading it per outbound message is wasted I/O on the critical
+    /// path. Debounce to at most once per `MIN_SYNC_INTERVAL_MS`: a burst of
+    /// sends pays the disk load once. Freshness for a newly-trusted peer stays
+    /// bounded by the interval, and the route-refresh tick still calls the
+    /// undebounced `sync_account_peer_registry` directly.
+    pub(crate) async fn sync_account_peer_registry_debounced(&self) -> Result<(), AircError> {
+        const MIN_SYNC_INTERVAL_MS: u64 = 1_000;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let last = self.inner.peer_sync_last_ms.load(Ordering::Relaxed);
+        if now != 0 && now.saturating_sub(last) < MIN_SYNC_INTERVAL_MS {
+            return Ok(()); // recently synced — skip the per-send disk load
+        }
+        self.inner.peer_sync_last_ms.store(now, Ordering::Relaxed);
+        self.sync_account_peer_registry().await
     }
 
     pub(crate) async fn sync_account_peer_registry(&self) -> Result<(), AircError> {

--- a/crates/airc-lib/src/command_bus.rs
+++ b/crates/airc-lib/src/command_bus.rs
@@ -177,7 +177,9 @@ impl Airc {
     ) -> Result<PendingCommand, AircError> {
         let correlation_id = Uuid::new_v4();
         let deadline_at_ms = now_ms()? + deadline.as_millis() as u64;
+        let __t_sub = std::time::Instant::now();
         let reply_stream = self.subscribe().await?;
+        airc_diagnostics::timing::record("airc.req.subscribe", __t_sub.elapsed().as_nanos() as u64);
 
         headers.insert(
             HEADER_AIRC_CORRELATION_ID.into(),
@@ -189,8 +191,13 @@ impl Airc {
         );
         headers.insert(HEADER_AIRC_DEADLINE.into(), deadline_at_ms.to_string());
 
+        let __t_send = std::time::Instant::now();
         self.send_frame_to(airc_protocol::FrameKind::Message, target, body, headers)
             .await?;
+        airc_diagnostics::timing::record(
+            "airc.req.send_frame",
+            __t_send.elapsed().as_nanos() as u64,
+        );
 
         Ok(PendingCommand {
             correlation_id,

--- a/crates/airc-lib/src/command_bus.rs
+++ b/crates/airc-lib/src/command_bus.rs
@@ -177,9 +177,9 @@ impl Airc {
     ) -> Result<PendingCommand, AircError> {
         let correlation_id = Uuid::new_v4();
         let deadline_at_ms = now_ms()? + deadline.as_millis() as u64;
-        let __t_sub = std::time::Instant::now();
+        let __sub = airc_diagnostics::timing::start();
         let reply_stream = self.subscribe().await?;
-        airc_diagnostics::timing::record("airc.req.subscribe", __t_sub.elapsed().as_nanos() as u64);
+        __sub.stop("airc.req.subscribe");
 
         headers.insert(
             HEADER_AIRC_CORRELATION_ID.into(),
@@ -191,13 +191,10 @@ impl Airc {
         );
         headers.insert(HEADER_AIRC_DEADLINE.into(), deadline_at_ms.to_string());
 
-        let __t_send = std::time::Instant::now();
+        let __send = airc_diagnostics::timing::start();
         self.send_frame_to(airc_protocol::FrameKind::Message, target, body, headers)
             .await?;
-        airc_diagnostics::timing::record(
-            "airc.req.send_frame",
-            __t_send.elapsed().as_nanos() as u64,
-        );
+        __send.stop("airc.req.send_frame");
 
         Ok(PendingCommand {
             correlation_id,

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -155,15 +155,12 @@ impl Airc {
         // event_id in the broadcast ring BEFORE the wire write, so the
         // wire subscriber's later re-read of the same frame still skips
         // a duplicate fan-out.
-        let __t_append = std::time::Instant::now();
+        let __append = airc_diagnostics::timing::start();
         self.append_sent_frame(frame.clone()).await?;
-        airc_diagnostics::timing::record(
-            "airc.append_sent",
-            __t_append.elapsed().as_nanos() as u64,
-        );
-        let __t_route = std::time::Instant::now();
+        __append.stop("airc.append_sent");
+        let __route = airc_diagnostics::timing::start();
         self.execute_send_route(route.kind, room, frame).await?;
-        airc_diagnostics::timing::record("airc.exec_route", __t_route.elapsed().as_nanos() as u64);
+        __route.stop("airc.exec_route");
         Ok(SendFrameResult {
             event_id,
             lamport,

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -107,7 +107,10 @@ impl Airc {
                 .daemon_send_frame(room, kind, target, body, headers)
                 .await;
         }
-        self.sync_account_peer_registry().await?;
+        // Debounced: the verifier registry is for INBOUND verification and
+        // rarely changes between sends; loading it from disk per outbound
+        // message was ~95% of send latency (profiled). Sync at most once/sec.
+        self.sync_account_peer_registry_debounced().await?;
         let route = self.resolve_send_route(kind)?;
         let event_id = EventId::new();
         let occurred_at_ms = now_ms()?;
@@ -129,12 +132,14 @@ impl Airc {
                 signature: Signature::Unsigned,
             },
         };
-        frame.envelope.signature = self
-            .inner
-            .identity
-            .keypair
-            .sign_envelope(&frame.envelope, self.inner.identity.peer_id, 0)
-            .map_err(|error| AircError::Crypto(error.to_string()))?;
+        frame.envelope.signature = airc_diagnostics::timing::timed("airc.sign", || {
+            self.inner.identity.keypair.sign_envelope(
+                &frame.envelope,
+                self.inner.identity.peer_id,
+                0,
+            )
+        })
+        .map_err(|error| AircError::Crypto(error.to_string()))?;
         // Deliver-first, persist-then-transport. `append_sent_frame`
         // persists to the local ORM (durability source of truth) and
         // fans out to in-process subscribers via `live_tx`;
@@ -150,8 +155,15 @@ impl Airc {
         // event_id in the broadcast ring BEFORE the wire write, so the
         // wire subscriber's later re-read of the same frame still skips
         // a duplicate fan-out.
+        let __t_append = std::time::Instant::now();
         self.append_sent_frame(frame.clone()).await?;
+        airc_diagnostics::timing::record(
+            "airc.append_sent",
+            __t_append.elapsed().as_nanos() as u64,
+        );
+        let __t_route = std::time::Instant::now();
         self.execute_send_route(route.kind, room, frame).await?;
+        airc_diagnostics::timing::record("airc.exec_route", __t_route.elapsed().as_nanos() as u64);
         Ok(SendFrameResult {
             event_id,
             lamport,

--- a/crates/airc-lib/tests/lan_latency_bench.rs
+++ b/crates/airc-lib/tests/lan_latency_bench.rs
@@ -1,0 +1,140 @@
+//! Manual latency bench for the LAN request/reply path.
+//!
+//! Sequential small request→reply round-trips over a real LAN TCP+TLS
+//! connection — the shape that exposes Nagle's algorithm + delayed-ACK
+//! interaction most clearly (each round-trip waits on the prior, small frames).
+//! Used to measure the TCP_NODELAY change on the LAN adapter.
+//!
+//! `#[ignore]` — it's a measurement (prints a latency table), not a CI assertion.
+//! Run: `cargo test -p airc-lib --test lan_latency_bench -- --ignored --nocapture`
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use airc_core::{Body, Headers, MentionTarget, PeerId};
+use airc_lib::Airc;
+use airc_protocol::{
+    HEADER_AIRC_COMMAND_KIND, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_REPLY_TO,
+    HEADER_FORGE_BODY_HINT,
+};
+use futures::stream::StreamExt;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+/// Returns (send_leg_us, wait_leg_us): time for `request()` (encode→sign→flush
+/// to the wire) vs `await_reply()` (peer processes + replies + delivery back).
+/// Splitting the round-trip localizes which half owns the latency.
+async fn one_round_trip(alice: &Airc) -> (u64, u64) {
+    let mut headers = Headers::new();
+    headers.insert(HEADER_AIRC_COMMAND_KIND.into(), "lat.ping".into());
+    let t0 = Instant::now();
+    let pending = alice
+        .request(
+            MentionTarget::All,
+            headers,
+            Body::text("ping"),
+            Duration::from_secs(3),
+        )
+        .await
+        .expect("request");
+    let send_us = t0.elapsed().as_micros() as u64;
+    let t1 = Instant::now();
+    alice.await_reply(pending).await.expect("reply");
+    let wait_us = t1.elapsed().as_micros() as u64;
+    (send_us, wait_us)
+}
+
+#[test]
+#[ignore = "manual latency measurement; run with --ignored --nocapture"]
+fn lan_request_reply_latency() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let alice_home = TempDir::new().unwrap();
+        let bob_home = TempDir::new().unwrap();
+        let alice = Airc::open(alice_home.path()).await.unwrap();
+        let bob = Airc::open(bob_home.path()).await.unwrap();
+        let alice_spec = alice.peer_spec().parse().unwrap();
+        let bob_spec = bob.peer_spec().parse().unwrap();
+        alice.add_peer(bob_spec).await.unwrap();
+        bob.add_peer(alice_spec).await.unwrap();
+        alice.join("lat").await.unwrap();
+        bob.join("lat").await.unwrap();
+        let bob_addr = bob
+            .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        alice.connect_lan(bob_addr, bob.peer_id()).await.unwrap();
+
+        // Persistent echo responder.
+        let bob_handle = bob.clone();
+        tokio::spawn(async move {
+            let mut stream = bob_handle.subscribe().await.unwrap();
+            while let Some(ev) = stream.next().await {
+                let Ok(event) = ev else { continue };
+                if event.peer_id == bob_handle.peer_id() {
+                    continue;
+                }
+                let (Some(corr), Some(rt)) = (
+                    event.headers.get(HEADER_AIRC_CORRELATION_ID),
+                    event.headers.get(HEADER_AIRC_REPLY_TO),
+                ) else {
+                    continue;
+                };
+                let correlation_id = Uuid::parse_str(corr).unwrap();
+                let reply_to = PeerId::from_uuid(Uuid::parse_str(rt).unwrap());
+                let mut h = Headers::new();
+                h.insert(HEADER_FORGE_BODY_HINT.into(), "lat.pong".into());
+                let _ = bob_handle
+                    .reply(reply_to, correlation_id, h, Body::text("pong"))
+                    .await;
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        const N: usize = 200;
+        for _ in 0..5 {
+            one_round_trip(&alice).await; // warmup
+        }
+        // Turn on seam timing AFTER warmup so the breakdown reflects steady state.
+        airc_diagnostics::timing::reset();
+        airc_diagnostics::timing::enable();
+        let mut total = Vec::with_capacity(N);
+        let mut send = Vec::with_capacity(N);
+        let mut wait = Vec::with_capacity(N);
+        for _ in 0..N {
+            let t0 = Instant::now();
+            let (s, w) = one_round_trip(&alice).await;
+            total.push(t0.elapsed().as_micros() as u64);
+            send.push(s);
+            wait.push(w);
+        }
+        let report = |label: &str, v: &mut Vec<u64>| {
+            v.sort_unstable();
+            let n = v.len();
+            println!(
+                "  {label:<6} avg={:>6}us  p50={:>6}us  p99={:>6}us  max={:>6}us",
+                v.iter().sum::<u64>() / n as u64,
+                v[n / 2],
+                v[n * 99 / 100],
+                v[n - 1],
+            );
+        };
+        airc_diagnostics::timing::disable();
+        println!("\n  LAN req/reply latency, {N} sequential round-trips:");
+        report("total", &mut total);
+        report("send", &mut send); // request(): encode→sign→flush to wire
+        report("wait", &mut wait); // await_reply(): peer process + reply delivery
+
+        // Per-seam internal breakdown (airc_diagnostics::timing). Counts span
+        // BOTH legs (request send + reply send both go through the transport).
+        println!("\n  internal seam breakdown (avg over all sends in the window):");
+        for (seam, stat) in airc_diagnostics::timing::snapshot() {
+            println!(
+                "  {seam:<16} count={:>4}  avg={:>6}us  max={:>6}us",
+                stat.count,
+                stat.avg_us(),
+                stat.max_ns / 1_000,
+            );
+        }
+    });
+}

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -235,7 +235,7 @@ impl Transport for LanTcpAdapter {
         // than being silently dropped by the write loop after the
         // caller already saw Ok. Grievance §9: `send()` must mean
         // something measurable.
-        let __send_start = std::time::Instant::now();
+        let __send = airc_diagnostics::timing::start();
         let payload =
             airc_diagnostics::timing::timed("lan.serialize", || serde_json::to_vec(&frame))?;
         if payload.len() > MAX_FRAME_BYTES as usize {
@@ -287,21 +287,15 @@ impl Transport for LanTcpAdapter {
         // dropped sender (write loop hit a dead socket) resolves to Err
         // and counts as non-delivery.
         let mut delivered_any = false;
-        let __flush_start = std::time::Instant::now();
+        let __flush = airc_diagnostics::timing::start();
         for flushed_rx in pending {
             match flushed_rx.await {
                 Ok(()) => delivered_any = true,
                 Err(_dropped) => last_error = Some(LanTcpError::NoActivePeers),
             }
         }
-        airc_diagnostics::timing::record(
-            "lan.flush_ack",
-            __flush_start.elapsed().as_nanos() as u64,
-        );
-        airc_diagnostics::timing::record(
-            "lan.send_total",
-            __send_start.elapsed().as_nanos() as u64,
-        );
+        __flush.stop("lan.flush_ack");
+        __send.stop("lan.send_total");
         if delivered_any {
             Ok(())
         } else {

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -235,7 +235,9 @@ impl Transport for LanTcpAdapter {
         // than being silently dropped by the write loop after the
         // caller already saw Ok. Grievance §9: `send()` must mean
         // something measurable.
-        let payload = serde_json::to_vec(&frame)?;
+        let __send_start = std::time::Instant::now();
+        let payload =
+            airc_diagnostics::timing::timed("lan.serialize", || serde_json::to_vec(&frame))?;
         if payload.len() > MAX_FRAME_BYTES as usize {
             return Err(LanTcpError::FrameTooLarge {
                 announced: u32::try_from(payload.len()).unwrap_or(u32::MAX),
@@ -285,12 +287,21 @@ impl Transport for LanTcpAdapter {
         // dropped sender (write loop hit a dead socket) resolves to Err
         // and counts as non-delivery.
         let mut delivered_any = false;
+        let __flush_start = std::time::Instant::now();
         for flushed_rx in pending {
             match flushed_rx.await {
                 Ok(()) => delivered_any = true,
                 Err(_dropped) => last_error = Some(LanTcpError::NoActivePeers),
             }
         }
+        airc_diagnostics::timing::record(
+            "lan.flush_ack",
+            __flush_start.elapsed().as_nanos() as u64,
+        );
+        airc_diagnostics::timing::record(
+            "lan.send_total",
+            __send_start.elapsed().as_nanos() as u64,
+        );
         if delivered_any {
             Ok(())
         } else {

--- a/crates/airc-transport/src/signed.rs
+++ b/crates/airc-transport/src/signed.rs
@@ -105,10 +105,11 @@ where
     async fn send(&self, mut frame: Frame) -> Result<(), Self::Error> {
         // Sign over the canonical bytes of the envelope (excluding the
         // signature field itself per signature.rs's contract).
-        let signature = self
-            .keypair
-            .sign_envelope(&frame.envelope, self.self_peer_id, self.key_id)
-            .map_err(SignedError::Sign)?;
+        let signature = airc_diagnostics::timing::timed("transport.sign", || {
+            self.keypair
+                .sign_envelope(&frame.envelope, self.self_peer_id, self.key_id)
+        })
+        .map_err(SignedError::Sign)?;
         frame.envelope.signature = signature;
         self.inner.send(frame).await.map_err(SignedError::Inner)
     }

--- a/docs/stream-plane-crypto.md
+++ b/docs/stream-plane-crypto.md
@@ -1,0 +1,87 @@
+# Stream-plane crypto: sign the handle, not the frame
+
+**Status:** design / spec (not yet built). Motivated by a profiled latency finding
+(see `crates/airc-lib/tests/lan_latency_bench.rs` + `airc-diagnostics::timing`).
+
+## The problem
+
+airc wraps every transport in `SignedTransport`, which applies a **per-frame
+Ed25519 signature** (`sign_envelope`). Measured cost: **~113µs per frame** (sign),
+plus a matching inbound `verify` on the receiver.
+
+For the **control plane** (commands, presence, lifecycle — discrete, low-rate)
+this is correct and cheap *enough*: it provides **end-to-end authenticity that
+survives relay hops**. A relay forwards a frame but cannot forge a peer's
+signature; point-to-point TLS alone cannot give that (the relay terminates TLS).
+So the app-level signature is doing real work on relayed control traffic — keep it.
+
+For the **data/stream plane** (WebRTC media, UDP packet streams, high-rate
+DataChannels) per-frame Ed25519 is a throughput killer. At media rates (tens of
+frames/sec/track × many tracks × many peers) 113µs/frame of asymmetric crypto
+dominates and does not scale.
+
+## The model: two planes, keyed off `FrameKind` / `RouteClass`
+
+| Plane | Traffic | Per-frame auth | Why |
+|---|---|---|---|
+| **Control** | commands, presence, lifecycle (`Message`/`Control` at command rate) | per-frame **Ed25519** | end-to-end authenticity across relays; rate is low |
+| **Stream** | WebRTC media, UDP streams, high-rate DataChannels | **symmetric AEAD** under a once-signed session key | per-frame asymmetric crypto doesn't scale to packet rates |
+
+The discriminator already exists: `FrameKind` → `RouteClass` (`route_class_for_frame`).
+The signing policy in `SignedTransport` (or a policy layer above it) should branch
+on it: **per-frame sign for control classes, session-key for stream classes.**
+
+## Stream plane: sign the handle once, reuse the symmetric key
+
+This is the standard pattern (DTLS-SRTP, QUIC, WireGuard, Noise):
+
+1. **At stream/channel establishment**, run ONE Ed25519-authenticated handshake
+   that establishes a shared **symmetric** key (X25519 ECDH → HKDF, authenticated
+   by each peer's Ed25519 identity key — the same identities airc already pins).
+2. **Per packet**, seal/authenticate with the symmetric key via **AEAD
+   (ChaCha20-Poly1305)** — ~tens of ns/packet vs 113µs.
+
+The **reuse** is the session key: pay the asymmetric cost ONCE at the handle, reuse
+the symmetric key for every frame. The symmetric tag *is* the proof the packet came
+from the authenticated session — identity is not re-proven per packet.
+
+## airc-specific wiring
+
+- **WebRTC media tracks** are already DTLS-SRTP session-keyed by the `webrtc`
+  crate. Do NOT layer per-frame app-Ed25519 on media. Instead: at SDP-offer time,
+  do ONE Ed25519 binding of the **DTLS fingerprint → airc peer identity** (sign the
+  handle), then let SRTP do per-packet auth. This binds the media session to the
+  pinned peer identity without per-frame asymmetric cost.
+- **DataChannel + UDP envelopes** today go through `SignedTransport` (per-frame).
+  Split by class: keep per-frame Ed25519 for the **control** DataChannel; for
+  **stream** channels, Ed25519 the channel-open to derive a symmetric key, then
+  AEAD per frame.
+- **UDP** (`crates/airc-transport/src/udp`) is explicitly "wrapped with
+  `SignedTransport`" today — for any stream-rate UDP use, route it through the
+  session-key path instead.
+
+## Secondary levers (control plane, only if ever needed)
+
+- **Ed25519 batch verification** — verifying N signatures together is ~2× faster
+  than N individual verifies; useful for inbound bursts.
+- **Merkle-root signing** — one signature amortized over a burst of frames.
+
+Both are secondary to the two-plane split; the split is the architectural fix.
+
+## Build sequence
+
+1. Introduce a per-stream **session-key** primitive (X25519 + HKDF +
+   ChaCha20-Poly1305), authenticated by the existing Ed25519 peer identities.
+2. Make the signing policy branch on `RouteClass` (control → per-frame Ed25519;
+   stream → session AEAD). Default unchanged (control) so nothing regresses.
+3. Bind WebRTC DTLS fingerprint → peer identity at SDP-offer (one signature).
+4. Route stream-rate DataChannel/UDP through the session-key path.
+5. Extend `lan_latency_bench` with a stream-rate (per-packet) measurement to prove
+   the per-frame cost drops from ~113µs to ~tens of ns.
+
+## Non-goals
+
+- Do **not** drop the per-frame Ed25519 on the control plane — it is the relay
+  end-to-end authenticity guarantee.
+- Do not micro-optimize per-frame Ed25519 as the primary fix; the architectural
+  split is the fix.


### PR DESCRIPTION
## What
Profiled the full LAN request/reply path (new seam-timing util + a latency bench). The dominant cost was **not the wire** — it was `send_frame_to_room` calling `sync_account_peer_registry()` on **every send**, which loads the peer registry from **disk** and re-enrols every peer. That was **~95% of the send leg (~1ms/send)**.

The verifier registry holds peer pubkeys for **inbound** verification and rarely changes between sends, so loading it per **outbound** message is wasted critical-path I/O. Debounced to load at most once/sec.

## Result (LAN loopback, sequential RTT)
| | before | after |
|---|---|---|
| total round-trip | 2852µs | **1531µs (−46%)** |
| send leg | 1077µs | **421µs** |

Both `command_bus_round_trip` tests (LAN + relay) still pass. `add_peer` enrols in-memory immediately and the route-refresh tick still calls the undebounced sync, so freshness is preserved.

## Also adds (reusable diagnostics — shared core lives in airc since continuum imports it)
- `airc-diagnostics::timing` — opt-in seam accumulator (atomic-gated, near-zero when off), the **summed** twin of `probe!`/`time_probe!`.
- Permanent opt-in send-path seams (`airc.sign`/`append_sent`/`exec_route`, `lan.*`, `airc.req.*`).
- `lan_latency_bench` (`#[ignore]`) — the harness that found this + measures the next lever.

## Next levers (measured)
`airc.sign` 113µs + `airc.append_sent` 107µs per send (~690µs/RTT is crypto + durability). `append_sent`'s local durability write is backgroundable but delicate (dedup-ring/ordering) — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)