### PR TITLE
fix(route): cert-identity-mismatch dial evicts the orphan on the first strike — self-heal when a peer returns under a new identity (#240 follow-up)

### DIFF
--- a/crates/airc-lib/src/route/dial_quarantine.rs
+++ b/crates/airc-lib/src/route/dial_quarantine.rs
@@ -263,6 +263,54 @@ impl DialQuarantine {
         );
     }
 
+    /// Record a TERMINAL dial failure — one whose cause is deterministic, so
+    /// retrying the SAME stored endpoint can never succeed and counting five
+    /// strikes only wastes ~five refresh cycles hammering an orphan. The
+    /// canonical case (glass-boxed on the M5↔bigmama grid 2026-07-28): a peer
+    /// re-installs and comes back under a NEW identity, so its old advertised
+    /// endpoint now presents a cert for a DIFFERENT peer — every dial to it
+    /// fails with the same identity-mismatch verdict forever. That is the
+    /// "survivor stuck on the orphan" wedge.
+    ///
+    /// This jumps the streak straight to [`DEAD_AFTER_CONSECUTIVE_FAILURES`]
+    /// so [`Self::gate`] evicts the endpoint on the FIRST such failure. Crucially
+    /// it changes ONLY the strike count — the revival conditions are untouched:
+    /// a FRESHER advertisement (`advert_stamp_ms`) or a proof-of-life newer than
+    /// `failed_at_ms` still revives it in `gate`. So when the returning peer
+    /// re-advertises its new endpoint (or that endpoint proves live), the dead
+    /// orphan is released exactly as a failure-counted one would be — the peer
+    /// reconnects on its own, no manual `airc join`.
+    pub fn record_terminal_failure(
+        &mut self,
+        key: QuarantineKey,
+        now_ms: u64,
+        advert_stamp_ms: u64,
+    ) {
+        // Same unbounded-growth sweep as record_failure.
+        self.entries.retain(|_, entry| {
+            now_ms.saturating_sub(entry.failed_at_ms) <= QUARANTINE_RETENTION_MS
+        });
+        let prev_stamp = self
+            .entries
+            .get(&key)
+            .map_or(0, |prev| prev.advert_stamp_ms);
+        self.entries.insert(
+            key,
+            QuarantineEntry {
+                failed_at_ms: now_ms,
+                // Cap the backoff too: irrelevant while DEAD (gate short-circuits
+                // before the backoff check), but if a fresher advert revives the
+                // entry and it terminally re-fails, it must not restart at the
+                // initial window.
+                backoff_ms: MAX_BACKOFF_MS,
+                // The whole point: DEAD on the first terminal strike.
+                consecutive_failures: DEAD_AFTER_CONSECUTIVE_FAILURES,
+                // Monotonic max, same contract as record_failure.
+                advert_stamp_ms: prev_stamp.max(advert_stamp_ms),
+            },
+        );
+    }
+
     /// A successful dial clears any quarantine for `key` so the endpoint
     /// is immediately eligible again — a peer that flapped and came back
     /// must not stay shadow-banned behind a stale backoff.
