### PR TITLE
fix(deps): sync Cargo.lock with airc-protocol's direct crypto deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,12 +273,16 @@ name = "airc-protocol"
 version = "0.1.0"
 dependencies = [
  "airc-core",
+ "chacha20poly1305",
  "ciborium",
  "dashmap",
  "ed25519-dalek",
+ "hkdf",
  "rand 0.8.6",
  "serde",
  "serde_json",
+ "sha2",
+ "x25519-dalek",
 ]
 
 [[package]]


### PR DESCRIPTION
The stream-plane crypto PRs added `chacha20poly1305 / hkdf / sha2 / x25519-dalek` as **direct** deps of `airc-protocol`, but the Cargo.lock updates were dropped during commits (`git checkout Cargo.lock` to avoid cross-branch noise). So canary's lockfile didn't list them under `airc-protocol` → `cargo build --locked` (CI / fresh clone) **failed**. They were present transitively, so a normal build auto-fixed it and hid the gap.

Adds the 4 direct-dep edges to `Cargo.lock`. Verified `cargo build --locked -p airc-protocol` now passes. Lock-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)