### PR TITLE
feat(grid-auth): Airc::sign_grant — issue a capability grant with the node key

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -987,6 +987,22 @@ impl Airc {
         )
     }
 
+    /// Issue (sign) a capability grant with THIS node's identity key — the node is
+    /// the owner/issuer delegating a capability to `grant.grantee`. The raw key
+    /// never leaves airc (same contract as [`sign_assertion`]); a verifier
+    /// authorizes the result by pinning this node's
+    /// [`peer_public_key`](Self::peer_public_key) as its `trusted_issuer_pubkey`.
+    /// The grant body is the caller's to compose (grantee + grantee key +
+    /// capabilities + mesh + expiry + epoch); this only signs it. Fallible solely
+    /// on body serialization (a programmer error in practice), surfaced rather than
+    /// swallowed — fail-closed.
+    pub fn sign_grant(
+        &self,
+        grant: crate::grid_auth::CapabilityGrant,
+    ) -> Result<crate::grid_auth::SignedCapabilityGrant, serde_json::Error> {
+        crate::grid_auth::SignedCapabilityGrant::sign(&self.inner.identity.keypair, grant)
+    }
+
     pub fn is_daemon_attached(&self) -> bool {
         self.inner.daemon_client.is_some()
     }


### PR DESCRIPTION
The issuance half of the contracted grid: an owner node signs a `CapabilityGrant` with its own identity key so a grantee can present it on a cross-grid command. The raw key never leaves airc (same contract as `sign_assertion`); a verifier authorizes the result by pinning this node's `peer_public_key` as `trusted_issuer_pubkey`. Delegates to `SignedCapabilityGrant::sign`; fallible only on body serialization (surfaced, fail-closed).

Pairs with the continuum `grid/grant/issue` command + the receive path already wired (airc #1276/#1277).

Gate: build + no-silent-fallback clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)