@@ -486,6 +534,58 @@ mod tests {
         // A success wipes the streak entirely.
         q.record_success(&key(7717));
         assert_eq!(q.gate(&key(7717), now, stamp, 0), DialGate::Dial);
+    }
+
+    // what this catches (2026-07-28 M5↔bigmama "survivor stuck on the orphan"):
+    // a TERMINAL failure — an identity-mismatch verdict, deterministic, will
+    // fail identically forever — must evict the endpoint on the FIRST strike,
+    // NOT waste five refresh cycles hammering it. But it must NOT change the
+    // revival contract: a fresher advertisement (the returning peer's new
+    // endpoint) or a proof-of-life still lifts the eviction, so reconnection is
+    // automatic. Mutation checks: not jumping to the DEAD threshold fails the
+    // first-strike assert; a revival axis regression fails the advert/PoL asserts.
+    #[test]
+    fn terminal_failure_is_dead_on_the_first_strike_but_still_revives() {
+        let stamp = 1_000u64;
+        // Past the backoff window, so revival lands on Dial (not Backoff) —
+        // isolates the eviction/revival axis from the timed backoff, exactly as
+        // the fifth-failure sibling test does.
+        let later = MAX_BACKOFF_MS + 1;
+
+        // ONE terminal failure ⇒ already DEAD (vs. record_failure, which needs 5).
+        // Checked at the failure instant AND after the backoff elapsed: a timed
+        // quarantine would dial again at `later`; the terminal eviction must not.
+        let mut q = DialQuarantine::default();
+        q.record_terminal_failure(key(54060), 0, stamp);
+        assert!(
+            matches!(
+                q.gate(&key(54060), 0, stamp, 0),
+                DialGate::Dead { consecutive_failures } if consecutive_failures == DEAD_AFTER_CONSECUTIVE_FAILURES
+            ),
+            "a deterministic (identity-mismatch) failure evicts on the first strike"
+        );
+        assert!(
+            matches!(q.gate(&key(54060), later, stamp, 0), DialGate::Dead { .. }),
+            "still dead after the backoff expired — it's failure-counted, not timed"
+        );
+
+        // A STRICTLY fresher advertisement (the peer came back under a new
+        // endpoint) lifts the eviction — the orphan releases on its own.
+        assert_eq!(
+            q.gate(&key(54060), later, stamp + 1, 0),
+            DialGate::Dial,
+            "a fresher advert must lift a terminal eviction — automatic reconnect"
+        );
+
+        // Proof-of-life newer than the failure also lifts it (the peer is
+        // provably reachable again), independent of the advert axis.
+        let mut q2 = DialQuarantine::default();
+        q2.record_terminal_failure(key(54060), 0, stamp);
+        assert_eq!(
+            q2.gate(&key(54060), later, stamp, 1),
+            DialGate::Dial,
+            "proof-of-life after the failure lifts a terminal eviction too"
+        );
     }
 
     // what this catches (#240 — live-beaconing peer stuck at 0-connected):

--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -607,12 +607,29 @@ impl Airc {
                                 self.dial_quarantine_record_success(peer_id, addr);
                                 break;
                             }
