### PR TITLE
fix(self-heal): proof-of-life revives a DEAD dial endpoint — live-beaconing peer no longer stuck at 0-connected (#240)

### DIFF
--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -129,6 +129,20 @@ pub enum AircError {
         owner: Option<airc_core::PeerId>,
     },
 
+    /// Caller attempted to claim a card whose lifecycle state is past
+    /// claiming (Review/Merged/Closed). Live evidence (2026-07-24):
+    /// personas kept re-claiming ALREADY-COMPLETED cards because the
+    /// claim guard only checked lease expiry, not state — settled work
+    /// looked open to every board reader. Settled cards are history,
+    /// not backlog.
+    #[error(
+        "work card {card_id} is {state:?} — settled work is not claimable; pick an Open card (or reopen this one explicitly with `airc work state`)"
+    )]
+    WorkCardNotClaimable {
+        card_id: airc_work::WorkCardId,
+        state: airc_work::CardState,
+    },
+
     /// Card 09fddedd: `relink` supersedes an EXISTING link — a card
     /// with no linked PR has nothing to supersede. Use `airc work
     /// link` for the first link; refusing here keeps the audit

--- a/crates/airc-lib/src/route/dial_quarantine.rs
+++ b/crates/airc-lib/src/route/dial_quarantine.rs
@@ -168,17 +168,49 @@ impl DialQuarantine {
     }
 
     /// The full dial verdict for `key` (self-healing join): DEAD after
