### PR TITLE
fix(build): repair canary — #1271 broke examples (EventFilter.self_echo) + fmt

### DIFF
--- a/crates/airc-lib/src/stream.rs
+++ b/crates/airc-lib/src/stream.rs
@@ -302,7 +302,10 @@ mod tests {
             my_join_client,
             SelfFilter::ExcludeSamePeer,
         );
-        assert!(!agent_feed.matches(&my_send), "own broadcast must be hidden");
+        assert!(
+            !agent_feed.matches(&my_send),
+            "own broadcast must be hidden"
+        );
         assert!(agent_feed.matches(&peer_send), "peer messages stay visible");
     }
 }

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -513,6 +513,8 @@ pub fn decode_capability_offer(
 /// Subscription filter admitting capability offers (and only those).
 pub fn capability_offer_filter() -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),
@@ -724,6 +726,8 @@ pub async fn request_inference_remote(
 /// specific persona or activity at subscribe time.
 pub fn any_persona_event_filter() -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),
@@ -738,6 +742,8 @@ pub fn any_persona_event_filter() -> EventFilter {
 /// AND whose `forge.continuum.activity_id` equals the given id.
 pub fn activity_event_filter(activity_id: &str) -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),
@@ -914,6 +920,8 @@ pub fn decode_embedding_event(
 /// bridge subscribing only to embedding traffic).
 pub fn any_embedding_event_filter() -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),

--- a/crates/examples/consumer_shapes/src/hermes.rs
+++ b/crates/examples/consumer_shapes/src/hermes.rs
@@ -170,6 +170,8 @@ pub fn decode_hermes_event(
 
 pub fn any_hermes_event_filter() -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),
@@ -185,6 +187,8 @@ pub fn any_hermes_event_filter() -> EventFilter {
 /// is opaque to the substrate.
 pub fn agent_event_filter(agent_id: &str) -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),

--- a/crates/examples/consumer_shapes/src/openclaw.rs
+++ b/crates/examples/consumer_shapes/src/openclaw.rs
@@ -171,6 +171,8 @@ pub fn decode_openclaw_event(
 
 pub fn any_openclaw_event_filter() -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),
@@ -184,6 +186,8 @@ pub fn any_openclaw_event_filter() -> EventFilter {
 /// Scope by workspace — common cross-thread routing requirement.
 pub fn workspace_event_filter(workspace_id: &str) -> EventFilter {
     EventFilter {
+        // #1271 added EventFilter.self_echo; consumers see everything (None).
+        self_echo: None,
         channel: None,
         channels: HashSet::new(),
         kinds: BTreeSet::new(),

--- a/crates/examples/embedded_consumer_smoke/src/agent.rs
+++ b/crates/examples/embedded_consumer_smoke/src/agent.rs
@@ -87,6 +87,9 @@ impl AgentConsumer {
                 key: HEADER_AGENT_KIND.to_string(),
                 value: AGENT_KIND_PROMPT.to_string(),
             },
+            // #1271 added EventFilter.self_echo; consumers want to see
+            // everything (None = no self-echo suppression) — see stream.rs.
+            self_echo: None,
         };
         Ok(AgentInbox {
             owner: self.clone(),
@@ -109,6 +112,9 @@ impl AgentConsumer {
                 key: HEADER_AGENT_KIND.to_string(),
                 value: AGENT_KIND_PROMPT.to_string(),
             },
+            // #1271 added EventFilter.self_echo; consumers want to see
+            // everything (None = no self-echo suppression) — see stream.rs.
+            self_echo: None,
         };
         Ok(self
             .airc


### PR DESCRIPTION
## Canary is red (blocks every PR)
#1271 added a required field `self_echo: Option<SelfEcho>` to `EventFilter` but only updated the airc-cli construction sites. The **example crates** (`consumer_shapes`, `embedded_consumer_smoke`) still construct `EventFilter` without it → `E0063` workspace compile failure → reddens `clippy`, `cargo fmt`, and `cargo test --workspace` on every platform. Merged red, so every downstream PR inherits a broken gate (hit live on #1272 / #10).

## Fix
- `self_echo: None` on every example `EventFilter` — `None` = no self-echo suppression, i.e. consumers/RAG/Continuum keep seeing everything (per the design note in `stream.rs`).
- `rustfmt` on `stream.rs` (also left dirty by #1271).

Verified locally: `cargo build --workspace` clean, `cargo fmt --check` clean, production no-silent-fallback gate green.

## Process note
This is the **2nd red-canary inheritance this cycle** (after #1264's `expect()` gate failure). Canary branch protection isn't enforcing green CI before merge, so breakage accumulates and every new PR pays for it. Worth tightening required checks on canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)