### PR TITLE
feat(self-heal): a dropped LAN session nudges route-refresh — reconnect at once (#240 event-driven heal, peer-dropped leg)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1428,6 +1428,19 @@ pub async fn run_daemon(
         rendezvous_for_heal.clone(),
     );
 
+    // #240 event-driven heal (peer-DROPPED mirror of the registry-import
+    // nudge): when a live LAN session terminates, nudge the route-refresh loop
+    // to attempt reconnection AT ONCE — quarantine-gated, so a genuinely-offline
+    // peer costs at most one dial, while a transient blip reconnects in seconds
+    // instead of waiting out a full refresh interval. Registered on the shared
+    // daemon handle; the wake permit coalesces a burst of drops into one refresh.
+    {
+        let route_wake = state.route_wake.clone();
+        daemon_airc.set_disconnect_observer(std::sync::Arc::new(move |_peer_id| {
+            route_wake.notify_one();
+        }));
+    }
+
     // #1268: autonomous self-update — keep the node on current canary with no
     // human in the loop (the version-drift pain we just lived: stale binaries,
     // peers that can't speak the current protocol). The dangerous half (fetch +

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -179,6 +179,13 @@ pub struct Airc {
     pub(crate) inner: Arc<AircInner>,
 }
 
+/// #240 event-driven heal: the shared slot holding the optional peer-disconnect
+/// callback the daemon registers (see [`AircInner::on_disconnect`]). Aliased so
+/// the nested handle type doesn't trip clippy's `type_complexity` gate at the
+/// field and at every construction.
+pub(crate) type DisconnectCallbackSlot =
+    Arc<std::sync::Mutex<Option<Arc<dyn Fn(PeerId) + Send + Sync>>>>;
+
 pub(crate) struct AircInner {
     pub(crate) home: PathBuf,
     pub(crate) wire_root: PathBuf,
@@ -216,6 +223,15 @@ pub(crate) struct AircInner {
     /// accepts the inbound, every handle's dialer sees the learned IP.
     pub(crate) learned_ips:
         Arc<std::sync::Mutex<std::collections::HashMap<PeerId, std::net::IpAddr>>>,
+    /// #240 event-driven heal: optional callback the daemon registers to be
+    /// notified when a peer's live LAN session terminates. A SLOT (not the
+    /// adapter observer itself) so registration order is irrelevant — the LAN
+    /// adapter's disconnect observer, wired once at adapter creation, reads
+    /// this slot each disconnect, so `set_disconnect_observer` works whether it
+    /// runs before or after the adapter is first built. Shared across daemon
+    /// clones like `learned_ips`, so whichever handle owns the dropped session
+    /// fires the same callback (the daemon's route-refresh wake nudge).
+    pub(crate) on_disconnect: DisconnectCallbackSlot,
     pub(crate) lamport_clock: AtomicU64,
     /// Epoch-ms of the last send-path peer-registry sync. Debounces the
     /// per-send disk load (see `sync_account_peer_registry_debounced`).
@@ -491,6 +507,7 @@ impl Airc {
                 )),
                 advertised_endpoints_host: std::sync::Mutex::new(None),
                 learned_ips: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+                on_disconnect: Arc::new(std::sync::Mutex::new(None)),
                 lamport_clock: AtomicU64::new(0),
                 peer_sync_last_ms: AtomicU64::new(0),
                 lan_tcp: Mutex::new(None),
@@ -1303,6 +1320,7 @@ impl Airc {
             // #9: share the learned-IP map across the daemon clone so an
             // inbound learned on any handle informs every handle's dialer.
             learned_ips: self.inner.learned_ips.clone(),
+            on_disconnect: self.inner.on_disconnect.clone(),
             lamport_clock: AtomicU64::new(self.inner.lamport_clock.load(Ordering::Relaxed)),
             peer_sync_last_ms: AtomicU64::new(0),
             lan_tcp: Mutex::new(None),

--- a/crates/airc-lib/src/lan.rs
+++ b/crates/airc-lib/src/lan.rs
@@ -382,8 +382,30 @@ impl Airc {
                 map.insert(peer_id, ip);
             }
         }));
+        // #240 event-driven heal: forward every session termination to the
+        // `on_disconnect` SLOT. Wired once here; it reads the slot each drop, so
+        // `set_disconnect_observer` works before OR after this adapter is built.
+        let on_disconnect = self.inner.on_disconnect.clone();
+        adapter.set_disconnect_observer(std::sync::Arc::new(move |peer_id| {
+            let cb = on_disconnect.lock().ok().and_then(|guard| guard.clone());
+            if let Some(cb) = cb {
+                cb(peer_id);
+            }
+        }));
         *guard = Some(adapter.clone());
         Ok(adapter)
