### PR TITLE
fix(work): board verb reads the complete projection — chat traffic must never empty the board

### DIFF
--- a/crates/airc-cli/src/lane_cli.rs
+++ b/crates/airc-cli/src/lane_cli.rs
@@ -32,7 +32,9 @@ pub enum LaneAction {
     },
     /// Print the current room's lane projection.
     Status {
-        /// Recent transcript events to replay into the projection.
+        /// Deprecated no-op (kept so existing invocations still parse):
+        /// the projection is always complete now — continuum #154, the
+        /// recent-window read lost durable state to chat traffic.
         #[arg(long, default_value_t = 128)]
         limit: usize,
     },
@@ -62,7 +64,8 @@ pub enum LaneManagerAction {
     },
     /// Print current manager hats from the board projection.
     Status {
-        /// Recent transcript events to replay into the projection.
+        /// Deprecated no-op (kept so existing invocations still parse):
+        /// the projection is always complete now — continuum #154.
         #[arg(long, default_value_t = 128)]
         limit: usize,
     },

--- a/crates/airc-cli/src/lane_commands.rs
+++ b/crates/airc-cli/src/lane_commands.rs
@@ -44,9 +44,9 @@ pub async fn run_state(
     Ok(())
 }
 
-pub async fn run_status(home: &Path, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run_status(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let airc = crate::commands::attached_airc(home).await?;
-    let board = airc.work_board(limit).await?;
+    let board = airc.work_board().await?;
     print_status(&board);
     Ok(())
 }
@@ -79,12 +79,9 @@ pub async fn run_manager_release(
     Ok(())
 }
 
-pub async fn run_manager_status(
-    home: &Path,
-    limit: usize,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run_manager_status(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let airc = crate::commands::attached_airc(home).await?;
-    let board = airc.work_board(limit).await?;
+    let board = airc.work_board().await?;
     print_manager_status(&board);
     Ok(())
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -832,7 +832,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             LaneAction::State { lane_id, state } => {
                 lane_commands::run_state(&home, lane_id, state).await
             }
-            LaneAction::Status { limit } => lane_commands::run_status(&home, limit).await,
+            LaneAction::Status { limit: _ } => lane_commands::run_status(&home).await,
             LaneAction::Manager { action } => match action {
                 LaneManagerAction::Claim { repo, ttl_ms } => {
                     lane_commands::run_manager_claim(&home, repo, ttl_ms).await
@@ -840,8 +840,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 LaneManagerAction::Release { repo } => {
                     lane_commands::run_manager_release(&home, repo).await
                 }
-                LaneManagerAction::Status { limit } => {
-                    lane_commands::run_manager_status(&home, limit).await
+                LaneManagerAction::Status { limit: _ } => {
+                    lane_commands::run_manager_status(&home).await
                 }
             },
         },
@@ -922,7 +922,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             WorkspaceAction::Release { workspace_id } => {
                 workspace_commands::run_release(&home, workspace_id).await
             }
-            WorkspaceAction::List { limit } => workspace_commands::run_list(&home, limit).await,
+            WorkspaceAction::List { limit: _ } => workspace_commands::run_list(&home).await,
         },
 
         Command::QueueCard(args) => match args.action {

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -163,7 +163,9 @@ pub enum WorkAction {
     /// over the projection so peers can see their slice fast (kink
     /// b408698c). When none are passed, the full board is shown.
     Board {
-        /// Recent transcript events to replay into the projection.
+        /// Maximum card rows to display (newest kept). The projection
+        /// itself is always complete — continuum #154: the old
+        /// recent-window read lost durable cards to chat traffic.
         #[arg(long, default_value_t = 128)]
         limit: usize,
         /// Show only cards available to claim now: no active claim, or

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1979,7 +1979,10 @@ pub async fn run_board(
     filter: BoardFilter,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = crate::commands::attached_airc(home).await?;
-    let board = airc.work_board(limit).await?;
+    // Continuum #154: the board is always the COMPLETE projection —
+    // the old recent-window read lost every durable card to chat
+    // traffic in busy rooms. `limit` now caps displayed rows only.
+    let board = airc.work_board().await?;
     let me = airc.peer_id();
 
     // Pre-fetch published aliases for every distinct non-self owner on
@@ -2011,7 +2014,7 @@ pub async fn run_board(
         }
     }
 
-    print_board(&board, me, filter, &aliases);
+    print_board(&board, me, filter, &aliases, limit);
     Ok(())
 }
 
@@ -2154,6 +2157,7 @@ fn print_board(
     me: airc_lib::PeerId,
     filter: BoardFilter,
     aliases: &std::collections::HashMap<airc_lib::PeerId, String>,
+    limit: usize,
 ) {
     let snapshot = board.snapshot();
     if snapshot.cards.is_empty() && snapshot.agent_availability.is_empty() {
@@ -2163,20 +2167,36 @@ fn print_board(
     let stale_claims = board.stale_claims(now_ms());
 
     let now = now_ms();
-    let visible: Vec<&airc_work::WorkCard> = snapshot
+    let mut visible: Vec<&airc_work::WorkCard> = snapshot
         .cards
         .iter()
         .filter(|card| filter.matches(card, me, now))
         .collect();
+    // Continuum #154: `limit` caps displayed ROWS of the complete
+    // projection (newest kept), never the event window the board is
+    // built from — truncation is announced, never silent.
+    let matched = visible.len();
+    if matched > limit.max(1) {
+        visible = visible.split_off(matched - limit.max(1));
+    }
     if !visible.is_empty() {
         if matches!(filter, BoardFilter::All) {
-            println!("work cards: {}", visible.len());
+            if visible.len() < matched {
+                println!(
+                    "work cards: showing {} of {} (raise --limit for the rest)",
+                    visible.len(),
+                    matched,
+                );
+            } else {
+                println!("work cards: {}", visible.len());
+            }
         } else {
             println!(
-                "work cards: {} (filter={:?}, hidden={})",
+                "work cards: {} of {} matched (filter={:?}, hidden={})",
                 visible.len(),
+                matched,
                 filter,
-                snapshot.cards.len() - visible.len(),
+                snapshot.cards.len() - matched,
             );
         }
     } else if !matches!(filter, BoardFilter::All) {

--- a/crates/airc-cli/src/workspace_cli.rs
+++ b/crates/airc-cli/src/workspace_cli.rs
@@ -49,7 +49,8 @@ pub enum WorkspaceAction {
     },
     /// Print the current room's projected workspace leases.
     List {
-        /// Recent transcript events to replay into the projection.
+        /// Deprecated no-op (kept so existing invocations still parse):
+        /// the projection is always complete now — continuum #154.
         #[arg(long, default_value_t = 128)]
         limit: usize,
     },

--- a/crates/airc-cli/src/workspace_commands.rs
+++ b/crates/airc-cli/src/workspace_commands.rs
@@ -74,9 +74,9 @@ pub async fn run_release(
     Ok(())
 }
 
-pub async fn run_list(home: &Path, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run_list(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let airc = crate::commands::attached_airc(home).await?;
-    let board = airc.work_board(limit).await?;
+    let board = airc.work_board().await?;
     print_workspaces(&board);
     Ok(())
 }

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -1,5 +1,11 @@
 //! Consumer request structs for the work coordination API.
 
+use crate::time::now_ms;
+use crate::work_board_cache::{
+    cursor_strictly_before, zero_transcript_cursor, WorkBoardCache, WorkBoardCacheSource,
+    WORK_BOARD_CACHE_FORMAT_VERSION,
+};
+use crate::{Airc, AircError};
 use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
@@ -12,39 +18,18 @@ use airc_work::{
     WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated, WorkspaceHeartbeat, WorkspaceId,
     WorkspaceReleased, WorkspaceRequested,
 };
-use airc_work_store::WorkEventStore;
-
-use crate::time::now_ms;
-use crate::work_board_cache::{
-    cursor_strictly_before, zero_transcript_cursor, WorkBoardCache, WorkBoardCacheSource,
-    WORK_BOARD_CACHE_FORMAT_VERSION,
-};
-use crate::{Airc, AircError};
 
 const WORK_MUTATION_PAGE_SIZE: usize = 512;
 
-/// Card 79953b4d: how many raw transcript events to fetch from the
-/// daemon per requested work board page entry. Heartbeats with their
-/// d4e3e350 coordination payload share the recent-event window with
-/// work events; with N active peers heart-beating every 60s a flat
-/// `limit`-event scan can be ~90% heartbeats. 4x over-fetch trades a
-/// bit of IPC bandwidth for the property "user's requested `limit`
-/// number of work events actually lands in the projection." Server-
-/// side filtering at the daemon's page rpc would be cleaner; this is
-/// the minimum-viable fix until that follow-up.
-const WORK_BOARD_FETCH_MULTIPLIER: usize = 4;
-
 /// Canonical pagination size for complete work-board projections.
 ///
-/// Card acd72c81: every prior caller that needed the complete board
-/// was passing `usize::MAX` to `work_board(limit)`. That issues ONE
-/// Inbox RPC asking for `usize::MAX * WORK_BOARD_FETCH_MULTIPLIER`
-/// events; the daemon serializes every transcript event in the room
-/// into a single CBOR frame, which trips
-/// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
-/// accumulates ~9000+ events. Empirically caught on Joel's box
-/// 2026-06-01: `airc work state X closed` failed with
-/// `daemon I/O: ipc frame too large: 16973574 bytes exceeds 16777216`.
+/// Card acd72c81: a complete projection read as ONE Inbox RPC asks the
+/// daemon to serialize every transcript event in the room into a
+/// single CBOR frame, which trips `airc_ipc::codec::MAX_FRAME_BYTES`
+/// (16 MiB) once the room accumulates ~9000+ events. Empirically
+/// caught on Joel's box 2026-06-01: `airc work state X closed` failed
+/// with `daemon I/O: ipc frame too large: 16973574 bytes exceeds
+/// 16777216`.
 ///
 /// `work_board_complete(page_size)` paginates: each IPC frame stays
 /// well under the cap while the projection is still complete.
@@ -53,18 +38,6 @@ const WORK_BOARD_FETCH_MULTIPLIER: usize = 4;
 /// and the round-trip count stays low for the 9000+ event case
 /// (~9 RPCs instead of one giant one).
 pub const WORK_BOARD_PROJECTION_PAGE_SIZE: usize = 1024;
-
-/// Card 79953b4d (pure helper for unit-testability): true when a
-/// transcript event is a work-domain event. Distinguishes work events
-/// from heartbeats / chat / other lifecycle by header presence rather
-/// than body shape — every work event carries
-/// `HEADER_FORGE_WORK_EVENT_KIND`; heartbeats and chat do not.
-fn is_work_event_transcript(event: &airc_core::TranscriptEvent) -> bool {
-    event
-        .headers
-        .iter()
-        .any(|(key, _)| key == airc_work::HEADER_FORGE_WORK_EVENT_KIND)
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateWorkCard {
@@ -843,45 +816,18 @@ impl Airc {
         })
     }
 
-    /// Rebuild the current room's work board from persisted work
-    /// events. `limit` is the transcript page size for interactive
-    /// board views; scheduling code should use
-    /// [`Airc::work_board_complete`] instead.
-    ///
-    /// **DO NOT pass `usize::MAX`** — it issues a single Inbox RPC
-    /// asking for every event in the room, which trips
-    /// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
-    /// has accumulated ~9000+ events. If you need the complete
-    /// board, call [`Airc::work_board_complete`] with
-    /// [`WORK_BOARD_PROJECTION_PAGE_SIZE`] (paginated, never hits
-    /// the cap). Card acd72c81.
-    pub async fn work_board(&self, limit: usize) -> Result<WorkBoardProjection, AircError> {
-        let room = self.current_room().await?;
-        // Recent-window view (not the complete board): daemon reads the
-        // most-recent `limit`; direct reads the recent store page.
-        if self.is_daemon_attached() {
-            // Card 79953b4d: heartbeats with the d4e3e350 coordination
-            // payload (active_claims + doctrine_version) dominate the
-            // recent-event window at scale. With three+ peers heart-
-            // beating every 60s, a flat `limit`-event page fills with
-            // heartbeats and squeezes card lifecycle events out — the
-            // projection then misses recent cards even when they're
-            // durably in the transcript. Filter to events carrying
-            // HEADER_FORGE_WORK_EVENT_KIND (work-domain events only)
-            // and over-fetch by WORK_BOARD_FETCH_MULTIPLIER so the
-            // projection sees `limit` work events worth of history.
-            let fetch_limit = limit.saturating_mul(WORK_BOARD_FETCH_MULTIPLIER);
-            let transcripts: Vec<_> = self
-                .daemon_page_recent(&room, fetch_limit)
-                .await?
-                .into_iter()
-                .filter(is_work_event_transcript)
-                .take(limit)
-                .collect();
-            return Ok(airc_work_store::project_transcripts(transcripts)?);
-        }
-        let store = WorkEventStore::new(self.event_store());
-        Ok(store.project_recent(Some(room.channel), limit).await?)
+    /// The current room's complete work board — the interactive board
+    /// view. Continuum #154: this used to be a recent-window projection
+    /// (`limit × WORK_BOARD_FETCH_MULTIPLIER` transcript events, work-
+    /// event-filtered); in any chat-heavy room every work event ages out
+    /// of that window and the board projects EMPTY while cards durably
+    /// exist — the instrument lies. Cards are event-sourced state, not
+    /// recent traffic, so the board verb reads the same complete cached
+    /// projection the scheduling/mutation paths use (cheap since card
+    /// 1291173d: snapshot + incremental resume).
+    pub async fn work_board(&self) -> Result<WorkBoardProjection, AircError> {
+        self.work_board_complete(WORK_BOARD_PROJECTION_PAGE_SIZE)
+            .await
     }
 
     /// Rebuild the current room's complete work board. Scheduling and
@@ -1277,66 +1223,6 @@ fn availability_state_rank(state: AgentAvailabilityState) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use airc_core::headers::Headers;
-    use airc_core::{ClientId, EventId, MentionTarget, RoomId, TranscriptKind};
-
-    fn event_with_headers(headers: Headers) -> airc_core::TranscriptEvent {
-        airc_core::TranscriptEvent {
-            event_id: EventId::new(),
-            room_id: RoomId::new(),
-            peer_id: airc_core::PeerId::new(),
-            client_id: ClientId::new(),
-            kind: TranscriptKind::System,
-            occurred_at_ms: 0,
-            lamport: 0,
-            target: MentionTarget::All,
-            headers,
-            body: None,
-            attachment: None,
-            receipt: None,
-            metadata: serde_json::Value::Null,
-        }
-    }
-
-    #[test]
-    fn work_event_transcript_filter_pins_header_presence_not_body_shape() {
-        // Card 79953b4d: at scale, heartbeats with the d4e3e350
-        // coordination payload share the recent-event window. The
-        // distinguishing signal is HEADER_FORGE_WORK_EVENT_KIND —
-        // every work event carries it, heartbeats / chat / generic
-        // lifecycle do not.
-
-        // Work event: header present → keep.
-        let mut work_headers = Headers::new();
-        work_headers.insert(
-            airc_work::HEADER_FORGE_WORK_EVENT_KIND.to_owned(),
-            "card_created".to_owned(),
-        );
-        assert!(is_work_event_transcript(&event_with_headers(work_headers)));
-
-        // Empty headers (e.g. raw heartbeat alive) → drop.
-        assert!(!is_work_event_transcript(&event_with_headers(
-            Headers::new()
-        )));
-
-        // Unrelated header only (e.g. a chat msg with bridge headers) → drop.
-        let mut other_headers = Headers::new();
-        other_headers.insert("airc.bridge.source".to_owned(), "slack".to_owned());
-        assert!(!is_work_event_transcript(&event_with_headers(
-            other_headers
-        )));
-
-        // Mixed headers including the work-kind header → keep
-        // (work events often carry several headers like
-        // forge.work.card_id alongside forge.work.kind).
-        let mut mixed_headers = Headers::new();
-        mixed_headers.insert(
-            airc_work::HEADER_FORGE_WORK_EVENT_KIND.to_owned(),
-            "card_claimed".to_owned(),
-        );
-        mixed_headers.insert("forge.work.card_id".to_owned(), "abc".to_owned());
-        assert!(is_work_event_transcript(&event_with_headers(mixed_headers)));
-    }
 
     #[test]
     fn build_operator_card_created_never_emits_origin_none() {

--- a/crates/airc-lib/src/work_board_cache.rs
+++ b/crates/airc-lib/src/work_board_cache.rs
@@ -160,7 +160,16 @@ impl WorkBoardCache {
             .ok_or_else(|| std::io::Error::other("cache path has no parent directory"))?;
         std::fs::create_dir_all(dir)?;
         let bytes = serde_json::to_vec(self).map_err(std::io::Error::other)?;
-        let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+        // Temp name unique per ATTEMPT, not just per process: an embedded
+        // consumer (continuum core) runs many board reads concurrently in
+        // ONE process, and a pid-only suffix made concurrent saves share a
+        // tmp file — the first rename consumed it, the second ENOENT'd, so
+        // the snapshot never persisted and every subsequent read full-
+        // replayed the room (observed live 2026-07-13: paired failure
+        // lines per persona in the continuum core log).
+        static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = path.with_extension(format!("tmp.{}.{seq}", std::process::id()));
         std::fs::write(&tmp, bytes)?;
         std::fs::rename(&tmp, path)?;
         Ok(())
@@ -193,6 +202,35 @@ mod tests {
         let loaded = WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon)
             .expect("snapshot loads back");
         assert_eq!(loaded, cache);
+    }
+
+    // what this catches: concurrent saves to the SAME snapshot path must
+    // all persist (continuum #154 tail, live 2026-07-13). The tmp file was
+    // named per-process only, so two threads saving one persona's cache
+    // shared a tmp: the first rename consumed it, the second ENOENT'd, and
+    // the cache never engaged — every board read full-replayed the room.
+    #[test]
+    fn concurrent_saves_to_one_path_all_persist() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let channel = RoomId::from_u128(9);
+        let results: Vec<std::io::Result<()>> = std::thread::scope(|scope| {
+            (0..8)
+                .map(|_| {
+                    let home = home.path();
+                    scope.spawn(move || {
+                        let cache = sample(channel);
+                        cache.try_save(&WorkBoardCache::path(home, channel))
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(|h| h.join().expect("thread"))
+                .collect()
+        });
+        for r in results {
+            r.expect("every concurrent save must persist — shared tmp names race");
+        }
+        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon).is_some());
     }
 
     #[test]

--- a/crates/airc-lib/tests/work_board_cache.rs
+++ b/crates/airc-lib/tests/work_board_cache.rs
@@ -188,6 +188,36 @@ async fn snapshot_with_rewound_log_is_rebuilt_never_served_stale() {
     );
 }
 
+// what this catches: continuum #154 — `airc work board` projected EMPTY
+// in a live persona room while 9 cards durably existed and claims flowed.
+// The interactive board verb read a recent-window projection
+// (`limit × WORK_BOARD_FETCH_MULTIPLIER` transcript events); four personas
+// chatting push every work event outside that window within the hour, so
+// the instrument lies ("no work cards") about a board that is full. The
+// board verb must project from the complete (cached) projection: a card
+// followed by any amount of chat traffic is still on the board.
+#[tokio::test]
+async fn board_survives_chat_flood() {
+    let machine = Machine::boot().await;
+    let airc = machine.solo("board-chat-flood").await;
+
+    create_card(&airc, "buried by chatter").await;
+
+    // Flood well past the old recent-window (default limit 128 × 4).
+    for i in 0..600 {
+        airc.say(&format!("persona chatter {i}"))
+            .await
+            .expect("chat send");
+    }
+
+    let board = airc.work_board().await.expect("board");
+    assert_eq!(
+        card_titles(&board),
+        vec!["buried by chatter".to_string()],
+        "interactive board lost a durable card to chat traffic"
+    );
+}
+
 #[tokio::test]
 async fn corrupt_snapshot_is_discarded_and_rebuilt() {
     let machine = Machine::boot().await;


### PR DESCRIPTION
## The live bug (continuum #154)

In the persona room (4 personas chatting continuously), `airc work board` printed `(no work cards)` while **9 cards durably existed and claims flowed**. The interactive board verb read a *recent-window* projection — `limit × WORK_BOARD_FETCH_MULTIPLIER` transcript events, filtered to work events. Chat traffic pushes every work event outside that window within the hour, so the instrument lies about a full board. `lane status`, `lane manager status`, and `workspace list` shared the same trap.

## The fix

Cards are event-sourced **state**, not recent traffic. The board verb now reads the same complete cached projection the scheduling/mutation paths already use (`work_board_complete`, cheap since card 1291173d snapshot + incremental resume):

- `Airc::work_board()` → complete projection; the recent-window read, the 4× over-fetch multiplier (card 79953b4d), and the work-event transcript filter are **deleted** — they were the minimum-viable patch for this same disease, cured at the root now.
- `airc work board --limit` becomes an announced display-row cap (newest kept, `showing N of M`); lane/manager/workspace `--limit` flags stay parseable as documented no-ops so existing persona invocations don't break.
- New integration pin: `board_survives_chat_flood` — card + 600 chat events → card still on the board.

## Validation

- `cargo check --workspace` clean
- `cargo test -p airc-lib --test work_board_cache` — 5/5 incl. the new pin
- `cargo test -p airc-lib --lib work` — 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo