### PR TITLE
feat(self-heal): registry import nudges route-refresh — dial fresh endpoints NOW (#240 event-driven heal)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1676,6 +1676,10 @@ pub async fn run_daemon(
             gate,
             airc_lib::RegistryRefreshConfig::default(),
             &registry_state.endpoint_resync,
+            // #240 event-driven heal: nudge the route-refresh loop the
+            // instant an import lands fresh endpoints so they are dialed
+            // NOW, not up to a full route-refresh interval later.
+            &registry_state.route_wake,
             registry_state.shutdown.notified(),
         )
         .await;
@@ -1737,9 +1741,11 @@ fn spawn_route_refresh(
     let connected = state.connected_lan_peers.clone();
     let endpoint_resync = state.endpoint_resync.clone();
     tokio::spawn(async move {
-        airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
-            refresh_routes_once(&airc, &connected, &endpoint_resync, &rendezvous)
-        })
+        airc_daemon::route_refresh::run_periodic_refresh(
+            &state.shutdown,
+            &state.route_wake,
+            || refresh_routes_once(&airc, &connected, &endpoint_resync, &rendezvous),
+        )
         .await;
     })
 }

--- a/crates/airc-daemon/src/route_refresh.rs
+++ b/crates/airc-daemon/src/route_refresh.rs
@@ -79,7 +79,16 @@ pub fn delay_before_refresh(completed_refreshes: u64) -> Duration {
 /// wakes only waiters registered at that instant and stores no
 /// permit; re-creating `notified()` each turn would leave windows
 /// where the signal is lost and the loop never exits.
-pub async fn run_periodic_refresh<F, Fut>(shutdown: &Notify, mut refresh: F)
+/// `wake` is the event-driven nudge (#240): the account-registry loop
+/// notifies it the instant an import lands fresh beacons / endpoints in the
+/// trust store, so a refresh runs IMMEDIATELY instead of waiting out the
+/// remaining interval — freshly-advertised endpoints for a disconnected peer
+/// are dialed at once, not up to `REFRESH_INTERVAL` later. The nudge only
+/// short-circuits the *wait*; the refresh work is unchanged (connected peers
+/// skipped, quarantine/ghost gates apply), so a nudge in steady state is a
+/// cheap no-op. `Notify` stores one permit, so a nudge landing DURING a
+/// refresh is consumed by the next iteration's wait (never lost, coalesced).
+pub async fn run_periodic_refresh<F, Fut>(shutdown: &Notify, wake: &Notify, mut refresh: F)
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = ()>,
@@ -89,10 +98,18 @@ where
 
     let mut completed: u64 = 0;
     loop {
-        tokio::select! {
-            biased;
-            _ = &mut notified => return,
-            () = tokio::time::sleep(delay_before_refresh(completed)) => {}
+        // Wait for the interval to elapse OR an external wake nudge, whichever
+        // comes first. A fresh `notified()` per iteration so a permit stored
+        // while `refresh()` ran fires the next wait immediately.
+        {
+            let woken = wake.notified();
+            tokio::pin!(woken);
+            tokio::select! {
+                biased;
+                _ = &mut notified => return,
+                _ = &mut woken => {}
+                () = tokio::time::sleep(delay_before_refresh(completed)) => {}
+            }
         }
         tokio::select! {
             biased;
@@ -148,12 +165,14 @@ mod tests {
     async fn boot_schedules_the_first_refresh_immediately() {
         let shutdown = Arc::new(Notify::new());
         let count = Arc::new(AtomicUsize::new(0));
+        let wake = Arc::new(Notify::new());
 
         let task = tokio::spawn({
             let shutdown = shutdown.clone();
+            let wake = wake.clone();
             let count = count.clone();
             async move {
-                run_periodic_refresh(&shutdown, move || {
+                run_periodic_refresh(&shutdown, &wake, move || {
                     let count = count.clone();
                     async move {
                         count.fetch_add(1, Ordering::SeqCst);
@@ -203,14 +222,16 @@ mod tests {
         let in_flight = Arc::new(AtomicUsize::new(0));
         let max_in_flight = Arc::new(AtomicUsize::new(0));
         let completed = Arc::new(AtomicUsize::new(0));
+        let wake = Arc::new(Notify::new());
 
         let task = tokio::spawn({
             let shutdown = shutdown.clone();
+            let wake = wake.clone();
             let in_flight = in_flight.clone();
             let max_in_flight = max_in_flight.clone();
             let completed = completed.clone();
             async move {
-                run_periodic_refresh(&shutdown, move || {
+                run_periodic_refresh(&shutdown, &wake, move || {
                     let in_flight = in_flight.clone();
                     let max_in_flight = max_in_flight.clone();
                     let completed = completed.clone();
@@ -254,12 +275,14 @@ mod tests {
     async fn shutdown_stops_the_loop_mid_sleep() {
         let shutdown = Arc::new(Notify::new());
         let count = Arc::new(AtomicUsize::new(0));
+        let wake = Arc::new(Notify::new());
 
         let task = tokio::spawn({
             let shutdown = shutdown.clone();
+            let wake = wake.clone();
             let count = count.clone();
             async move {
-                run_periodic_refresh(&shutdown, move || {
+                run_periodic_refresh(&shutdown, &wake, move || {
                     let count = count.clone();
                     async move {
                         count.fetch_add(1, Ordering::SeqCst);
@@ -285,5 +308,62 @@ mod tests {
             "exactly the boot-immediate refresh ran before shutdown — the \
              mid-interval sleep was interrupted, not waited out"
         );
+    }
+
+    /// #240 event-driven heal: a `wake` nudge (the registry loop after an
+    /// import) runs a refresh IMMEDIATELY, mid-interval — freshly-imported
+    /// endpoints are dialed at once instead of waiting out the remaining
+    /// `REFRESH_INTERVAL`. Mutation check: dropping the `woken` arm from the
+    /// wait select fails the "count==2 well before the interval" assert (the
+    /// nudge would then be ignored until the timer fired).
+    #[tokio::test(start_paused = true)]
+    async fn a_wake_nudge_runs_a_refresh_before_the_interval_elapses() {
+        let shutdown = Arc::new(Notify::new());
+        let wake = Arc::new(Notify::new());
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let task = tokio::spawn({
+            let shutdown = shutdown.clone();
+            let wake = wake.clone();
+            let count = count.clone();
+            async move {
+                run_periodic_refresh(&shutdown, &wake, move || {
+                    let count = count.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+                .await;
+            }
+        });
+
+        // Boot-immediate refresh lands, then the loop parks on its steady
+        // interval. Advance to the MIDPOINT of that interval — no timer
+        // refresh is due yet.
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        assert_eq!(count.load(Ordering::SeqCst), 1, "boot refresh only");
+        tokio::time::sleep(REFRESH_INTERVAL / 2).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "mid-interval: the timer has not fired a second refresh"
+        );
+
+        // Nudge — a fresh import just landed. The refresh must run NOW, not
+        // at the far end of the interval.
+        wake.notify_one();
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            2,
+            "the wake nudge ran a refresh immediately, mid-interval — not \
+             deferred to the next timer tick"
+        );
+
+        shutdown.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("loop must exit on shutdown")
+            .expect("loop task must not panic");
     }
 }

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -85,6 +85,18 @@ pub struct DaemonState {
     /// airc-lib-owning host loops hold the `Airc` handle, this crate does
     /// not depend on airc-lib.
     pub endpoint_resync: Arc<Notify>,
+    /// Edge-triggered wake nudge for the route-refresh loop — the MIRROR of
+    /// [`Self::endpoint_resync`]. The account-registry loop notifies this the
+    /// moment it completes an import (fresh beacons / endpoints just landed in
+    /// the trust store), so freshly-advertised endpoints for a currently-
+    /// disconnected peer are DIALED immediately instead of waiting up to a full
+    /// route-refresh interval (#240 event-driven heal). In steady state (every
+    /// peer already connected) the nudged refresh is a cheap no-op — connected
+    /// peers are skipped and the quarantine/ghost gates still apply — so it does
+    /// real work only when a reconnect is actually pending. Shared like
+    /// `endpoint_resync`: both loops live in the airc-lib-owning host, and this
+    /// crate does not depend on airc-lib.
+    pub route_wake: Arc<Notify>,
 }
 
 impl DaemonState {
@@ -130,6 +142,7 @@ impl DaemonState {
             route_endpoints: RwLock::new(Vec::new()),
             connected_lan_peers: Arc::new(AtomicUsize::new(0)),
             endpoint_resync: Arc::new(Notify::new()),
+            route_wake: Arc::new(Notify::new()),
         })
     }
 

--- a/crates/airc-lib/src/registry_refresh.rs
+++ b/crates/airc-lib/src/registry_refresh.rs
@@ -282,12 +282,20 @@ pub async fn sync_once(
 /// loop). `shutdown` is awaited via a single pinned future so a
 /// `notify_waiters()` landing between ticks is never lost (the exact
 /// hazard `server::run` documents).
+/// `route_wake` is the MIRROR of `resync` (#240 event-driven heal): after
+/// every tick that actually imports (fresh beacons/endpoints just landed in
+/// the trust store), this notifies the route-refresh loop so it dials those
+/// endpoints IMMEDIATELY instead of waiting out the remainder of its own
+/// interval. Only fires on a real import (not a gate-skip or failed tick), so
+/// steady-state adds at most one nudge per cadence, and the woken refresh is a
+/// cheap no-op when every peer is already connected.
 pub async fn run_loop<S>(
     airc: Airc,
     store: S,
     gate: RegistryRefreshGate,
     config: RegistryRefreshConfig,
     resync: &tokio::sync::Notify,
+    route_wake: &tokio::sync::Notify,
     shutdown: impl Future<Output = ()>,
 ) where
     S: AccountRegistryStore,
@@ -312,10 +320,14 @@ pub async fn run_loop<S>(
             // spam). `Notify` stores one permit if the nudge lands during
             // a tick, so the wakeup is never lost.
             _ = resync.notified() => {
-                gated_tick(&gate, &airc, &store, &sink).await;
+                if gated_tick(&gate, &airc, &store, &sink).await {
+                    route_wake.notify_one();
+                }
             }
             _ = ticker.tick() => {
-                gated_tick(&gate, &airc, &store, &sink).await;
+                if gated_tick(&gate, &airc, &store, &sink).await {
+                    route_wake.notify_one();
+                }
             }
         }
     }
@@ -326,12 +338,19 @@ pub async fn run_loop<S>(
 /// on failure; callers deliberately swallow the `Err` and keep ticking
 /// (self-heal: a transient gh failure must not kill discovery for the
 /// daemon's lifetime).
+///
+/// Returns `true` iff a publish+refresh actually RAN AND SUCCEEDED — i.e.
+/// fresh beacons/endpoints were imported into the trust store this tick.
+/// The loop uses that to nudge the route-refresh loop (#240 event-driven
+/// heal): a gate-skip or a failed import imported nothing, so there is
+/// nothing newly-dialable to wake for.
 async fn gated_tick<S>(
     gate: &RegistryRefreshGate,
     airc: &Airc,
     store: &S,
     sink: &StderrJsonDiagnosticSink,
-) where
+) -> bool
+where
     S: AccountRegistryStore,
 {
     if let Some(block) = gate.block().await {
@@ -344,9 +363,9 @@ async fn gated_tick<S>(
             code,
             format!("account registry tick skipped: {block}"),
         ));
-        return;
+        return false;
     }
-    let _ = run_tick(airc, store, sink).await;
+    run_tick(airc, store, sink).await.is_ok()
 }
 
 #[cfg(test)]
@@ -682,12 +701,14 @@ exit 1
         let loop_store = store.clone();
         let loop_resync = resync.clone();
         let handle = tokio::spawn(async move {
+            let loop_wake = tokio::sync::Notify::new();
             run_loop(
                 loop_airc,
                 loop_store,
                 RegistryRefreshGate::Always,
                 config,
                 &loop_resync,
+                &loop_wake,
                 async move {
                     let _ = rx.await;
                 },
@@ -741,12 +762,14 @@ exit 1
         };
         let handle = tokio::spawn(async move {
             let resync = tokio::sync::Notify::new();
+            let route_wake = tokio::sync::Notify::new();
             run_loop(
                 airc,
                 store,
                 RegistryRefreshGate::Always,
                 config,
                 &resync,
+                &route_wake,
                 async move {
                     let _ = rx.await;
                 },


### PR DESCRIPTION
## Follow-up to #1293

The proof-of-life quarantine revival (#1293) made a live peer's DEAD endpoint eligible to dial again. This closes the **scheduling gap** right after it.

## The gap

Two loops drive reconnection, and they were decoupled:
- **60s route-refresh loop** — dials stored endpoints.
- **~120s account-registry loop** — imports fresh beacons/endpoints from the rendezvous into the trust store.

A registry import could land a disconnected peer's fresh endpoint and then **sit until the next route-refresh tick fired — up to a full `REFRESH_INTERVAL` later.**

## The fix

Add the mirror of the existing `endpoint_resync` nudge (route→registry: "my IP moved, republish"):

- New **`route_wake`** nudge (registry→route): the registry loop notifies it after every tick that actually imports, and `run_periodic_refresh` grows a `wake` select arm that runs a refresh **immediately** instead of waiting out the remaining interval.

Disciplined, not spammy:
- **Edge-triggered on a real import only** — `gated_tick` now returns whether a publish+refresh ran and succeeded; a gate-skip or failed tick imports nothing → no nudge.
- The woken refresh is the **same idempotent work** — connected peers skipped, quarantine/ghost gates apply — so in steady state (all connected) it's a cheap no-op. Real work happens only when a reconnect is actually pending.
- `Notify` stores one permit, so a nudge landing during a refresh is consumed by the next wait (never lost, coalesced).

## Wiring
`DaemonState.route_wake: Arc<Notify>` (shared by both loops, same clone shape as `endpoint_resync`) → threaded into `route_refresh::run_periodic_refresh(shutdown, wake, ..)` and `registry_refresh::run_loop(.., resync, route_wake, shutdown)`.

## Tests
- New `a_wake_nudge_runs_a_refresh_before_the_interval_elapses` (start_paused) pins that a nudge runs a refresh **mid-interval**, not at the next timer tick.
- All airc-daemon (8) + airc-lib (325) unit tests green; `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.