-    /// [`DEAD_AFTER_CONSECUTIVE_FAILURES`] consecutive failures unless
-    /// `current_advert_stamp_ms` is STRICTLY fresher than the stamp the
-    /// streak accrued under (a fresher advertisement revives the
-    /// endpoint for a probe); otherwise the timed backoff; otherwise
-    /// dial.
-    pub fn gate(&self, key: &QuarantineKey, now_ms: u64, current_advert_stamp_ms: u64) -> DialGate {
+    /// [`DEAD_AFTER_CONSECUTIVE_FAILURES`] consecutive failures unless the
+    /// endpoint is revived for a probe; otherwise the timed backoff;
+    /// otherwise dial.
+    ///
+    /// A DEAD endpoint is revived for ONE probe when EITHER revival signal
+    /// is fresher than this streak's last failure:
+    ///
+    /// - `current_advert_stamp_ms` STRICTLY greater than the stamp the
+    ///   streak accrued under — a fresher endpoint ADVERTISEMENT arrived
+    ///   (a rendezvous import rewrote the peer's endpoint set), or
+    /// - `proof_of_life_ms` STRICTLY greater than the last failure's
+    ///   wall-clock — the peer has been seen ALIVE since we last failed to
+    ///   reach it (a fresh presence beacon; `StoredPeer::last_seen_ms`).
+    ///
+    /// Proof-of-life is the strictly more robust of the two: `last_seen_ms`
+    /// advances on EVERY registry import (`airc_trust::touch_last_seen`),
+    /// whereas the advert stamp advances only when that same import ALSO
+    /// rewrites the endpoint set (`set_endpoints_json`, gated on the beacon
+    /// carrying endpoints + the monotonic guard). A provably-live peer whose
+    /// endpoint set is unchanged — or whose stamp write is skipped for a
+    /// cycle — would otherwise stay evicted FOREVER despite beaconing,
+    /// which is exactly the "live peer stuck at 0-connected until a manual
+    /// `airc join`" gap (#240). Recognizing proof-of-life closes it while
+    /// keeping the eviction's purpose: the anti-noise contract is identical
+    /// — a failure under the fresher signal re-kills immediately (see
+    /// [`Self::record_failure`], which re-stamps `failed_at_ms` to the probe
+    /// instant), so a live-but-unreachable endpoint costs at most one 3s
+    /// dial per fresh beacon, never one per tick.
+    pub fn gate(
+        &self,
+        key: &QuarantineKey,
+        now_ms: u64,
+        current_advert_stamp_ms: u64,
+        proof_of_life_ms: u64,
+    ) -> DialGate {
         let Some(entry) = self.entries.get(key) else {
             return DialGate::Dial;
         };
+        let advert_fresher = current_advert_stamp_ms > entry.advert_stamp_ms;
+        let alive_since_failure = proof_of_life_ms > entry.failed_at_ms;
         if entry.consecutive_failures >= DEAD_AFTER_CONSECUTIVE_FAILURES
-            && current_advert_stamp_ms <= entry.advert_stamp_ms
+            && !advert_fresher
+            && !alive_since_failure
         {
             return DialGate::Dead {
                 consecutive_failures: entry.consecutive_failures,
@@ -410,10 +442,12 @@ mod tests {
         }
 
         // Every backoff window has elapsed — a timed quarantine would
-        // dial again. Failure-counted eviction must NOT.
+        // dial again. Failure-counted eviction must NOT. `proof_of_life=0`
+        // here means "peer not seen alive since the streak" — isolates the
+        // advertisement-revival axis from proof-of-life revival.
         assert!(
             matches!(
-                q.gate(&key(7717), now, stamp),
+                q.gate(&key(7717), now, stamp, 0),
                 DialGate::Dead {
                     consecutive_failures
                 } if consecutive_failures == DEAD_AFTER_CONSECUTIVE_FAILURES
@@ -428,13 +462,13 @@ mod tests {
             four.record_failure(key(1), u64::from(i), stamp);
         }
         assert!(
-            !matches!(four.gate(&key(1), now, stamp), DialGate::Dead { .. }),
+            !matches!(four.gate(&key(1), now, stamp, 0), DialGate::Dead { .. }),
             "below the threshold the timed backoff still governs"
         );
 
         // A STRICTLY fresher advertisement revives the endpoint for a probe.
         assert_eq!(
-            q.gate(&key(7717), now, stamp + 1),
+            q.gate(&key(7717), now, stamp + 1, 0),
             DialGate::Dial,
             "a fresher advertisement must lift the eviction for one probe"
         );
@@ -443,7 +477,7 @@ mod tests {
         q.record_failure(key(7717), now, stamp + 1);
         assert!(
             matches!(
-                q.gate(&key(7717), now + MAX_BACKOFF_MS + 1, stamp + 1),
+                q.gate(&key(7717), now + MAX_BACKOFF_MS + 1, stamp + 1, 0),
                 DialGate::Dead { .. }
             ),
             "a failure under the fresher stamp re-arms the eviction against it"
@@ -451,7 +485,81 @@ mod tests {
 
         // A success wipes the streak entirely.
         q.record_success(&key(7717));
-        assert_eq!(q.gate(&key(7717), now, stamp), DialGate::Dial);
+        assert_eq!(q.gate(&key(7717), now, stamp, 0), DialGate::Dial);
+    }
+
+    // what this catches (#240 — live-beaconing peer stuck at 0-connected):
+    // a DEAD endpoint whose peer is PROVABLY ALIVE (a presence beacon seen
+    // AFTER the streak's last failure — `proof_of_life_ms > failed_at_ms`)
+    // is revived for one probe EVEN WITH NO fresher endpoint advertisement.
+    // This is the robustness gap: `last_seen_ms` advances on every registry
+    // import while the advert stamp can stay frozen (unchanged endpoint set
+    // / skipped stamp write), so without this a beaconing peer stays evicted
+    // forever and needs a manual `airc join`. Mutation checks: dropping the
+    // `alive_since_failure` term fails the revival assert; comparing against
+    // anything other than `failed_at_ms` breaks the re-kill assert below.
+    #[test]
+    fn fresh_proof_of_life_revives_a_dead_endpoint_without_a_new_advertisement() {
+        let mut q = DialQuarantine::default();
+        let stamp = 1_000u64;
+        // Fail 5×, most recent failure at `last_failure_at`. The advertised
+        // stamp NEVER advances (the frozen-endpoint-set condition), so the
+        // advert-revival axis stays inert throughout this test.
+        let mut now = 0u64;
+        let mut last_failure_at = 0u64;
+        for _ in 0..DEAD_AFTER_CONSECUTIVE_FAILURES {
+            last_failure_at = now;
+            q.record_failure(key(7717), now, stamp);
+            now += MAX_BACKOFF_MS + 1;
+        }
+
+        // Same stamp + no proof of life (last_seen at/behind the failure) =>
+        // still DEAD, exactly as before this fix.
+        assert!(
+            matches!(
+                q.gate(&key(7717), now, stamp, last_failure_at),
+                DialGate::Dead { .. }
+            ),
+            "a stale-or-equal proof-of-life must NOT revive (last_seen == failed_at)"
+        );
+
+        // A presence beacon seen AFTER the last failure revives for one probe
+        // — with the SAME advertisement stamp (no rendezvous re-read needed).
+        assert_eq!(
+            q.gate(&key(7717), now, stamp, last_failure_at + 1),
+            DialGate::Dial,
+            "fresh proof-of-life must lift the eviction for one probe, no new advert"
+        );
+
+        // The probe fails again: re-stamps `failed_at_ms` to the probe
+        // instant, so the SAME proof-of-life no longer counts as "since the
+        // failure" — one probe per fresh beacon, not one per tick.
+        let probe_at = now;
+        q.record_failure(key(7717), probe_at, stamp);
+        assert!(
+            matches!(
+                q.gate(
+                    &key(7717),
+                    probe_at + MAX_BACKOFF_MS + 1,
+                    stamp,
+                    last_failure_at + 1
+                ),
+                DialGate::Dead { .. }
+            ),
+            "the beacon that already bought a probe must not buy another (re-killed)"
+        );
+
+        // A newer beacon (after the probe failure) buys the next probe.
+        assert_eq!(
+            q.gate(
+                &key(7717),
+                probe_at + MAX_BACKOFF_MS + 1,
+                stamp,
+                probe_at + 1
+            ),
+            DialGate::Dial,
+            "a beacon fresher than the probe failure revives again"
+        );
     }
 
     // what this catches: doubling must SURVIVE a re-failure that lands

--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -302,6 +302,13 @@ impl Airc {
         // revival signal (a fresher advertisement lifts a dead verdict).
         let mut advert_stamps: std::collections::HashMap<PeerId, u64> =
             std::collections::HashMap::new();
+        // Self-healing join (#240): the freshest presence stamp seen for
+        // each peer across both stores — proof-of-life that revives a DEAD
+        // endpoint for a probe even when its endpoint set (and thus its
+        // advert stamp) is unchanged. Same monotonic-max discipline as
+        // `advert_stamps` (a stale store copy must never rewind it).
+        let mut proof_of_life: std::collections::HashMap<PeerId, u64> =
+            std::collections::HashMap::new();
         // Self-healing join (machine-vs-scope): each peer's declared
         // transport host — the identity whose TLS cert answers at its
         // stored endpoints. First-seen (wire-root) order wins, matching
@@ -357,6 +364,8 @@ impl Airc {
             }
             let stamp = advert_stamps.entry(peer.peer_id).or_insert(0);
             *stamp = (*stamp).max(peer.endpoints_advertised_at_ms);
+            let alive = proof_of_life.entry(peer.peer_id).or_insert(0);
+            *alive = (*alive).max(peer.last_seen_ms);
             if let Some(host) = peer.endpoints_peer_id.filter(|host| *host != peer.peer_id) {
                 declared_hosts.entry(peer.peer_id).or_insert(host);
             }
@@ -393,11 +402,12 @@ impl Airc {
         // tests pin). What is now CONCURRENT is ACROSS peers: dialing
         // peer B must not wait on peer A's 3s timeout (see
         // DIAL_CONCURRENCY — the serial-sum hang this fixes).
-        let dial_list: Vec<(PeerId, PeerId, Vec<RouteEndpoint>, u64)> = order
+        let dial_list: Vec<(PeerId, PeerId, Vec<RouteEndpoint>, u64, u64)> = order
             .into_iter()
             .filter_map(|peer_id| {
                 merged.remove(&peer_id).map(|eps| {
                     let stamp = advert_stamps.get(&peer_id).copied().unwrap_or(0);
+                    let alive = proof_of_life.get(&peer_id).copied().unwrap_or(0);
                     // Machine-vs-scope: cert-pin the record's declared
                     // transport host when it is enrolled (strict —
                     // resolve_dial_pin); an unenrolled declared host is
@@ -420,7 +430,7 @@ impl Airc {
                             );
                         }
                     }
-                    (peer_id, pin, eps, stamp)
+                    (peer_id, pin, eps, stamp, alive)
                 })
             })
             .collect();
@@ -431,20 +441,28 @@ impl Airc {
         // Arc adapter and every mutation (quarantine map, transport
         // health) sits behind its own brief lock, so concurrent dials to
         // distinct peers do not race.
-        let mut dialed: Vec<(usize, PeerDialOutcome)> =
-            futures::stream::iter(dial_list.into_iter().enumerate())
-                .map(
-                    |(idx, (peer_id, pin, endpoints, advert_stamp_ms))| async move {
-                        (
-                            idx,
-                            self.dial_one_peer(peer_id, pin, endpoints, now_ms, advert_stamp_ms)
-                                .await,
-                        )
-                    },
+        let mut dialed: Vec<(usize, PeerDialOutcome)> = futures::stream::iter(
+            dial_list.into_iter().enumerate(),
+        )
+        .map(
+            |(idx, (peer_id, pin, endpoints, advert_stamp_ms, proof_of_life_ms))| async move {
+                (
+                    idx,
+                    self.dial_one_peer(
+                        peer_id,
+                        pin,
+                        endpoints,
+                        now_ms,
+                        advert_stamp_ms,
+                        proof_of_life_ms,
+                    )
+                    .await,
                 )
-                .buffer_unordered(DIAL_CONCURRENCY)
-                .collect()
-                .await;
+            },
+        )
+        .buffer_unordered(DIAL_CONCURRENCY)
+        .collect()
+        .await;
         dialed.sort_by_key(|(idx, _)| *idx);
         for (_, (peer_failures, peer_skips)) in dialed {
             failures.extend(peer_failures);
@@ -472,6 +490,11 @@ impl Airc {
         endpoints: Vec<RouteEndpoint>,
         now_ms: u64,
         advert_stamp_ms: u64,
+        // Self-healing join (#240): the peer's presence freshness
+        // (`StoredPeer::last_seen_ms`) — a DEAD endpoint is revived for one
+        // probe when this proves the peer is alive since its last failure,
+        // even with no fresher endpoint advertisement.
+        proof_of_life_ms: u64,
     ) -> PeerDialOutcome {
         let mut failures = Vec::new();
         let mut skips = Vec::new();
@@ -504,7 +527,13 @@ impl Airc {
                     // `airc transport health`'s failure count. The operator still
                     // sees "in backoff" via the skips channel — honest, not a
                     // clean-list lie and not an over-report.
-                    match self.dial_quarantine_gate(peer_id, addr, now_ms, advert_stamp_ms) {
+                    match self.dial_quarantine_gate(
+                        peer_id,
+                        addr,
+                        now_ms,
+                        advert_stamp_ms,
+                        proof_of_life_ms,
+                    ) {
                         super::dial_quarantine::DialGate::Dial => {}
                         super::dial_quarantine::DialGate::Backoff { remaining_ms } => {
                             skips.push(PeerDialSkip {
@@ -626,8 +655,13 @@ impl Airc {
                     let Some((relay_peer, relay_addr)) = endpoint.connectable_relay() else {
                         continue;
                     };
-                    match self.dial_quarantine_gate(relay_peer, relay_addr, now_ms, advert_stamp_ms)
-                    {
+                    match self.dial_quarantine_gate(
+                        relay_peer,
+                        relay_addr,
+                        now_ms,
+                        advert_stamp_ms,
+                        proof_of_life_ms,
+                    ) {
                         super::dial_quarantine::DialGate::Dial => {}
                         super::dial_quarantine::DialGate::Backoff { remaining_ms } => {
                             skips.push(PeerDialSkip {
@@ -903,13 +937,19 @@ impl Airc {
         addr: std::net::SocketAddr,
         now_ms: u64,
         current_advert_stamp_ms: u64,
+        proof_of_life_ms: u64,
     ) -> super::dial_quarantine::DialGate {
         let guard = self
             .inner
             .dial_quarantine
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        guard.gate(&(peer_id, addr), now_ms, current_advert_stamp_ms)
+        guard.gate(
+            &(peer_id, addr),
+            now_ms,
+            current_advert_stamp_ms,
+            proof_of_life_ms,
+        )
     }
 
     /// Card 7e3c9a1f: stamp a failed dial to `(peer_id, addr)` (starts /

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -1155,6 +1155,19 @@ impl Airc {
                 room_id: room.channel,
             });
         };
+        // Settled work is history, not backlog: a Review/Merged/Closed card is
+        // past claiming regardless of lease status. Live evidence (2026-07-24):
+        // personas kept re-claiming already-completed cards because this guard
+        // only checked lease expiry — the board read as open work forever.
+        // Reopening is an explicit `airc work state` transition, never a claim.
+        if matches!(
+            card.state,
+            airc_work::CardState::Review
+                | airc_work::CardState::Merged
+                | airc_work::CardState::Closed
+        ) {
+            return Err(AircError::WorkCardNotClaimable { card_id, state: card.state });
+        }
         let now_ms = now_ms()?;
         if card.claim_id.is_none()
             || card

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -1166,7 +1166,10 @@ impl Airc {
                 | airc_work::CardState::Merged
                 | airc_work::CardState::Closed
         ) {
-            return Err(AircError::WorkCardNotClaimable { card_id, state: card.state });
+            return Err(AircError::WorkCardNotClaimable {
+                card_id,
+                state: card.state,
+            });
         }
         let now_ms = now_ms()?;
         if card.claim_id.is_none()


### PR DESCRIPTION
## The gap (#240)

A peer that is **provably alive** — beaconing, `last_seen_ms` advancing on every registry import via `touch_last_seen` — could stay at **0-connected until a manual `airc join`**.

The failure-counted eviction (`DEAD_AFTER_CONSECUTIVE_FAILURES` = 5) is only revived by a strictly-fresher endpoint **advertisement** (`endpoints_advertised_at_ms`). That stamp is written **only** when a rendezvous import *also* rewrites the peer's endpoint set (`set_endpoints_json`, gated on the beacon carrying endpoints + the monotonic guard). So when a live peer's endpoint set is unchanged — or its stamp write is skipped for a cycle — the DEAD verdict never clears, the endpoint keeps emitting `PeerDialSkip{dead:true}`, the route reads 0-connected, and only a manual `airc join` recovers it. That is exactly the field symptom.

## The fix

Recognize **proof-of-life** as a second DEAD-revival signal, parallel to the advert stamp. `DialQuarantine::gate` now also takes the peer's `last_seen_ms`; a DEAD endpoint is revived for **one probe** when the peer has been seen alive **since this streak's last failure** (`proof_of_life_ms > entry.failed_at_ms`), even with no new advertisement.

Why it's the right signal:
- **Strictly more robust** than the advert stamp — `last_seen_ms` advances on *every* import; the advert stamp only when the endpoint set is *also* rewritten. It catches every case the stamp catches, plus the frozen-endpoint-set / skipped-stamp cases that were stranding live peers.
- **Same anti-noise contract** — a failure under the fresher signal re-kills immediately (`record_failure` re-stamps `failed_at_ms`), so a live-but-unreachable endpoint costs at most **one 3s dial per fresh beacon**, never one per tick.
- **Minimal blast radius** — only the DEAD branch is affected; timed backoff and the never-failed path are unchanged.

Threaded `last_seen_ms` from `StoredPeer` (collected monotonic-max alongside `advert_stamps` in `dial_stored_peer_endpoints`) → `dial_one_peer` → `dial_quarantine_gate` → `gate`, for both the LAN/Tailscale and relay dial arms.

The **honest send-receipt** half of #240 was already fixed (#1243): `format_send_receipt` loudly reports "reached 0 of N enrolled peer(s): NONE currently connected". This closes the **self-heal** half so that receipt stops being the steady state for a peer that is actually reachable.

## Tests
- New unit test `fresh_proof_of_life_revives_a_dead_endpoint_without_a_new_advertisement` pins the revival + one-probe-per-beacon re-kill.
- All **325** airc-lib unit tests + **13** `stored_endpoint_dial` integration tests stay green.
- `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean (whole workspace).

Note: reaching DEAD end-to-end requires 5 *timed* failures (15s→120s backoffs), so the revival *logic* is unit-tested (as the existing DEAD-eviction behavior itself is) rather than driven through a multi-minute real-time integration test; the `last_seen → gate` threading is type-checked and the full integration suite stays green.