### PR TITLE
fix(work): settled cards (Review/Merged/Closed) refuse claims — CardState gates the claim path

### DIFF
--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -129,6 +129,20 @@ pub enum AircError {
         owner: Option<airc_core::PeerId>,
     },
 
+    /// Caller attempted to claim a card whose lifecycle state is past
+    /// claiming (Review/Merged/Closed). Live evidence (2026-07-24):
+    /// personas kept re-claiming ALREADY-COMPLETED cards because the
+    /// claim guard only checked lease expiry, not state — settled work
+    /// looked open to every board reader. Settled cards are history,
+    /// not backlog.
+    #[error(
+        "work card {card_id} is {state:?} — settled work is not claimable; pick an Open card (or reopen this one explicitly with `airc work state`)"
+    )]
+    WorkCardNotClaimable {
+        card_id: airc_work::WorkCardId,
+        state: airc_work::CardState,
+    },
+
     /// Card 09fddedd: `relink` supersedes an EXISTING link — a card
     /// with no linked PR has nothing to supersede. Use `airc work
     /// link` for the first link; refusing here keeps the audit

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -1155,6 +1155,19 @@ impl Airc {
                 room_id: room.channel,
             });
         };
+        // Settled work is history, not backlog: a Review/Merged/Closed card is
+        // past claiming regardless of lease status. Live evidence (2026-07-24):
+        // personas kept re-claiming already-completed cards because this guard
+        // only checked lease expiry — the board read as open work forever.
+        // Reopening is an explicit `airc work state` transition, never a claim.
+        if matches!(
+            card.state,
+            airc_work::CardState::Review
+                | airc_work::CardState::Merged
+                | airc_work::CardState::Closed
+        ) {
+            return Err(AircError::WorkCardNotClaimable { card_id, state: card.state });
+        }
         let now_ms = now_ms()?;
         if card.claim_id.is_none()
             || card


### PR DESCRIPTION
Personas spent the day re-claiming already-completed cards: the claim guard checked lease expiry only, so settled work read as open backlog to every board reader. This gates claims on CardState with a loud WorkCardNotClaimable error naming the state and the explicit reopen path. 324 airc-lib tests green. Test debt noted in-commit: the seam needs a board-fixture regression test when that harness exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo