### PR TITLE
reland(identity): peer_id-adopting mint (open_as_with_peer_id / attach_as_with_peer_id)

### DIFF
--- a/crates/airc-identity/src/lib.rs
+++ b/crates/airc-identity/src/lib.rs
@@ -194,6 +194,29 @@ impl LocalIdentity {
         home: &Path,
         agent_name: impl AsRef<str>,
     ) -> Result<Self, IdentityError> {
+        Self::load_or_generate_as_with_peer_id(home, agent_name, None).await
+    }
+
+    /// Like [`load_or_generate_as`], but lets the caller pin the `peer_id`
+    /// adopted **on a fresh mint**.
+    ///
+    /// `peer_id`:
+    /// - `Some(id)` → if (and only if) this call mints a brand-new identity
+    ///   (no key + no row on disk), adopt `id` as the `peer_id` so
+    ///   `peer_id()` coheres with a host-derived identifier. See
+    ///   [`generate_and_save_as_with_peer_id`] for the rationale.
+    /// - `None` → mint a random `peer_id`, the historical behavior.
+    ///
+    /// On EVERY resume/load path the supplied id is ignored — the stored
+    /// identity is authoritative — so an existing citizen is never rotated.
+    /// The id is likewise not consulted by the "key exists, row missing"
+    /// recovery arms (multi-agent-in-one-home); those keep minting a random
+    /// `peer_id`, since a host that pins ids gives each citizen its own home.
+    pub async fn load_or_generate_as_with_peer_id(
+        home: &Path,
+        agent_name: impl AsRef<str>,
+        peer_id: Option<PeerId>,
+    ) -> Result<Self, IdentityError> {
         let agent_name = normalise_agent_name(agent_name.as_ref())?;
         let store = open_store(home).await?;
         let key_path = Self::key_path(home);
@@ -216,7 +239,13 @@ impl LocalIdentity {
                     state_exists: false,
                 }),
             },
