### PR TITLE
feat(route): crypto-mode policy — the two-plane decision seam (stream slice 3)

### DIFF
--- a/crates/airc-lib/src/route/mod.rs
+++ b/crates/airc-lib/src/route/mod.rs
@@ -21,6 +21,7 @@ pub use invite::{
     endpoints_from_json, endpoints_to_json, ImportedInvite, InviteBeacon, RouteEndpoint,
 };
 pub use policy::{
-    RouteClass, RouteDecision, RoutePolicy, TransportCandidate, TransportKind, TransportRole,
+    crypto_mode, CryptoMode, RouteClass, RouteDecision, RoutePolicy, TransportCandidate,
+    TransportKind, TransportRole,
 };
 pub use resolver::{TransportResolver, TransportRoute};

--- a/crates/airc-lib/src/route/policy.rs
+++ b/crates/airc-lib/src/route/policy.rs
@@ -185,9 +185,70 @@ fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
     }
 }
 
+/// How a frame's authenticity is protected on a given transport — the two-plane
+/// split from `docs/stream-plane-crypto.md` ("sign the handle, not the frame").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CryptoMode {
+    /// Per-frame Ed25519 signature (`SignedTransport`). Relay-survivable,
+    /// audit-able authenticity for control/message frames at moderate rate;
+    /// the default and the only mode that survives re-emission by an
+    /// intermediary.
+    PerFrameSign,
+    /// Symmetric AEAD under a per-peer session keyed by an Ed25519-authenticated
+    /// X25519 handshake (`airc_protocol::handshake` + `StreamSession`). Pay the
+    /// asymmetric cost ONCE at the handshake; each frame after is ~ns, not
+    /// ~113µs. For the packet-rate stream transports only.
+    SessionAead,
+}
+
+/// Crypto mode for a transport. ONLY the connection-oriented, packet-rate
+/// stream transports (`Udp`, `WebRtcDataChannel`) carry a session and use AEAD;
+/// everything else signs per frame. Conservative by construction: any transport
+/// not explicitly a stream transport keeps the relay-survivable per-frame
+/// signature (so adding a transport never silently downgrades its authenticity).
+pub fn crypto_mode(transport: TransportKind) -> CryptoMode {
+    match transport {
+        TransportKind::Udp | TransportKind::WebRtcDataChannel => CryptoMode::SessionAead,
+        TransportKind::LanTcp
+        | TransportKind::Tailscale
+        | TransportKind::Reticulum
+        | TransportKind::Relay
+        | TransportKind::Ssh
+        | TransportKind::GhGist => CryptoMode::PerFrameSign,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the two-plane crypto split — ONLY the packet-rate
+    // stream transports use a session; every other transport keeps per-frame
+    // Ed25519 (the relay-survivable default). A regression that flipped a
+    // control transport to SessionAead would silently drop its re-emission
+    // authenticity guarantee.
+    #[test]
+    fn crypto_mode_is_session_aead_only_for_stream_transports() {
+        assert_eq!(crypto_mode(TransportKind::Udp), CryptoMode::SessionAead);
+        assert_eq!(
+            crypto_mode(TransportKind::WebRtcDataChannel),
+            CryptoMode::SessionAead
+        );
+        for control in [
+            TransportKind::LanTcp,
+            TransportKind::Tailscale,
+            TransportKind::Reticulum,
+            TransportKind::Relay,
+            TransportKind::Ssh,
+            TransportKind::GhGist,
+        ] {
+            assert_eq!(
+                crypto_mode(control),
+                CryptoMode::PerFrameSign,
+                "{control:?} must keep per-frame signing"
+            );
+        }
+    }
 
     fn candidate(kind: TransportKind, role: TransportRole) -> TransportCandidate {
         TransportCandidate {

--- a/docs/stream-plane-crypto.md
+++ b/docs/stream-plane-crypto.md
@@ -70,14 +70,50 @@ Both are secondary to the two-plane split; the split is the architectural fix.
 
 ## Build sequence
 
-1. Introduce a per-stream **session-key** primitive (X25519 + HKDF +
-   ChaCha20-Poly1305), authenticated by the existing Ed25519 peer identities.
-2. Make the signing policy branch on `RouteClass` (control → per-frame Ed25519;
-   stream → session AEAD). Default unchanged (control) so nothing regresses.
-3. Bind WebRTC DTLS fingerprint → peer identity at SDP-offer (one signature).
-4. Route stream-rate DataChannel/UDP through the session-key path.
-5. Extend `lan_latency_bench` with a stream-rate (per-packet) measurement to prove
+1. **[done, #1261]** Per-stream **session-key** primitive (`airc_protocol::session`
+   `StreamSession`: X25519+HKDF directional keys, ChaCha20-Poly1305 seal/open,
+   replay window) + the Ed25519-authenticated X25519 **handshake**
+   (`airc_protocol::handshake`). The crypto core, adversarially reviewed.
+2. **[done]** Crypto-mode policy keyed off **`TransportKind`** (not RouteClass —
+   the session lives on the connection-oriented transport, and a control-class
+   frame can ride UDP). `route::policy::crypto_mode(TransportKind)`: only the
+   packet-rate stream transports (`Udp`, `WebRtcDataChannel`) → `SessionAead`;
+   every other transport → `PerFrameSign` (exhaustive match, so a new transport
+   must explicitly choose — never a silent downgrade). Default unchanged.
+3. **[next — the heavy integration]** Session lifecycle in the transport
+   (see "Session lifecycle" below): per-peer session store, handshake-over-the-
+   transport orchestration, and `SignedTransport`/a session layer dispatching on
+   `crypto_mode`.
+4. Bind WebRTC DTLS fingerprint → peer identity at SDP-offer (one signature).
+5. Route stream-rate DataChannel/UDP through the session-key path.
+6. Extend `lan_latency_bench` with a stream-rate (per-packet) measurement to prove
    the per-frame cost drops from ~113µs to ~tens of ns.
+
+## Session lifecycle (slice 3 integration — the heavy part)
+
+The crypto core + policy are in place; wiring them into the live transport is the
+remaining work, and it is a **coordinated wire-lane change** (it touches frame
+dispatch + connection lifecycle). Design:
+
+- **Per-peer session store.** A `DashMap<PeerId, StreamSession>` (or per
+  `(PeerId, TransportKind)`) holds the live session. Absent = not yet handshaked.
+- **Handshake over the transport.** On first stream-class frame to a peer with no
+  session, run the `handshake` exchange as two control frames (`HandshakeInit` /
+  `HandshakeResp` ride the existing per-frame-signed control plane — they ARE the
+  "sign the handle"), then install the resulting `StreamSession`. Queue or briefly
+  block the triggering frame until the session is up; surface handshake failure
+  loudly (no silent plaintext fallback — `[[no-fallbacks-ever]]`).
+- **Dispatch on `crypto_mode`.** A session-aware transport layer (above or beside
+  `SignedTransport`) consults `crypto_mode(transport_kind)`: `PerFrameSign` →
+  today's `SignedTransport` path unchanged; `SessionAead` → `session.seal` on
+  send, `session.open` on receive, with the routing headers as the AEAD `aad`.
+- **Rekey.** On `SessionError::CounterExhausted` (or a time/byte budget), re-run
+  the handshake and swap the session. Counter exhaustion is astronomically far;
+  the budget is the practical trigger.
+- **Ordering vs the replay window.** UDP reorders — the 64-wide window already
+  tolerates it; out-of-window reorder is dropped (acceptable for a stream).
+
+This stays in the airc transport/wire lane; coordinate before landing.
 
 ## Non-goals
 


### PR DESCRIPTION
## What
The decision half of stream-plane slice 3 (`docs/stream-plane-crypto.md`). With the crypto core merged (#1261), this is where a frame chooses **per-frame Ed25519** vs the **session AEAD**.

`route::policy::crypto_mode(TransportKind) -> CryptoMode`:
- keyed off the **transport** (the session lives on the connection-oriented transport; a control-class frame can ride UDP, so RouteClass is the wrong axis)
- `Udp` / `WebRtcDataChannel` → `SessionAead`; every other transport → `PerFrameSign`
- **exhaustive match** — a new transport must choose its mode at compile time, never a silent authenticity downgrade
- conservative default: per-frame signing stays everywhere it is today

Pure + tested; nothing dispatches on it yet (no behavior change).

## Heavy integration is specced, not rushed
The remaining slice-3 work — per-peer session store, handshake-over-the-transport orchestration, `SignedTransport` dispatch on `crypto_mode`, rekey — is a **coordinated wire-lane change** and is now documented in `docs/stream-plane-crypto.md` → "Session lifecycle". Landing the policy seam first keeps that change small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)