### PR TITLE
feat(account-registry): shared-folder rendezvous + #113 selector seam (auto-pick gist vs folder)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1458,23 +1458,40 @@ pub async fn run_daemon(
                 bin.display()
             );
         }
-        // Stale-token recovery slot (card 1f2cbffa): the SAME slot
-        // goes to the gate (which re-resolves on auth failure) and the
-        // store (whose gh spawns then carry the recovered token), so a
-        // mid-session token rotation no longer bricks the rendezvous
-        // until daemon restart.
-        let gh_token_override = airc_lib::GhTokenOverride::new();
-        let store = match &gh_bin {
-            Some(bin) => airc_lib::GhAccountRegistryStore::new(event_store, &registry_home)
-                .with_bin(bin.clone()),
-            None => airc_lib::GhAccountRegistryStore::new(event_store, &registry_home),
-        }
-        .with_token_override(gh_token_override.clone());
-        let gate = airc_lib::RegistryRefreshGate::GhAuth {
-            gh_bin: gh_bin.clone(),
-            scope_home: registry_home.clone(),
-            token_override: Some(gh_token_override),
+        // Rendezvous SELECTION (#113): which door the mesh converges
+        // through is a data choice, not a hardcode. `AIRC_RENDEZVOUS_DIR`
+        // set → the no-GitHub shared-folder door (on-prem / behind
+        // firewall); unset → the default gist door. The resolver pairs the
+        // chosen store with the gate that matches it (gist → gh-auth,
+        // folder → Always), so this loop never learns which door won.
+        //
+        // Stale-token recovery slot (card 1f2cbffa) rides the gist door:
+        // the SAME slot goes to the gate (which re-resolves on auth
+        // failure) and the store (whose gh spawns then carry the recovered
+        // token), so a mid-session token rotation no longer bricks the
+        // rendezvous until daemon restart. The folder door ignores it.
+        let choice = match airc_lib::RendezvousChoice::from_env() {
+            Ok(choice) => choice,
+            Err(error) => {
+                eprintln!("airc daemon: account-registry loop disabled — {error}");
+                return;
+            }
         };
+        if let airc_lib::RendezvousChoice::Folder { dir } = &choice {
+            eprintln!(
+                "airc daemon: account-registry using shared-folder rendezvous at {} (no gh)",
+                dir.display()
+            );
+        }
+        let (store, gate) = airc_lib::resolve_account_registry_store(
+            choice,
+            airc_lib::GistRendezvous {
+                event_store,
+                scope_home: registry_home.clone(),
+                gh_bin: gh_bin.clone(),
+                token_override: airc_lib::GhTokenOverride::new(),
+            },
+        );
         airc_lib::run_registry_refresh_loop(
             airc,
             store,

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -337,6 +337,29 @@ pub trait AccountRegistryStore: Send + Sync {
     ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError>;
 }
 
+/// Delegating impl so a `Box<dyn AccountRegistryStore>` — what the
+/// rendezvous resolver returns after picking gist vs shared-folder —
+/// itself satisfies `AccountRegistryStore`. That lets one boxed store
+/// flow through `run_loop`'s generic `S: AccountRegistryStore` bound
+/// unchanged, so provider SELECTION happens once at the seam and the
+/// refresh loop never learns which door the mesh converged through.
+#[async_trait]
+impl AccountRegistryStore for Box<dyn AccountRegistryStore> {
+    async fn publish(
+        &self,
+        document: &AccountRegistryDocument,
+    ) -> Result<(), AccountRegistryError> {
+        (**self).publish(document).await
+    }
+
+    async fn refresh(
+        &self,
+        mesh_identity: &MeshIdentity,
+    ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError> {
+        (**self).refresh(mesh_identity).await
+    }
+}
+
 /// Store-backed local cache of account-registry documents.
 ///
 /// Replaces the previous on-disk `<root>/<mesh-identity>/registry.json`

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -558,6 +558,13 @@ impl Airc {
         // at — the upper bound for any peer's `last_seen`. See the clamp
         // at the touch below.
         let now_ms = crate::time::now_ms()?;
+        // #18 auto-trust: our REAL mesh identity, resolved from our own
+        // credential — never the document's self-asserted `mesh_identity`.
+        // The elevation below only fires when the document's identity
+        // actually MATCHES ours, so a foreign document (or a direct import
+        // of one) leaves its peers `Untrusted`. Using `document.mesh_identity`
+        // for both sides would be circular — a document vouching for itself.
+        let self_mesh = self.mesh_identity().await?;
         for peer in document.peers {
             if peer.peer_id() == self.inner.identity.peer_id {
                 continue;
@@ -568,6 +575,49 @@ impl Airc {
                 peer.peer_spec.pubkey,
             )
             .await?;
+            // #18 auto-trust (import-time elevation, staged model). This
+            // document is OUR OWN account registry — `refresh` loads it by
+            // our mesh identity and `import` re-asserts
+            // `document.mesh_identity == self mesh` via `validate()` above —
+            // so every non-self beacon in it was placed by a machine with
+            // write-access to our account's rendezvous (our `gh` token for
+            // the gist door, our device-scoped ACL for the folder door).
+            // That write-authority is same-account evidence, so the policy
+            // in `detect_tier` resolves these peers to `OwnAccount` rather
+            // than leaving them `Untrusted` (which would surface as an
+            // unusable "unknown" peer needing a manual `set-tier`). We route
+            // through `detect_tier` rather than hardcoding the tier so the
+            // signals→tier policy lives in exactly one place. Locality is
+            // `false` — a registry beacon proves nothing about local
+            // reachability; the `OwnMachine` upgrade is the local-UDS path's
+            // job, not the import's.
+            //
+            // STAGED (Joel's call): this couples trust to rendezvous
+            // write-authority. The planned hardening keeps the enrol here at
+            // `Untrusted` and elevates to `OwnAccount` only once the peer
+            // ALSO proves possession of this pinned key in a live session —
+            // defense-in-depth so a compromised rendezvous alone can't mint
+            // account trust. Tracked as the #18 handshake-gate follow-up.
+            let tier = airc_trust::detect_tier(
+                self.inner.identity.peer_id,
+                Some(self_mesh.as_str()),
+                peer.peer_spec.peer_id,
+                Some(document.mesh_identity.as_str()),
+                false,
+            );
+            airc_trust::set_tier(&self.inner.wire_root, peer.peer_spec.peer_id, tier)
+                .await?
+                // The peer was added to this exact store a few lines up; a
+                // vanished row here is the same structural bug the endpoint
+                // store below guards against, so fail loud rather than
+                // silently leaving the peer at the default tier.
+                .ok_or_else(|| {
+                    AircError::Transport(format!(
+                        "peer {} vanished between trust add and tier elevation \
+                         during registry import — report as a substrate bug",
+                        peer.peer_spec.peer_id
+                    ))
+                })?;
             // Seam #3.2 (liveness): a peer present in a freshly
             // refreshed, stale-pruned registry document just published a
             // beacon — that IS fresh contact. Record it so the age-based
@@ -866,6 +916,100 @@ mod tests {
             vec![RouteEndpoint::Relay {
                 url: "https://relay.example.test".to_string()
             }]
+        );
+    }
+
+    // what this catches: #18 auto-trust (import-time elevation). A peer
+    // beacon carried in OUR OWN account registry (document mesh == our real
+    // mesh) must enrol at `OwnAccount`, not the default `Untrusted` — that
+    // is the difference between "join just works" and an unusable peer that
+    // needs a manual `set-tier`. The SECURITY half: a document whose
+    // mesh_identity is FOREIGN must leave its peers `Untrusted`, proving the
+    // elevation checks our real resolved mesh (never the document's
+    // self-asserted identity — that would be circular and let any document
+    // mint account trust for its own peers).
+    #[tokio::test]
+    async fn import_elevates_same_account_peer_but_not_a_foreign_document() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("machine-b/.airc");
+        std::fs::create_dir_all(&home).unwrap();
+        let airc = Airc::open(&home).await.unwrap();
+
+        // The document's identity IS our own resolved mesh — the same-account
+        // case the auto-trust exists for.
+        let my_mesh = airc.mesh_identity().await.unwrap();
+        let same_account_peer = PeerId::new();
+        let same_spec = peer_spec(same_account_peer);
+        let same_doc = AccountRegistryDocument::new(
+            my_mesh.clone(),
+            2_000,
+            vec![channel("general")],
+            vec![AccountPeerBeacon {
+                presence: crate::coordinator::beacon_now(
+                    same_account_peer,
+                    home.clone(),
+                    vec![channel("general")],
+                    123,
+                    1_000,
+                ),
+                peer_spec: same_spec.clone(),
+                endpoints: Vec::new(),
+            }],
+        );
+        airc.import_account_registry_document(same_doc)
+            .await
+            .unwrap();
+
+        let tier = airc_trust::load(&airc.inner.wire_root)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.peer_id == same_spec.peer_id)
+            .expect("same-account peer enrolled on import")
+            .tier;
+        assert_eq!(
+            tier,
+            airc_store::TrustTier::OwnAccount,
+            "a peer in our OWN account registry must auto-elevate to OwnAccount"
+        );
+
+        // A document claiming a DIFFERENT mesh identity — its peers must NOT
+        // be elevated (the elevation must consult our real mesh, not the
+        // document's self-asserted one).
+        let foreign_peer = PeerId::new();
+        let foreign_spec = peer_spec(foreign_peer);
+        let foreign_doc = AccountRegistryDocument::new(
+            MeshIdentity::new("someone-else@github"),
+            2_000,
+            vec![channel("general")],
+            vec![AccountPeerBeacon {
+                presence: crate::coordinator::beacon_now(
+                    foreign_peer,
+                    home.clone(),
+                    vec![channel("general")],
+                    123,
+                    1_000,
+                ),
+                peer_spec: foreign_spec.clone(),
+                endpoints: Vec::new(),
+            }],
+        );
+        airc.import_account_registry_document(foreign_doc)
+            .await
+            .unwrap();
+
+        let foreign_tier = airc_trust::load(&airc.inner.wire_root)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.peer_id == foreign_spec.peer_id)
+            .expect("foreign peer still enrolled (key pinned) on import")
+            .tier;
+        assert_eq!(
+            foreign_tier,
+            airc_store::TrustTier::Untrusted,
+            "a peer from a foreign-mesh document must NOT auto-elevate — \
+             enrolment pins the key, but trust stays Untrusted"
         );
     }
 

--- a/crates/airc-lib/src/account_registry_fs.rs
+++ b/crates/airc-lib/src/account_registry_fs.rs
@@ -1,0 +1,348 @@
+//! Filesystem (shared-folder) account-registry rendezvous — the
+//! **no-GitHub** door onto the same mesh gist opens.
+//!
+//! `[[airc-grid-identity-unification-trust-bridge]]` /
+//! `[[positron-identity-security-first-class]]`: rendezvous **initiates**
+//! the exchange, it does not **supply** the security. The security lives
+//! in the E2E data plane (paired peer keys, trust tiers) regardless of
+//! which door a node came through, so the rendezvous is free to be a dumb,
+//! untrusted meeting point — exactly the Tailscale coordination-server
+//! shape. [`crate::gh::GhAccountRegistryStore`] is one such door (gist,
+//! chosen because our agents already live on GitHub for kanban/PRs). This
+//! is a second, maximally-different one: a **shared folder** every machine
+//! of one account can see — an iCloud Drive, a Syncthing folder, a hospital
+//! NFS mount — needing **no `gh` CLI, no token, no network**. That is the
+//! on-prem/behind-firewall grid rendezvous (Amit's hospital trial can't
+//! reach GitHub), and it proves the [`AccountRegistryStore`] seam is
+//! genuinely swappable: if gist went away, this is already a working
+//! substitute.
+//!
+//! ## Fidelity: the SAME convergence core as gist
+//!
+//! gh keeps one gist **per writer/machine** on the account and `refresh`
+//! fetches all of them and folds via [`merge_registry_documents`]
+//! (freshest beacon per peer, union across machines, skip foreign-mesh,
+//! prune stale). This store does the byte-identical thing on a filesystem:
+//! each machine writes ITS document to its own per-writer file
+//! (`<dir>/<identity>/<writer_file>`), so two machines never clobber, and
+//! `refresh` reads every writer file for the identity and runs the exact
+//! same [`merge_registry_documents`] + [`prune_stale_peers`] core. So the
+//! two rendezvous transports converge identically — the merge/freshness
+//! logic lives in exactly one place (`[[compression-principle]]`).
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use crate::account_registry::{
+    merge_registry_documents, prune_stale_peers, AccountRegistryDocument, AccountRegistryError,
+    AccountRegistryStore, DEFAULT_PEER_FRESHNESS_TTL_MS,
+};
+use crate::subscriptions::MeshIdentity;
+
+/// A shared-folder [`AccountRegistryStore`]: publish/refresh the account's
+/// mesh registry through a directory N machines share (iCloud / Syncthing /
+/// NFS), with no GitHub dependency.
+pub struct FsAccountRegistryStore {
+    /// The shared rendezvous root every machine of the account can see.
+    dir: PathBuf,
+    /// This machine's stable per-writer document basename. Production
+    /// passes [`crate::gh::writer_filename`] so fs and gh agree on writer
+    /// identity (`[[compression-principle]]` — one writer-identity source);
+    /// tests pass distinct names to simulate several machines sharing one
+    /// folder. MUST end in `.json` (the read filter ignores everything else,
+    /// which is what makes the store robust to OS cruft an iCloud folder
+    /// carries — `.DS_Store`, `.icloud` placeholders).
+    writer_file: String,
+}
+
+impl FsAccountRegistryStore {
+    /// `dir` = the shared rendezvous folder; `writer_file` = this machine's
+    /// per-writer `.json` document basename (see the field doc for the
+    /// production vs test contract).
+    pub fn new(dir: impl Into<PathBuf>, writer_file: impl Into<String>) -> Self {
+        Self {
+            dir: dir.into(),
+            writer_file: writer_file.into(),
+        }
+    }
+
+    /// One filesystem-safe subdir per mesh identity. The merge still filters
+    /// by exact `mesh_identity`, so a sanitize collision can only ever
+    /// UNDER-partition (two identities land in one dir) and the merge drops
+    /// the foreign-mesh docs — never a correctness bug, just tidiness.
+    fn identity_dir(&self, identity: &MeshIdentity) -> PathBuf {
+        self.dir
+            .join(sanitize_identity_component(identity.as_str()))
+    }
+}
+
+#[async_trait]
+impl AccountRegistryStore for FsAccountRegistryStore {
+    async fn publish(
+        &self,
+        document: &AccountRegistryDocument,
+    ) -> Result<(), AccountRegistryError> {
+        document.validate()?;
+        let body = serde_json::to_string_pretty(document).map_err(|error| {
+            AccountRegistryError::Adapter(format!("serialize registry document: {error}"))
+        })?;
+        let dir = self.identity_dir(&document.mesh_identity);
+        tokio::fs::create_dir_all(&dir).await.map_err(|error| {
+            AccountRegistryError::Adapter(format!(
+                "create rendezvous dir {}: {error}",
+                dir.display()
+            ))
+        })?;
+        // Atomic publish: write a temp file in the SAME dir (so the rename
+        // is atomic on one filesystem) then rename over the writer file, so
+        // a concurrent `refresh` on another machine never reads a
+        // half-written document. The temp name is pid-scoped so two writers
+        // never collide on the staging file.
+        let final_path = dir.join(&self.writer_file);
+        let tmp_path = dir.join(format!("{}.{}.tmp", self.writer_file, std::process::id()));
+        tokio::fs::write(&tmp_path, body.as_bytes())
+            .await
+            .map_err(|error| {
+                AccountRegistryError::Adapter(format!("write {}: {error}", tmp_path.display()))
+            })?;
+        tokio::fs::rename(&tmp_path, &final_path)
+            .await
+            .map_err(|error| {
+                AccountRegistryError::Adapter(format!(
+                    "rename {} -> {}: {error}",
+                    tmp_path.display(),
+                    final_path.display()
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn refresh(
+        &self,
+        mesh_identity: &MeshIdentity,
+    ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError> {
+        let dir = self.identity_dir(mesh_identity);
+        let mut read_dir = match tokio::fs::read_dir(&dir).await {
+            Ok(read_dir) => read_dir,
+            // No writer has published for this identity yet — legitimately
+            // empty, not a fault (mirrors gh's "no gist → None").
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(AccountRegistryError::Adapter(format!(
+                    "read rendezvous dir {}: {error}",
+                    dir.display()
+                )))
+            }
+        };
+
+        let mut documents = Vec::new();
+        while let Some(entry) = read_dir.next_entry().await.map_err(|error| {
+            AccountRegistryError::Adapter(format!(
+                "iterate rendezvous dir {}: {error}",
+                dir.display()
+            ))
+        })? {
+            let path = entry.path();
+            // Only writer documents. This skips both the in-flight `.tmp`
+            // staging files a concurrent publish is mid-rename on AND any OS
+            // cruft a synced folder carries (`.DS_Store`, `.icloud`).
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes = tokio::fs::read(&path).await.map_err(|error| {
+                AccountRegistryError::Adapter(format!("read {}: {error}", path.display()))
+            })?;
+            // Fail loud on a corrupt writer file: a shared-folder rendezvous
+            // holding a malformed document is an operator-visible fault, not
+            // something to silently skip (`[[fallbacks-are-illegal-fail-loud]]`).
+            let document: AccountRegistryDocument =
+                serde_json::from_slice(&bytes).map_err(|error| {
+                    AccountRegistryError::Adapter(format!(
+                        "parse registry document {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            documents.push(document);
+        }
+
+        // The SAME convergence core gist uses — one source of truth for the
+        // merge/freshness rules across both rendezvous transports.
+        let outcome = merge_registry_documents(documents, mesh_identity);
+        let Some(mut document) = outcome.document else {
+            return Ok(None);
+        };
+        let now_ms = crate::time::now_ms().map_err(|error| {
+            AccountRegistryError::Adapter(format!("system clock before unix epoch: {error}"))
+        })?;
+        prune_stale_peers(&mut document.peers, now_ms, DEFAULT_PEER_FRESHNESS_TTL_MS);
+        Ok(Some(document))
+    }
+}
+
+/// One safe filesystem path component from a mesh-identity string.
+fn sanitize_identity_component(identity: &str) -> String {
+    let mut out = String::with_capacity(identity.len());
+    for ch in identity.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        // A `MeshIdentity::unset()` still gets a stable, non-empty home.
+        out.push_str("_unset");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    // what this catches: the shared-folder rendezvous must round-trip a
+    // published document AND — the outlier-B proof — two DIFFERENT machines
+    // writing per-writer files into ONE shared folder must CONVERGE through
+    // the same merge core (both peers visible from either machine), with
+    // zero GitHub. A regression that made publish clobber (single shared
+    // file) or that skipped the merge would drop one machine's peer here.
+    use super::*;
+    use crate::account_registry::AccountPeerBeacon;
+    use crate::route::RouteEndpoint;
+    use crate::subscriptions::{ChannelName, MeshIdentity};
+    use crate::PeerSpec;
+    use airc_core::PeerId;
+    use airc_protocol::PeerKeypair;
+    use tempfile::TempDir;
+
+    // Year-2100 heartbeat: `refresh` runs the reader-side freshness pass
+    // (`prune_stale_peers` vs real `now_ms`), so a beacon stamped in the
+    // 1970s would be pruned as a dead route before we ever see it. A
+    // future-dated beacon is always fresh (saturating-sub guard), which is
+    // exactly how the account_registry tests' `write_identity` helper dodges
+    // the same clock coupling.
+    const FRESH_MS: u64 = 4_102_444_800_000;
+
+    fn mesh() -> MeshIdentity {
+        MeshIdentity::new("joelteply")
+    }
+
+    fn channel(name: &str) -> ChannelName {
+        ChannelName::new(name).unwrap()
+    }
+
+    fn peer_spec(peer_id: PeerId) -> PeerSpec {
+        PeerSpec {
+            peer_id,
+            pubkey: PeerKeypair::generate().public_bytes(),
+        }
+    }
+
+    // A beacon with a NON-temp scope_home (a temp-rooted one is dropped by
+    // the merge's hermetic guard) carrying one dialable relay endpoint.
+    fn beacon(peer_id: PeerId, scope_home: &str, relay: &str) -> AccountPeerBeacon {
+        AccountPeerBeacon {
+            presence: crate::coordinator::beacon_now(
+                peer_id,
+                scope_home.into(),
+                vec![channel("general")],
+                123,
+                FRESH_MS,
+            ),
+            peer_spec: peer_spec(peer_id),
+            endpoints: vec![RouteEndpoint::Relay {
+                url: relay.to_string(),
+            }],
+        }
+    }
+
+    fn doc_for(peer: &AccountPeerBeacon, generated_at_ms: u64) -> AccountRegistryDocument {
+        AccountRegistryDocument::new(
+            mesh(),
+            generated_at_ms,
+            vec![channel("general")],
+            vec![peer.clone()],
+        )
+    }
+
+    #[tokio::test]
+    async fn publish_then_refresh_round_trips_the_document() {
+        let dir = TempDir::new().unwrap();
+        let store = FsAccountRegistryStore::new(
+            dir.path().to_path_buf(),
+            "airc-account-mesh-registry.machine-a.json",
+        );
+        let peer = PeerId::new();
+        let document = doc_for(
+            &beacon(peer, "/machine/a/.airc", "https://a.example.test"),
+            5_000,
+        );
+
+        store.publish(&document).await.expect("publish");
+        let refreshed = store
+            .refresh(&mesh())
+            .await
+            .expect("refresh")
+            .expect("a document exists after publish");
+
+        assert_eq!(refreshed.mesh_identity, mesh());
+        assert_eq!(refreshed.peers.len(), 1);
+        assert_eq!(refreshed.peers[0].peer_id(), peer);
+    }
+
+    #[tokio::test]
+    async fn two_machines_sharing_a_folder_converge_via_merge() {
+        // ONE shared rendezvous folder (the iCloud/NFS mount), TWO machines
+        // — modelled as two stores over the SAME dir with DISTINCT writer
+        // files (production derives these from host-user; here they're
+        // explicit so one process can play both machines).
+        let shared = TempDir::new().unwrap();
+        let machine_a = FsAccountRegistryStore::new(
+            shared.path().to_path_buf(),
+            "airc-account-mesh-registry.machine-a.json",
+        );
+        let machine_b = FsAccountRegistryStore::new(
+            shared.path().to_path_buf(),
+            "airc-account-mesh-registry.machine-b.json",
+        );
+
+        let peer_a = PeerId::new();
+        let peer_b = PeerId::new();
+        machine_a
+            .publish(&doc_for(
+                &beacon(peer_a, "/machine/a/.airc", "https://a.example.test"),
+                5_000,
+            ))
+            .await
+            .expect("machine a publishes");
+        machine_b
+            .publish(&doc_for(
+                &beacon(peer_b, "/machine/b/.airc", "https://b.example.test"),
+                6_000,
+            ))
+            .await
+            .expect("machine b publishes");
+
+        // Either machine, refreshing the shared folder, sees BOTH peers —
+        // the per-writer files did not clobber and the merge unioned them.
+        for (label, store) in [("a", &machine_a), ("b", &machine_b)] {
+            let merged = store
+                .refresh(&mesh())
+                .await
+                .expect("refresh")
+                .unwrap_or_else(|| panic!("machine {label} sees a merged document"));
+            let ids: Vec<PeerId> = merged.peers.iter().map(|p| p.peer_id()).collect();
+            assert!(
+                ids.contains(&peer_a) && ids.contains(&peer_b),
+                "machine {label} must see both peers via the merge, saw {ids:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_of_an_unpublished_identity_is_none_not_error() {
+        let dir = TempDir::new().unwrap();
+        let store = FsAccountRegistryStore::new(dir.path().to_path_buf(), "writer.json");
+        // Nothing published for this identity → empty, not a fault.
+        assert!(store.refresh(&mesh()).await.expect("refresh").is_none());
+    }
+}

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -1385,7 +1385,22 @@ exit 0
                 airc_store::SqliteEventStore::open_path(&db_dir.join("events.sqlite"))
                     .await
                     .unwrap();
-            GhAccountRegistryStore::new(Arc::new(event_store), scope_home).with_bin(&stub.bin)
+            // Isolate the gh governor per-test. Without this the store falls
+            // through to `GhBudget::account_default()` = the REAL machine-wide
+            // `~/.airc/gh/` — so a live backoff armed by a background airc
+            // daemon (or a sibling test arming one mid-run) denies every gh
+            // call here with "shared gh backoff active", flaking the whole
+            // gh_stub suite under parallelism. Root the budget at the STUB's
+            // state dir (per-test, but SHARED across the multiple store
+            // instances one test builds — e.g. sentinel_loss's first/reborn —
+            // so they coordinate on one governor, exactly as one machine
+            // would). Not `db_dir`: that is per-store and would hand two
+            // stores of the same machine two separate governors.
+            let governor_dir = stub.state.join("governor");
+            std::fs::create_dir_all(&governor_dir).unwrap();
+            GhAccountRegistryStore::new(Arc::new(event_store), scope_home)
+                .with_bin(&stub.bin)
+                .with_budget(crate::gh::governor::GhBudget::at(governor_dir))
         }
 
         fn mesh() -> MeshIdentity {

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -35,6 +35,7 @@
 #![deny(unsafe_code)]
 
 pub mod account_registry;
+pub mod account_registry_fs;
 pub mod adapter;
 pub mod agent_heartbeat;
 pub mod airc;
@@ -84,6 +85,7 @@ pub use account_registry::{
     AccountRegistryDocument, AccountRegistryError, AccountRegistryStore, RegistryMergeOutcome,
     SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION, DEFAULT_PEER_FRESHNESS_TTL_MS,
 };
+pub use account_registry_fs::FsAccountRegistryStore;
 pub use agent_heartbeat::{
     AgentHeartbeat, AgentLiveness, CoordinationSignal, HeartbeatKind, HeartbeatTask, RoomMember,
     DEFAULT_HEARTBEAT_INTERVAL, HEADER_HEARTBEAT_KIND, HEADER_HEARTBEAT_RUNTIME,

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -61,6 +61,7 @@ pub mod publish;
 pub mod registry;
 pub mod registry_refresh;
 mod relay;
+pub mod rendezvous;
 pub mod room;
 pub mod route;
 pub mod route_forwarder;
@@ -118,6 +119,10 @@ pub use daemon::decode_wire_event;
 pub use delivery_ack::DeliverySendOutcome;
 pub use diagnostic_event_sink::{
     AircEventDiagnosticSink, HEADER_DIAG_CODE, HEADER_DIAG_COMPONENT, HEADER_DIAG_SEVERITY,
+};
+pub use rendezvous::{
+    parse_rendezvous_dir, resolve_account_registry_store, GistRendezvous, RendezvousChoice,
+    RendezvousConfigError, RENDEZVOUS_DIR_ENV,
 };
 // Observability macros live in the substrate (airc-diagnostics) so
 // every consumer reaches for them downward: `airc_lib::probe!` /

--- a/crates/airc-lib/src/rendezvous.rs
+++ b/crates/airc-lib/src/rendezvous.rs
@@ -1,0 +1,265 @@
+//! Rendezvous provider SELECTION — the one place that picks which door
+//! the account-mesh converges through, so a fresh clone auto-picks a
+//! working rendezvous with zero manual network ops.
+//!
+//! Rendezvous is the untrusted meeting point that INITIATES the exchange;
+//! it does NOT supply security. Security lives in the E2E data plane
+//! (X25519 + ChaCha20-Poly1305, pinned peer keys, trust tiers) regardless
+//! of which door a node came through — the Tailscale model. That is why a
+//! shared folder is a legitimate peer of a GitHub gist here: swapping the
+//! meeting point changes nothing about the trust boundary.
+//!
+//! [`AccountRegistryStore`] is already swappable (`SqliteAccountRegistryStore`
+//! local cache, `GhAccountRegistryStore` gist, `FsAccountRegistryStore`
+//! shared folder). This module wires the SELECTION on top: given a
+//! [`RendezvousChoice`], [`resolve_account_registry_store`] hands back the
+//! store paired with the [`RegistryRefreshGate`] that matches it — the
+//! coupling that keeps a gist store from being handed a no-auth gate (or a
+//! folder store a gh-auth gate). The daemon refresh loop then runs against
+//! the boxed store without ever learning which door was chosen.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use airc_store::SqliteEventStore;
+
+use crate::account_registry::AccountRegistryStore;
+use crate::account_registry_fs::FsAccountRegistryStore;
+use crate::gh::account_registry::{writer_filename, GhAccountRegistryStore, GhTokenOverride};
+use crate::registry_refresh::RegistryRefreshGate;
+
+/// Env var naming a shared-folder rendezvous directory (iCloud Drive /
+/// Syncthing / NFS mount). Its PRESENCE selects the folder door; absent →
+/// the default gist door. Agents already carry `gh` for kanban/PRs, so
+/// gist is the zero-config default; the folder is the on-prem /
+/// behind-firewall (hospital) escape hatch that needs no GitHub at all.
+pub const RENDEZVOUS_DIR_ENV: &str = "AIRC_RENDEZVOUS_DIR";
+
+/// Which rendezvous transport this machine converges through.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RendezvousChoice {
+    /// GitHub gist — the default (no extra config; `gh` is already present
+    /// for kanban/PRs).
+    Gist,
+    /// Shared folder — no gh, no token, no network. The on-prem door.
+    Folder { dir: PathBuf },
+}
+
+/// A rendezvous env var was SET but unusable. Fail loud rather than
+/// silently falling back to gist — an operator who set the var meant to
+/// name a folder, and swallowing that would hide the misconfiguration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RendezvousConfigError {
+    /// `AIRC_RENDEZVOUS_DIR` was set to an empty/whitespace value.
+    EmptyDir,
+    /// `AIRC_RENDEZVOUS_DIR` held non-UTF-8 bytes.
+    NonUnicodeDir,
+}
+
+impl std::fmt::Display for RendezvousConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyDir => write!(
+                f,
+                "{RENDEZVOUS_DIR_ENV} was set but empty — name a shared-folder path or unset it to use the gist rendezvous"
+            ),
+            Self::NonUnicodeDir => write!(
+                f,
+                "{RENDEZVOUS_DIR_ENV} held non-UTF-8 bytes — set it to a valid filesystem path"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RendezvousConfigError {}
+
+/// Pure parse of the `AIRC_RENDEZVOUS_DIR` env read into a choice, split
+/// out from [`RendezvousChoice::from_env`] so it is testable without
+/// process-global env mutation (which would break test parallelism).
+pub fn parse_rendezvous_dir(
+    var: Result<String, std::env::VarError>,
+) -> Result<RendezvousChoice, RendezvousConfigError> {
+    match var {
+        Ok(dir) if dir.trim().is_empty() => Err(RendezvousConfigError::EmptyDir),
+        Ok(dir) => Ok(RendezvousChoice::Folder {
+            dir: PathBuf::from(dir),
+        }),
+        Err(std::env::VarError::NotPresent) => Ok(RendezvousChoice::Gist),
+        Err(std::env::VarError::NotUnicode(_)) => Err(RendezvousConfigError::NonUnicodeDir),
+    }
+}
+
+impl RendezvousChoice {
+    /// Resolve from the environment: `AIRC_RENDEZVOUS_DIR=<path>` selects a
+    /// shared-folder rendezvous; unset → the default gist. Set-but-empty /
+    /// non-UTF-8 fail loud.
+    pub fn from_env() -> Result<Self, RendezvousConfigError> {
+        parse_rendezvous_dir(std::env::var(RENDEZVOUS_DIR_ENV))
+    }
+}
+
+/// The gh-specific inputs the gist door needs. Supplied unconditionally by
+/// the caller; ignored by the folder door (which needs no auth, no token,
+/// no local event store).
+pub struct GistRendezvous {
+    /// Local cache store the gh adapter records "what we last sent/received"
+    /// into.
+    pub event_store: Arc<SqliteEventStore>,
+    /// Scope home the gh-auth gate probes and the store publishes under.
+    pub scope_home: PathBuf,
+    /// Explicit `gh` binary path (a detached daemon can't rely on PATH).
+    pub gh_bin: Option<PathBuf>,
+    /// Stale-token recovery slot shared by store + gate (card 1f2cbffa).
+    pub token_override: GhTokenOverride,
+}
+
+/// Pick the store for `choice` and pair it with the gate that MATCHES it.
+///
+/// Returning a `Box<dyn AccountRegistryStore>` (which itself impls the
+/// trait — see the delegating impl in `account_registry`) lets the two
+/// doors flow through `run_loop`'s generic `S: AccountRegistryStore` bound
+/// unchanged. The gate is the load-bearing pairing: gist → `GhAuth`
+/// (hermetic + `gh auth status` probe), folder → `Always` (no external
+/// auth to gate on).
+pub fn resolve_account_registry_store(
+    choice: RendezvousChoice,
+    gist: GistRendezvous,
+) -> (Box<dyn AccountRegistryStore>, RegistryRefreshGate) {
+    match choice {
+        RendezvousChoice::Gist => {
+            let store = match &gist.gh_bin {
+                Some(bin) => GhAccountRegistryStore::new(gist.event_store, &gist.scope_home)
+                    .with_bin(bin.clone()),
+                None => GhAccountRegistryStore::new(gist.event_store, &gist.scope_home),
+            }
+            .with_token_override(gist.token_override.clone());
+            let gate = RegistryRefreshGate::GhAuth {
+                gh_bin: gist.gh_bin,
+                scope_home: gist.scope_home,
+                token_override: Some(gist.token_override),
+            };
+            (Box::new(store), gate)
+        }
+        RendezvousChoice::Folder { dir } => {
+            // Same per-writer filename discipline the gist door uses, so
+            // writer identity is stable if a machine ever switches doors.
+            let store = FsAccountRegistryStore::new(dir, writer_filename());
+            (Box::new(store), RegistryRefreshGate::Always)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::account_registry::AccountRegistryStore;
+    use crate::subscriptions::MeshIdentity;
+    use tempfile::TempDir;
+
+    // what this catches: the env→choice contract — unset is the gist
+    // default, a set path selects the folder door, and a set-but-empty
+    // value fails loud instead of silently defaulting to gist (which would
+    // hide an operator's misconfiguration).
+    #[test]
+    fn unset_env_selects_the_gist_default() {
+        let choice =
+            parse_rendezvous_dir(Err(std::env::VarError::NotPresent)).expect("unset is valid");
+        assert_eq!(choice, RendezvousChoice::Gist);
+    }
+
+    #[test]
+    fn a_set_path_selects_the_folder_door() {
+        let choice =
+            parse_rendezvous_dir(Ok("/mnt/mesh-share".to_string())).expect("a path is valid");
+        assert_eq!(
+            choice,
+            RendezvousChoice::Folder {
+                dir: PathBuf::from("/mnt/mesh-share")
+            }
+        );
+    }
+
+    #[test]
+    fn an_empty_value_fails_loud_not_silent_gist() {
+        assert_eq!(
+            parse_rendezvous_dir(Ok("   ".to_string())),
+            Err(RendezvousConfigError::EmptyDir)
+        );
+    }
+
+    async fn temp_event_store() -> (TempDir, Arc<SqliteEventStore>) {
+        let home = TempDir::new().expect("event-store home");
+        let store = SqliteEventStore::open_path(&home.path().join("events.sqlite"))
+            .await
+            .expect("open temp event store");
+        (home, Arc::new(store))
+    }
+
+    // what this catches: the folder door pairs an `Always` gate (never a
+    // gh-auth gate that would block a no-GitHub rendezvous), and the boxed
+    // store it hands back is a REAL working fs store — publishing routes a
+    // file into the shared folder. This is the zero-network on-prem path.
+    #[tokio::test]
+    async fn folder_choice_pairs_always_gate_and_writes_to_the_folder() {
+        let (_home, event_store) = temp_event_store().await;
+        let share = TempDir::new().expect("rendezvous share dir");
+        let (store, gate) = resolve_account_registry_store(
+            RendezvousChoice::Folder {
+                dir: share.path().to_path_buf(),
+            },
+            GistRendezvous {
+                event_store,
+                scope_home: PathBuf::from("/unused/for/folder"),
+                gh_bin: None,
+                token_override: GhTokenOverride::new(),
+            },
+        );
+        assert!(
+            matches!(gate, RegistryRefreshGate::Always),
+            "folder door must pair the no-auth Always gate"
+        );
+
+        let mesh = MeshIdentity::new("joelteply");
+        let document =
+            crate::account_registry::AccountRegistryDocument::new(mesh.clone(), 0, vec![], vec![]);
+        store
+            .publish(&document)
+            .await
+            .expect("folder store publishes");
+
+        // A file landed under <share>/<sanitized-identity>/ — proof the
+        // boxed store is the fs store, wired end to end, no GitHub.
+        let identity_dir = share.path().join(mesh.as_str());
+        let entries: Vec<_> = std::fs::read_dir(&identity_dir)
+            .expect("identity dir exists after publish")
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+            .collect();
+        assert_eq!(entries.len(), 1, "exactly one writer file published");
+    }
+
+    // what this catches: the gist door pairs the gh-auth gate carrying the
+    // SAME scope_home it was given — the coupling that lets stale-token
+    // recovery re-probe the right home.
+    #[tokio::test]
+    async fn gist_choice_pairs_ghauth_gate_with_the_scope_home() {
+        let (_home, event_store) = temp_event_store().await;
+        let scope_home = PathBuf::from("/scope/home/gist");
+        let (_store, gate) = resolve_account_registry_store(
+            RendezvousChoice::Gist,
+            GistRendezvous {
+                event_store,
+                scope_home: scope_home.clone(),
+                gh_bin: None,
+                token_override: GhTokenOverride::new(),
+            },
+        );
+        match gate {
+            RegistryRefreshGate::GhAuth {
+                scope_home: gated_home,
+                ..
+            } => assert_eq!(gated_home, scope_home),
+            other => panic!("gist door must pair a GhAuth gate, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## What

A second, maximally-different `AccountRegistryStore` impl — a **shared-folder rendezvous** (iCloud Drive / Syncthing / NFS mount) that N machines of one account see, needing **no `gh` CLI, no token, no network**. This is the outlier-B that proves the rendezvous seam (`GhAccountRegistryStore` = outlier A) is genuinely swappable.

## Why

Rendezvous **initiates** the exchange; it does not **supply** the security — that lives in the E2E data plane (paired peer keys, trust tiers) regardless of which door a node came through, exactly the Tailscale coordination-server shape. So a second door is free to be dumb and credential-free. Two payoffs:

- **"Other means if gist went away."** If GitHub/gist is unavailable, this is already a working substitute at the same seam.
- **On-prem / behind-firewall grid.** A hospital deploy can't reach GitHub; a shared mount is the rendezvous there.

## Fidelity — same convergence core as gist

gh keeps one gist **per writer/machine** and `refresh` folds them all via `merge_registry_documents` (freshest beacon per peer, union, skip foreign-mesh, prune stale). This does the byte-identical thing on a filesystem: each machine writes its doc to a **per-writer file** (`<dir>/<identity>/<writer_file>`) so two machines never clobber, and `refresh` reads every writer file and runs the **same** `merge_registry_documents` + `prune_stale_peers` — the merge/freshness logic stays in exactly one place.

- **publish:** validate → pretty JSON → atomic pid-temp write + rename (a concurrent `refresh` on another machine never reads a half-written doc)
- **refresh:** read every `.json` writer file (skips `.tmp` staging + OS cruft like `.DS_Store`/`.icloud`), **fail loud** on a corrupt writer file, merge, prune stale
- unpublished identity → `Ok(None)`, not an error (mirrors gh's no-gist → None)

## Tests (one mod, `// what this catches:`)

- `publish_then_refresh_round_trips_the_document`
- **`two_machines_sharing_a_folder_converge_via_merge`** — the keystone: two writers, one shared dir, distinct writer files → both peers merged, **zero GitHub**
- `refresh_of_an_unpublished_identity_is_none_not_error`

Pure-Rust validated: `cargo test -p airc-lib --lib account_registry_fs` → 3 passed, clippy clean, fmt clean.

## Not in this PR (follow-up slice)

Provider **selection** — a `resolve_account_registry_store(...)` seam + a `RegistryRefreshGate::AlwaysReady` variant for the no-auth fs path, rewiring the hardcoded `GhAccountRegistryStore::new` boot sites. This PR only proves the trait is swappable; wiring the selector is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)