### PR TITLE
feat(grid-auth): expose Airc::mesh_identity for grant verification

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1129,7 +1129,12 @@ impl Airc {
     /// rooms when the coordinator path differs from the scope path —
     /// e.g. on Windows, where `machine_account_home` collapses temp
     /// homes that live under `USERPROFILE` onto one coordinator store.
-    pub(crate) async fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
+    ///
+    /// Public so a consumer can pin this node's own mesh as the expected mesh
+    /// when verifying a presented `grid_auth::SignedCapabilityGrant` (a grant is
+    /// rejected `WrongMesh` if it was scoped to a different grid). The authoritative
+    /// local-mesh accessor — read it once at boot, not on the hot path.
+    pub async fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
         if mesh_identity::load_cached(self.coordinator_store())
             .await?
             .is_none()


### PR DESCRIPTION
Widen the local-mesh accessor `Airc::mesh_identity` from `pub(crate)` to `pub`.

Continuum's capability-grant verifier (`GrantAuthorizer`) pins this node's own mesh as the `expected_mesh` when verifying a presented `grid_auth::SignedCapabilityGrant` — a grant scoped to a different grid is rejected `WrongMesh`. The accessor already resolves the authoritative coordinator-store identity; this only widens visibility. Read once at boot, not on the hot path.

Last airc-side add for the capability-grant receive path (header + sign + peer_public_key landed in #1276; own-key comes from the node's self-enrollment).

Gate: build + no-silent-fallback clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)