+    }
+
+    /// #240 event-driven heal: register a callback invoked with the `peer_id`
+    /// of every peer whose live LAN session terminates. The daemon uses this to
+    /// nudge its route-refresh loop so a dropped-but-still-reachable peer is
+    /// re-dialed at once instead of up to a full refresh interval later. Stored
+    /// in a slot the LAN adapter reads each disconnect, so this may be called
+    /// before or after the adapter is first built. A later call replaces it.
+    pub fn set_disconnect_observer(&self, observer: std::sync::Arc<dyn Fn(PeerId) + Send + Sync>) {
+        if let Ok(mut guard) = self.inner.on_disconnect.lock() {
+            *guard = Some(observer);
+        }
     }
 }
 

--- a/crates/airc-transport/src/lan_tcp/adapter/connection.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/connection.rs
@@ -117,6 +117,23 @@ async fn install_and_spawn_loops<R, W>(
     tokio::spawn(read_loop(inner, peer_id, read_half));
 }
 
+/// #240: terminate this peer's live session — drop it from `connections` and
+/// fire the disconnect observer (if the layer above registered one) so a
+/// dropped-but-still-reachable peer can be re-dialed at once. The connections
+/// lock is released BEFORE the observer runs (never held across the callback,
+/// mirroring the accept path's `on_inbound` discipline).
+pub(super) async fn disconnect(inner: &Arc<Inner>, peer_id: PeerId) {
+    inner.connections.lock().await.remove(&peer_id);
+    let observer = inner
+        .on_disconnect
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone());
+    if let Some(observer) = observer {
+        observer(peer_id);
+    }
+}
+
 /// Read loop: pull length-prefixed JSON frames off the TLS stream
 /// and fan out to subscribers per the Transport trait's lag policy.
 /// Removes this peer's entry from `connections` on any termination
@@ -129,17 +146,17 @@ where
         // Read 4-byte BE length prefix.
         let mut len_bytes = [0u8; 4];
         if read_half.read_exact(&mut len_bytes).await.is_err() {
-            inner.connections.lock().await.remove(&peer_id);
+            disconnect(&inner, peer_id).await;
             return;
         }
         let len = u32::from_be_bytes(len_bytes);
         if len > MAX_FRAME_BYTES {
-            inner.connections.lock().await.remove(&peer_id);
+            disconnect(&inner, peer_id).await;
             return;
         }
         let mut payload = vec![0u8; len as usize];
         if read_half.read_exact(&mut payload).await.is_err() {
-            inner.connections.lock().await.remove(&peer_id);
+            disconnect(&inner, peer_id).await;
             return;
         }
 
@@ -162,7 +179,7 @@ where
                     .with_field("payload_bytes", payload.len())
                     .with_field("error", error),
                 );
-                inner.connections.lock().await.remove(&peer_id);
+                disconnect(&inner, peer_id).await;
                 return;
             }
         };

--- a/crates/airc-transport/src/lan_tcp/adapter/inner.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/inner.rs
@@ -88,9 +88,22 @@ pub(super) struct Inner {
     /// set-once at adapter wiring, read briefly on each accept, never held
     /// across an await.
     pub(super) on_inbound: std::sync::Mutex<Option<InboundObserver>>,
+    /// #240 event-driven heal: optional observer invoked once per peer whose
+    /// live session TERMINATES (clean EOF, I/O error, or a malformed/oversized
+    /// frame) — i.e. the moment `connections` loses that peer. Symmetric with
+    /// `on_inbound`: the pipe reports that a link went away; it has no idea
+    /// what the layer above does with it. The daemon uses it to nudge the
+    /// route-refresh loop so a dropped-but-still-reachable peer is re-dialed
+    /// AT ONCE instead of up to a full refresh interval later. Same discipline
+    /// as `on_inbound` — brief lock, never held across an await or the removal.
+    pub(super) on_disconnect: std::sync::Mutex<Option<DisconnectObserver>>,
 }
 
 /// #9: callback the airc-lib layer registers to learn `(peer_id, source_ip)`
 /// from authenticated inbound connections. `Send + Sync` so the accept loop
 /// can invoke it from any connection task.
 pub(super) type InboundObserver = std::sync::Arc<dyn Fn(PeerId, std::net::IpAddr) + Send + Sync>;
+
+/// #240: callback invoked with the `peer_id` whose live session just
+/// terminated. `Send + Sync` so any connection task can fire it.
+pub(super) type DisconnectObserver = std::sync::Arc<dyn Fn(PeerId) + Send + Sync>;

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -53,8 +53,8 @@ use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair, Subscription};
 
 use crate::lan_tcp::adapter::connection::{handle_client_connection, handle_server_connection};
 use crate::lan_tcp::adapter::inner::{
-    InboundObserver, Inner, Outbound, OutboundTx, SubscriberHandle, MAX_FRAME_BYTES,
-    SUBSCRIBER_CHANNEL_DEPTH,
+    DisconnectObserver, InboundObserver, Inner, Outbound, OutboundTx, SubscriberHandle,
+    MAX_FRAME_BYTES, SUBSCRIBER_CHANNEL_DEPTH,
 };
 use crate::lan_tcp::tls_config::{build_client_config, build_server_config};
 use crate::transport::{FrameStream, Transport};
