### PR TITLE
fix(update): no-op auto-update must never touch the daemon

### DIFF
--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -66,9 +66,18 @@ pub fn run_update(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std::error
 /// leave a peer with a binary that compiles-but-doesn't-run.
 ///
 /// Flow: fetch + ff-pull the channel → if HEAD unchanged, nothing to do
-/// → else back up the installed binary to `airc.prev`, rebuild in place,
-/// smoke-test (the new binary's `version` reports the pulled SHA), and on
-/// failure restore `airc.prev`.
+/// (the daemon is NEVER touched — see below) → else stop the daemon, back
+/// up the installed binary to `airc.prev`, rebuild in place, smoke-test
+/// (the new binary's `version` reports the pulled SHA), and on failure
+/// restore `airc.prev`.
+///
+/// The no-op path must not restart the daemon: `git fetch`/`pull` only
+/// touch the source checkout, never the running binary, so only the
+/// rebuild+swap needs the daemon down. The pre-fix shape stopped the
+/// daemon BEFORE the SHA compare, which killed the transport owner every
+/// hourly "nothing to auto-update" tick — wiping in-process room state
+/// and blinding every subscribed client for the restart window
+/// (continuum blind-room incidents #2/#3, 2026-07-11/12).
 ///
 /// Platform note: on Windows the live `airc.exe` is locked while this
 /// process runs, so the in-place reinstall (and thus the swap) inherits
@@ -91,9 +100,6 @@ pub fn run_update_auto(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std::
     }
     let before = git_text(&source, ["rev-parse", "--short", "HEAD"])?;
 
-    if daemon_was_running {
-        stop_daemon(&airc_exe, home, &socket)?;
-    }
     run_checked(
         Command::new("git")
             .arg("-C")
@@ -111,12 +117,17 @@ pub fn run_update_auto(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std::
     let after = git_text(&source, ["rev-parse", "--short", "HEAD"])?;
 
     if before == after {
+        // Nothing pulled → nothing to rebuild → the daemon was never
+        // stopped and MUST NOT be restarted. Restart-on-no-op is the bug
+        // this ordering exists to prevent (hourly transport-owner death).
         println!("Already at {after} — nothing to auto-update.");
-        if daemon_was_running {
-            restart_daemon(&airc_exe, home, &socket)?;
-            wait_daemon_ready(&airc_exe, home, &socket)?;
-        }
         return Ok(());
+    }
+
+    // A real update is pending — only NOW does the binary swap need the
+    // transport owner down.
+    if daemon_was_running {
+        stop_daemon(&airc_exe, home, &socket)?;
     }
 
     // Back up the live binary BEFORE the rebuild — this is the rollback


### PR DESCRIPTION
## The bug

`run_update_auto` stops the transport-owner daemon **before** the fetch/ff-pull/SHA-compare. The daemon-side trigger fires every 3600s, so every node paid a **daemon death per hour** even when there was nothing to update ("Already at … — nothing to auto-update" → restart).

## Observed cost (live forensics, 2026-07-11/12)

Hourly at :54, like clockwork (`airc-daemon.log`: `airc daemon: stopped.` immediately followed by `Already at 61e79d5 — nothing to auto-update.`):
- in-process room state wiped every hour
- every subscribed client's channel reattach racing a socket that briefly doesn't exist (16 `reattach failed … No such file or directory` per node per hour)
- continuum personas' room perception going dark mid-conversation — blind-room incidents #2/#3 both trace to this metronome

Worse: if the fetch/pull errors after the stop (e.g. unreachable origin), the error path returns **without restarting** — daemon left dead.

## The fix

`git fetch`/`pull` only touch the source checkout, never the running binary — only the rebuild+swap needs the daemon down. New flow: fetch → pull → compare; unchanged HEAD returns with the daemon **untouched**; only a real pending update stops the daemon for backup/rebuild/smoke-test/swap. Rollback path unchanged.

Validated: `cargo clippy -p airc-cli --all-targets` clean; all `update_commands` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo