### PR TITLE
fix(install): source brew env so non-interactive update finds cargo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -276,9 +276,33 @@ Try: xcode-select --install   OR   sudo xcode-select --switch $clt"
   fi
 }
 
+# macOS: Homebrew — and the cargo it installs — live under /opt/homebrew/bin
+# (Apple Silicon) or /usr/local/bin (Intel). A NON-INTERACTIVE shell does NOT
+# get that prefix on PATH, because the `brew shellenv` line that adds it lives
+# in an interactive-only profile (~/.zprofile). That's exactly the `airc update`
+# -> spawned install.sh case, and a fresh login/automation shell: brew + cargo
+# are installed but invisible, so detect_pkgmgr reports "brew-missing" and the
+# build dies at the "cargo is required" probe. Source brew's env from the
+# well-known prefixes so the rest of the script (and the cargo build) see the
+# toolchain. Idempotent + cheap; no-op off macOS, when brew is already on PATH,
+# or when brew is genuinely absent (the installer path still handles that).
+ensure_brew_on_path() {
+  [ "$(uname -s 2>/dev/null)" = "Darwin" ] || return 0
+  command -v brew >/dev/null 2>&1 && return 0
+  local brew_bin
+  for brew_bin in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+    if [ -x "$brew_bin" ]; then
+      eval "$("$brew_bin" shellenv)"
+      return 0
+    fi
+  done
+  return 0
+}
+
 ensure_prereqs() {
   [ "${AIRC_SKIP_PREREQS:-0}" = "1" ] && { info "AIRC_SKIP_PREREQS=1 -- skipping prereq install"; return 0; }
 
+  ensure_brew_on_path
   local mgr; mgr=$(detect_pkgmgr)
   if [ "$mgr" = "unknown" ] || [ "$mgr" = "brew-missing" ]; then
     if [ "$mgr" = "brew-missing" ]; then
@@ -800,6 +824,9 @@ _setup_windows_firewall() {
 
 _install_airc_binary() {
   [ "${AIRC_SKIP_RUST_BUILD:-0}" = "1" ] && { info "AIRC_SKIP_RUST_BUILD=1 -- skipping airc build"; return 0; }
+  # Belt-and-suspenders: even when prereq install was skipped (AIRC_SKIP_PREREQS)
+  # the build still needs cargo on PATH. On macOS that means sourcing brew env.
+  ensure_brew_on_path
   if ! command -v cargo >/dev/null 2>&1; then
     fail "cargo is required to build airc. Install Rust, then re-run install.sh."
   fi


### PR DESCRIPTION
## Problem (a real self-update reliability bug)

`airc update` spawns `install.sh` in a **non-interactive shell**. On macOS that shell does NOT have `/opt/homebrew/bin` on PATH — the `brew shellenv` line that adds it lives in an interactive-only `~/.zprofile`. So `detect_pkgmgr` reported `brew-missing` and the build died at the `cargo is required to build airc` probe, **even though brew AND cargo were installed** at `/opt/homebrew/bin`.

Caught live on M5: `airc update` →
```
! macOS detected but Homebrew not found.
✗ cargo is required to build airc. Install Rust, then re-run install.sh.
```

This is load-bearing for the daemon **self-update** mechanism (#1268): `auto_update` → `airc update --auto` → `install.sh` inherits the same non-interactive blind spot, so the mechanism meant to keep nodes current couldn't rebuild on a stock macOS box. Reliability foundation for the mesh.

## Fix

`ensure_brew_on_path()`: on Darwin, if `brew` isn't already reachable, `eval "$(<prefix>/brew shellenv)"` from the well-known prefixes (`/opt/homebrew/bin`, `/usr/local/bin`) so brew + cargo land on PATH for the rest of the script. Called at the top of `ensure_prereqs` and (belt-and-suspenders, for the `AIRC_SKIP_PREREQS` path) at the top of `_install_airc_binary`. Idempotent; no-op off macOS, when brew is already on PATH, or when brew is genuinely absent (existing installer path still handles that).

## Proof

`bash -n` clean. Built + installed in a scrubbed `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin` where it previously bailed:
```
-> Building Rust CLI: airc
-> Installed airc: /Users/joel/.local/bin/airc
-> Installed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)