@@ -85,6 +85,7 @@ impl LanTcpAdapter {
                 subscribers: Mutex::new(Vec::new()),
                 next_sub_id: AtomicU64::new(0),
                 on_inbound: std::sync::Mutex::new(None),
+                on_disconnect: std::sync::Mutex::new(None),
             }),
         })
     }
@@ -97,6 +98,17 @@ impl LanTcpAdapter {
     /// set-once; a later call replaces the observer.
     pub fn set_inbound_observer(&self, observer: InboundObserver) {
         if let Ok(mut guard) = self.inner.on_inbound.lock() {
+            *guard = Some(observer);
+        }
+    }
+
+    /// #240: register an observer called once per peer whose live session
+    /// TERMINATES. The daemon uses this to nudge the route-refresh loop so a
+    /// dropped-but-still-reachable peer is re-dialed at once instead of up to a
+    /// full refresh interval later. Idempotent set-once; a later call replaces
+    /// the observer.
+    pub fn set_disconnect_observer(&self, observer: DisconnectObserver) {
+        if let Ok(mut guard) = self.inner.on_disconnect.lock() {
             *guard = Some(observer);
         }
     }
@@ -442,6 +454,39 @@ mod tests {
                 .and_then(Body::as_text)
                 .unwrap(),
             "hello from alice"
+        );
+    }
+
+    // #240 event-driven heal: a terminated session must (1) drop the peer from
+    // `connections` and (2) fire the registered disconnect observer with that
+    // peer_id — the signal the daemon turns into a route-refresh wake nudge.
+    // Mutation checks: dropping the observer call in `disconnect` fails the
+    // "observer fired" assert; skipping the remove fails the "gone" assert.
+    #[tokio::test]
+    async fn disconnect_removes_the_peer_and_fires_the_observer() {
+        let (_alice_id, alice, bob_id, _bob) = make_paired_adapters();
+
+        let fired: Arc<std::sync::Mutex<Vec<PeerId>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = fired.clone();
+        alice.set_disconnect_observer(Arc::new(move |peer| {
+            sink.lock().unwrap().push(peer);
+        }));
+
+        // Stand in a live connection entry for bob, then terminate it.
+        let (tx, _rx) = tokio::sync::mpsc::channel::<Outbound>(1);
+        alice.inner.connections.lock().await.insert(bob_id, tx);
+        assert!(alice.inner.connections.lock().await.contains_key(&bob_id));
+
+        super::connection::disconnect(&alice.inner, bob_id).await;
+
+        assert!(
+            !alice.inner.connections.lock().await.contains_key(&bob_id),
+            "the terminated peer must be dropped from connections"
+        );
+        assert_eq!(
+            fired.lock().unwrap().as_slice(),
+            &[bob_id],
+            "the disconnect observer must fire once with the terminated peer's id"
         );
     }
 


### PR DESCRIPTION
## Third leg of the #240 event-driven heal — completes the symmetry

- **peer CAME BACK:** registry import nudges route-refresh (#1294) ✓
- **peer DROPPED:** this — a terminated live session nudges route-refresh

## The gap

When a live LAN session dropped (clean EOF, I/O error, or a malformed/oversized frame), the daemon only noticed on its **next route-refresh tick — up to a full `REFRESH_INTERVAL` (60s) later.** That's the "two trusted peers can't maintain a conversation" latency: a transient blip left the link dark for up to a minute even though the peer was still reachable.

## The fix

The transport fires a **disconnect observer** the instant a peer leaves the `connections` map; the daemon turns that into a `route_wake` nudge, so a reconnection dial is attempted **at once** — quarantine-gated (a genuinely offline peer still costs at most one dial; a transient drop reconnects in seconds). The wake permit coalesces a burst of drops (partition) into one refresh.

## Wiring (mirrors the existing `on_inbound` learned-IP observer end to end)

- **airc-transport:** `Inner.on_disconnect` + `DisconnectObserver` type + `set_disconnect_observer`; a `disconnect()` helper removes the peer and fires the observer (lock released before the callback), called at all four session-termination sites in `read_loop`.
- **airc-lib:** `AircInner.on_disconnect` **slot** — so registration order is irrelevant: the adapter's observer, wired once at lazy adapter creation, reads the slot each drop, so `Airc::set_disconnect_observer` works before or after the adapter is built.
- **airc-cli daemon boot:** register `move |_peer| route_wake.notify_one()` on the shared daemon handle, beside the route-refresh spawn.

## Tests
- New `disconnect_removes_the_peer_and_fires_the_observer` pins the remove + observer-fire contract.
- airc-transport (33) + airc-lib (325) + airc-daemon (8) unit tests green; `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.