-                            self.dial_quarantine_record_failure(
-                                peer_id,
-                                addr,
-                                now_ms,
-                                advert_stamp_ms,
-                            );
+                            // An identity-mismatch we could NOT heal (presented
+                            // peer not enrolled/trusted) is TERMINAL — this stored
+                            // endpoint now hosts a different peer and will fail
+                            // identically forever. Evict on the first strike so the
+                            // orphan isn't hammered for five cycles; a transient
+                            // failure still counts normally.
+                            if airc_transport::presented_peer_from_mismatch_error(&error_text)
+                                .is_some()
+                            {
+                                self.dial_quarantine_record_terminal_failure(
+                                    peer_id,
+                                    addr,
+                                    now_ms,
+                                    advert_stamp_ms,
+                                );
+                            } else {
+                                self.dial_quarantine_record_failure(
+                                    peer_id,
+                                    addr,
+                                    now_ms,
+                                    advert_stamp_ms,
+                                );
+                            }
                             failures.push(PeerDialFailure {
                                 peer_id,
                                 endpoint: endpoint.clone(),
@@ -696,16 +713,35 @@ impl Airc {
                             break;
                         }
                         Ok(Err(error)) => {
-                            self.dial_quarantine_record_failure(
-                                relay_peer,
-                                relay_addr,
-                                now_ms,
-                                advert_stamp_ms,
-                            );
+                            // A relay host that re-installed comes back under a NEW
+                            // identity, so its stored endpoint now presents a cert
+                            // for a different peer — a TERMINAL mismatch that fails
+                            // identically forever (glass-boxed: the M5↔bigmama
+                            // "cert is for 71dcc50f, expected 2f0aed7f" orphan).
+                            // Evict on the first strike; revival on a fresher advert
+                            // still brings the relay's new endpoint in on its own.
+                            let error_text = error.to_string();
+                            if airc_transport::presented_peer_from_mismatch_error(&error_text)
+                                .is_some()
+                            {
+                                self.dial_quarantine_record_terminal_failure(
+                                    relay_peer,
+                                    relay_addr,
+                                    now_ms,
+                                    advert_stamp_ms,
+                                );
+                            } else {
+                                self.dial_quarantine_record_failure(
+                                    relay_peer,
+                                    relay_addr,
+                                    now_ms,
+                                    advert_stamp_ms,
+                                );
+                            }
                             failures.push(PeerDialFailure {
                                 peer_id,
                                 endpoint: endpoint.clone(),
-                                error: format!("relay connect: {error}"),
+                                error: format!("relay connect: {error_text}"),
                             });
                         }
                         Err(_elapsed) => {
@@ -968,6 +1004,28 @@ impl Airc {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         guard.record_failure((peer_id, addr), now_ms, advert_stamp_ms);
+    }
+
+    /// Terminal-failure eviction: a dial whose failure is DETERMINISTIC (an
+    /// identity-mismatch verdict — the endpoint now hosts a different peer, so
+    /// every dial will fail identically) evicts on the FIRST strike instead of
+    /// counting five. Stops the "survivor stuck on the orphan" wedge where a
+    /// re-installed peer's stale endpoint is hammered for ~5 refresh cycles.
+    /// Revival (fresher advert / proof-of-life) is unchanged — the returning
+    /// peer's new endpoint replaces the orphan on its own.
+    fn dial_quarantine_record_terminal_failure(
+        &self,
+        peer_id: PeerId,
+        addr: std::net::SocketAddr,
+        now_ms: u64,
+        advert_stamp_ms: u64,
+    ) {
+        let mut guard = self
+            .inner
+            .dial_quarantine
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.record_terminal_failure((peer_id, addr), now_ms, advert_stamp_ms);
     }
 
     /// Card 7e3c9a1f: clear any quarantine on `(peer_id, addr)` after a


### PR DESCRIPTION
## The wedge (glass-boxed on the M5↔bigmama grid, 2026-07-28)

bigmama re-installed and came back under a **new peer identity**, so her old advertised relay endpoint now presents a cert for a different peer. Every dial failed forever with:

```
relay connect: server cert is for peer 71dcc50f..., expected 2f0aed7f...
```

The survivor stayed **stuck on the orphan** — hammering the dead identity, grid wedged, recovery needing a manual reconnect on the other side. This is the *"one node goes down and comes back, the other stuck on the orphan"* gap that #240 didn't cover.

## Root cause

A cert-identity-mismatch is **deterministic** — the endpoint's identity is provably wrong, so retrying the *same* stored endpoint can never succeed. But the dial loop recorded it as a **transient** failure: it took `DEAD_AFTER_CONSECUTIVE_FAILURES` (5) strikes across ~5 refresh cycles to evict, and the **relay path had no mismatch handling at all**.

## Fix

- **`DialQuarantine::record_terminal_failure`** — jumps the streak straight to the DEAD threshold, so `gate` evicts on the **first** strike. It changes *only* the strike count: the revival conditions are untouched, so a **fresher advertisement** (the returning peer's new endpoint) or a **proof-of-life** still lifts the eviction. The peer reconnects on its own — no manual `airc join`.
- **`discovery.rs`** — both the direct-dial path (after the identity self-heal retry fails to adopt the presented identity) and the relay-dial path classify a mismatch verdict (`presented_peer_from_mismatch_error`) as terminal and evict immediately; a transient failure still counts normally.

The common orphan case is even cleaner: the returning peer's **new** identity is a new quarantine key with no entry → dials immediately. The terminal eviction just stops the survivor wasting cycles on the dead old identity.

## Validation
- `cargo test -p airc-lib dial_quarantine` — 11 passed, incl. new `terminal_failure_is_dead_on_the_first_strike_but_still_revives` (first-strike eviction **+** advert/proof-of-life revival).
- airc-lib `fmt --check` + `clippy` (deny-warnings) clean.
- **Not** yet end-to-end validated on a live 2-node down/up — that needs a coordinated bigmama reconnect. The unit test pins the eviction + revival logic; a live down/up is the acceptance test.