-            (false, None) => Self::generate_and_save_as(home, &store, &agent_name).await,
+            // The ONLY fresh-mint arm: adopt the supplied peer_id if any.
+            (false, None) => match peer_id {
+                Some(peer_id) => {
+                    Self::generate_and_save_as_with_peer_id(home, &store, &agent_name, peer_id).await
+                }
+                None => Self::generate_and_save_as(home, &store, &agent_name).await,
+            },
             (key, state) => Err(IdentityError::PartialState {
                 key_exists: key,
                 state_exists: state.is_some(),
@@ -341,10 +370,42 @@ impl LocalIdentity {
         store: &SqliteEventStore,
         agent_name: impl AsRef<str>,
     ) -> Result<Self, IdentityError> {
+        // The peer_id is airc's to assign, so the default mint stamps a
+        // fresh random one. Hosts that derive an actor's identifier BEFORE
+        // attach (e.g. Continuum personas, whose name + home are projected
+        // from a `persona_id`) use `generate_and_save_as_with_peer_id` to make
+        // the two cohere.
+        Self::generate_and_save_as_with_peer_id(home, store, agent_name, PeerId::new()).await
+    }
+
+    /// Like [`generate_and_save_as`], but ADOPTS a caller-supplied `peer_id`
+    /// instead of minting a random one.
+    ///
+    /// The `peer_id` is a stable uuid airc assigns and persists — it is NOT a
+    /// hash of the keypair (the keypair is separate signing material, still
+    /// freshly generated here). So there is no cryptographic reason it must be
+    /// minted inside airc: an embedding host that has already derived an
+    /// identifier can hand it in, and `peer_id()` will equal it.
+    ///
+    /// The motivating consumer is Continuum's per-persona runtime: a persona's
+    /// `agent_name` (and thus her home directory) is projected from a
+    /// `persona_id` chosen before `attach_as` runs. Passing that `persona_id`
+    /// here as the `peer_id` makes `airc.peer_id() == persona_id == the seed her
+    /// name was derived from` — coherent identity from birth, with no
+    /// throwaway-uuid divergence to collapse after the fact.
+    ///
+    /// This is the FRESH-mint path only. A resumed identity (key + row already
+    /// on disk) loads its stored `peer_id`; a supplied one is never consulted,
+    /// so an existing citizen's identity is never rotated.
+    pub async fn generate_and_save_as_with_peer_id(
+        home: &Path,
+        store: &SqliteEventStore,
+        agent_name: impl AsRef<str>,
+        peer_id: PeerId,
+    ) -> Result<Self, IdentityError> {
         let agent_name = normalise_agent_name(agent_name.as_ref())?;
         ensure_home_dir(home)?;
         let keypair = PeerKeypair::generate();
-        let peer_id = PeerId::new();
         let client_id = ClientId::new();
         let created_at_ms = now_ms()?;
 
@@ -550,6 +611,44 @@ mod tests {
             .unwrap();
         assert_eq!(default_row.peer_id, default.peer_id);
         assert_eq!(codex_row.peer_id, codex.peer_id);
+    }
+
+    #[tokio::test]
+    async fn fresh_mint_adopts_a_supplied_peer_id_but_resume_ignores_it() {
+        // what this catches: the coherence contract Continuum relies on — a
+        // fresh mint stamps the caller's peer_id (so name/home/peer_id cohere
+        // from birth), while a resume keeps the STORED identity even if a
+        // different peer_id is supplied (an existing citizen is never rotated).
+        let home = TempDir::new().unwrap();
+        let chosen = PeerId::new();
+
+        let first =
+            LocalIdentity::load_or_generate_as_with_peer_id(home.path(), "helper", Some(chosen))
+                .await
+                .unwrap();
+        assert_eq!(first.peer_id, chosen, "fresh mint must adopt the supplied peer_id");
+
+        // Resume with a DIFFERENT supplied id — the stored one wins.
+        let other = PeerId::new();
+        assert_ne!(other, chosen);
+        let second =
+            LocalIdentity::load_or_generate_as_with_peer_id(home.path(), "helper", Some(other))
+                .await
+                .unwrap();
+        assert_eq!(second.peer_id, chosen, "resume must ignore a supplied peer_id");
+        assert_eq!(
+            first.keypair.secret_bytes(),
+            second.keypair.secret_bytes(),
+            "resume keeps the same keypair"
+        );
+
+        // And the None path still mints a random id (historical behavior).
+        let home2 = TempDir::new().unwrap();
+        let random =
+            LocalIdentity::load_or_generate_as_with_peer_id(home2.path(), "helper", None)
+                .await
+                .unwrap();
+        assert_ne!(random.peer_id, chosen);
     }
 
     #[test]

--- a/crates/airc-identity/src/lib.rs
+++ b/crates/airc-identity/src/lib.rs
@@ -242,7 +242,8 @@ impl LocalIdentity {
             // The ONLY fresh-mint arm: adopt the supplied peer_id if any.
             (false, None) => match peer_id {
                 Some(peer_id) => {
-                    Self::generate_and_save_as_with_peer_id(home, &store, &agent_name, peer_id).await
+                    Self::generate_and_save_as_with_peer_id(home, &store, &agent_name, peer_id)
+                        .await
                 }
                 None => Self::generate_and_save_as(home, &store, &agent_name).await,
             },
@@ -626,7 +627,10 @@ mod tests {
             LocalIdentity::load_or_generate_as_with_peer_id(home.path(), "helper", Some(chosen))
                 .await
                 .unwrap();
-        assert_eq!(first.peer_id, chosen, "fresh mint must adopt the supplied peer_id");
+        assert_eq!(
+            first.peer_id, chosen,
+            "fresh mint must adopt the supplied peer_id"
+        );
 
         // Resume with a DIFFERENT supplied id — the stored one wins.
         let other = PeerId::new();
@@ -635,7 +639,10 @@ mod tests {
             LocalIdentity::load_or_generate_as_with_peer_id(home.path(), "helper", Some(other))
                 .await
                 .unwrap();
-        assert_eq!(second.peer_id, chosen, "resume must ignore a supplied peer_id");
+        assert_eq!(
+            second.peer_id, chosen,
+            "resume must ignore a supplied peer_id"
+        );
         assert_eq!(
             first.keypair.secret_bytes(),
             second.keypair.secret_bytes(),
@@ -644,10 +651,9 @@ mod tests {
 
         // And the None path still mints a random id (historical behavior).
         let home2 = TempDir::new().unwrap();
-        let random =
-            LocalIdentity::load_or_generate_as_with_peer_id(home2.path(), "helper", None)
-                .await
-                .unwrap();
+        let random = LocalIdentity::load_or_generate_as_with_peer_id(home2.path(), "helper", None)
+            .await
+            .unwrap();
         assert_ne!(random.peer_id, chosen);
     }
 

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -381,6 +381,48 @@ impl Airc {
         Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
     }
 
+    /// [`open_as`] that ADOPTS a caller-supplied `peer_id` when it mints a
+    /// fresh identity (owner-mode, no daemon).
+    ///
+    /// A multi-citizen host that derives each citizen's identifier BEFORE
+    /// attach — Continuum personas, whose `agent_name`/home are projected from
+    /// a `persona_id` — passes that id here so `peer_id() == persona_id`, a
+    /// coherent identity from birth. A resumed citizen loads its stored
+    /// identity and the supplied id is ignored (never a rotation).
+    pub async fn open_as_with_peer_id(
+        home: impl Into<PathBuf>,
+        agent_name: impl Into<String>,
+        peer_id: PeerId,
+    ) -> Result<Self, AircError> {
+        Self::open_with_policy_as_with_peer_id(
+            home,
+            VerificationPolicy::Strict,
+            agent_name,
+            peer_id,
+        )
+        .await
+    }
+
+    /// [`attach_as`] that ADOPTS a caller-supplied `peer_id` on a fresh mint —
+    /// the daemon-connected form of [`open_as_with_peer_id`], and the
+    /// constructor a Continuum persona runtime reaches for so its airc
+    /// `peer_id` equals the `persona_id` its name + home were derived from.
+    ///
+    /// Equivalent to:
+    /// ```ignore
+    /// let airc = Airc::open_as_with_peer_id(home, agent_name, peer_id).await?
+    ///     .with_daemon_client(DaemonClient::new(socket));
+    /// ```
+    pub async fn attach_as_with_peer_id(
+        home: impl Into<PathBuf>,
+        agent_name: impl Into<String>,
+        socket: impl Into<PathBuf>,
+        peer_id: PeerId,
+    ) -> Result<Self, AircError> {
+        let airc = Self::open_as_with_peer_id(home, agent_name, peer_id).await?;
+        Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
+    }
+
     /// Test-only [`attach`] that pins the machine-account wire root
     /// explicitly instead of deriving it from `HOME`/`USERPROFILE`.
     /// Two scopes sharing one `wire_root` resolve the same mesh
@@ -407,7 +449,7 @@ impl Airc {
         let home: PathBuf = home.into();
         std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
         let wire_root = machine_account_home(&home);
-        Self::open_inner(home, wire_root, policy, None).await
+        Self::open_inner(home, wire_root, policy, None, None).await
     }
 
     /// Variant of [`open_with_policy`] that pins the local agent name
@@ -420,7 +462,25 @@ impl Airc {
         let home: PathBuf = home.into();
         std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
         let wire_root = machine_account_home(&home);
-        Self::open_inner(home, wire_root, policy, Some(agent_name.into())).await
+        Self::open_inner(home, wire_root, policy, Some(agent_name.into()), None).await
+    }
+
+    /// Variant of [`open_with_policy_as`] that also ADOPTS a caller-supplied
+    /// `peer_id` on a fresh mint. This is the constructor behind
+    /// [`Airc::open_as_with_peer_id`] / [`Airc::attach_as_with_peer_id`]; a
+    /// resumed identity ignores the supplied id and keeps its stored one. See
+    /// [`airc_identity::LocalIdentity::generate_and_save_as_with_peer_id`] for
+    /// the coherence rationale.
+    pub async fn open_with_policy_as_with_peer_id(
+        home: impl Into<PathBuf>,
+        policy: VerificationPolicy,
+        agent_name: impl Into<String>,
+        peer_id: PeerId,
+    ) -> Result<Self, AircError> {
+        let home: PathBuf = home.into();
+        std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
+        let wire_root = machine_account_home(&home);
+        Self::open_inner(home, wire_root, policy, Some(agent_name.into()), Some(peer_id)).await
     }
 
     /// Test-only: open with an explicit machine-account wire root rather
@@ -439,6 +499,7 @@ impl Airc {
             wire_root.into(),
             VerificationPolicy::Strict,
             None,
+            None,
         )
         .await
     }
@@ -448,10 +509,17 @@ impl Airc {
         wire_root: PathBuf,
         policy: VerificationPolicy,
         agent_name: Option<String>,
+        // Adopted as the local `peer_id` ONLY on a fresh mint under a named
+        // agent (see `LocalIdentity::load_or_generate_as_with_peer_id`).
+        // `None` mints a random id, the historical behavior. Ignored without
+        // an `agent_name` (the anonymous default-scope path never pins ids).
+        peer_id: Option<PeerId>,
     ) -> Result<Self, AircError> {
         std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
         let identity = match agent_name {
-            Some(agent_name) => LocalIdentity::load_or_generate_as(&home, agent_name).await?,
+            Some(agent_name) => {
+                LocalIdentity::load_or_generate_as_with_peer_id(&home, agent_name, peer_id).await?
+            }
             None => LocalIdentity::load_or_generate(&home).await?,
         };
         std::fs::create_dir_all(&wire_root).map_err(IdentityError::Io)?;

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -480,7 +480,14 @@ impl Airc {
         let home: PathBuf = home.into();
         std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
         let wire_root = machine_account_home(&home);
-        Self::open_inner(home, wire_root, policy, Some(agent_name.into()), Some(peer_id)).await
+        Self::open_inner(
+            home,
+            wire_root,
+            policy,
+            Some(agent_name.into()),
+            Some(peer_id),
+        )
+        .await
     }
 
     /// Test-only: open with an explicit machine-account wire root rather


### PR DESCRIPTION
Continuum was pinned to `3655e3c` on `feat/persona-peer-id-mint` — a branch that never got a PR, so canary never received the mint. Bumping continuum to canary (for #1303 ListRooms) broke persona genesis (`attach_as_with_peer_id` gone). This relands the original commit verbatim (clean cherry-pick, additive, 2 files): the host mints a persona's airc identity with a pre-derived peer_id so name/id cohere by construction (continuum #199/#200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo