### PR TITLE
feat(route): delivery ledger — health = ACKed delivery, suspect purge kills half-open sessions (#1306)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1431,6 +1431,13 @@ pub async fn run_daemon(
     ));
     routed_forwarder.add_link(daemon_airc.clone()).await;
 
+    // #1306: end-to-end delivery truth. The forwarder's per-peer ack
+    // ledger feeds the shared daemon handle so route refresh can (a)
+    // force-drop + re-dial "connected" peers whose flushed frames go
+    // unacked (the half-open purge) and (b) stamp MEASURED lan-tcp
+    // health (rtt/success_ppm) instead of `healthy (not measured)`.
+    daemon_airc.set_delivery_ledger(routed_forwarder.delivery_ledger());
+
     // Self-healing join (refresh-on-failure): the ONE resolved rendezvous
     // store + gate, shared between the registry-refresh loop (its owner,
     // which fills this slot once resolution succeeds) and the

--- a/crates/airc-cli/src/transport_commands.rs
+++ b/crates/airc-cli/src/transport_commands.rs
@@ -161,6 +161,12 @@ pub async fn run_health(
     } else {
         println!("lan peers: {}", snapshot.connected_lan_peers.len());
     }
+    // #1306: half-open sessions the delivery ledger caught this refresh
+    // — a previously-silent failure class made visible. Each was dropped
+    // + re-dialed because flushed frames went unacked.
+    for peer in &snapshot.suspect_connections_dropped {
+        println!("suspect connection dropped (unacked frames, re-dialing): {peer}");
+    }
     // Card 625abe6d slice 1: every failed outbound dial to a stored
     // peer endpoint is visible here — an offline peer is normal mesh
     // weather, a silently-undialed endpoint is a bug.

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -123,6 +123,13 @@ pub enum DiagnosticCode {
     /// remote reports the channel unbound). The local transcript is
     /// intact; the remote machine did not confirm visibility.
     RoutedForwardFailed,
+    /// #1306: a live LAN session was force-dropped by route refresh
+    /// because frames flushed to it went unacked past the suspect
+    /// threshold — the half-open-socket purge. The peer is re-dialed
+    /// in the same refresh pass; this event is the visible trace of a
+    /// failure that was previously silent ("connected" forever, zero
+    /// delivery).
+    SuspectConnectionDropped,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -297,6 +297,15 @@ pub(crate) struct AircInner {
     /// attached scope reads — not in this handle's private scope store.
     pub(crate) inbound_sink:
         std::sync::RwLock<Option<Arc<dyn crate::router_bridge::InboundFrameSink>>>,
+    /// #1306: the daemon's per-peer delivery ledger, set once at daemon
+    /// boot ([`Airc::set_delivery_ledger`]) from the routed forwarder's
+    /// accounting. Route refresh consults it to distrust "connected"
+    /// peers whose flushed frames go unacked (the half-open purge) and
+    /// to stamp MEASURED lan-tcp health. `None` on every non-daemon
+    /// handle — refresh then keeps its unmeasured fallback. Outer `Arc`
+    /// so daemon-derived handles share the one slot.
+    pub(crate) delivery_ledger:
+        Arc<std::sync::OnceLock<Arc<crate::route::delivery_ledger::DeliveryLedger>>>,
 }
 
 /// Capacity of the delivery-ack fan-out channel. Acks are tiny,
@@ -606,6 +615,7 @@ impl Airc {
                     airc_diagnostics::StderrJsonDiagnosticSink,
                 )),
                 inbound_sink: std::sync::RwLock::new(None),
+                delivery_ledger: Arc::new(std::sync::OnceLock::new()),
             }),
         })
     }
@@ -1417,10 +1427,27 @@ impl Airc {
             ack_tx: self.inner.ack_tx.clone(),
             diag_sink: std::sync::RwLock::new(self.diag_sink()),
             inbound_sink: std::sync::RwLock::new(self.inbound_frame_sink()),
+            // #1306: share the ledger slot so any daemon-derived handle's
+            // route refresh sees the forwarder's delivery accounting.
+            delivery_ledger: self.inner.delivery_ledger.clone(),
         };
         Self {
             inner: Arc::new(inner),
         }
+    }
+
+    /// #1306: install the daemon's delivery ledger on this handle (and
+    /// every handle derived from it). Set-once at daemon boot from
+    /// [`crate::RoutedForwarder::delivery_ledger`]; a second call is a
+    /// no-op (the first ledger stays authoritative — one accounting per
+    /// process).
+    pub fn set_delivery_ledger(&self, ledger: Arc<crate::route::delivery_ledger::DeliveryLedger>) {
+        let _ = self.inner.delivery_ledger.set(ledger);
+    }
+
+    /// #1306: the installed delivery ledger, `None` on non-daemon handles.
+    pub fn delivery_ledger(&self) -> Option<Arc<crate::route::delivery_ledger::DeliveryLedger>> {
+        self.inner.delivery_ledger.get().cloned()
     }
 
     /// Replace the route-health view consumed by the resolver.

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -206,6 +206,7 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::DeliveryAckSendFailed => "delivery_ack_send_failed",
         DiagnosticCode::RoutedForwardQueueSaturated => "routed_forward_queue_saturated",
         DiagnosticCode::RoutedForwardFailed => "routed_forward_failed",
+        DiagnosticCode::SuspectConnectionDropped => "suspect_connection_dropped",
     }
 }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -175,6 +175,7 @@ pub use registry_refresh::{
     RegistryRefreshConfig, RegistryRefreshGate, SyncOutcome, TickReport as RegistrySyncReport,
 };
 pub use room::Room;
+pub use route::delivery_ledger::{DeliveryAggregate, DeliveryLedger, PeerDeliveryStats};
 pub use route::{
     endpoints_from_json, endpoints_to_json, ImportedInvite, InviteBeacon, PeerDialFailure,
     PeerDialSkip, RouteClass, RouteDecision, RouteDiscoverySnapshot, RouteEndpoint, RoutePolicy,

--- a/crates/airc-lib/src/route/delivery_ledger.rs
+++ b/crates/airc-lib/src/route/delivery_ledger.rs
@@ -1,0 +1,293 @@
+//! Per-peer delivery ledger — the end-to-end truth layer (#1306).
+//!
+//! ## The gap this closes
+//!
+//! Delivery acks exist on the wire (cards 39d37629 + 1998f6cb: every
+//! routed forward requests one, and the remote acks only after durable
+//! store). But their outcomes terminated in a global counter — nothing
+//! fed them back into route health or route refresh. Health was stamped
+//! `Healthy` from "a listener is bound or a connection object exists"
+//! (`state=healthy (not measured)`), and route refresh SKIPPED any peer
+//! present in the adapter's connection map. A half-open TCP session
+//! (peer force-killed, NAT state dropped, machine rebooted) keeps its
+//! map entry forever, so the one signal that proves non-delivery — sent
+//! frames going unacked — was observed, counted, and ignored, while
+//! both sides' doctors reported 8/8 clean. 2026-07-31: hours of silent
+//! one-directional loss between two "healthy" daemons, twice in one day.
+//!
+//! ## The mechanism
+//!
+//! The [`RoutedForwarder`](crate::RoutedForwarder) records every frame
+//! it flushes to a peer ([`DeliveryLedger::record_attempt`]) and every
+//! ack that comes back ([`DeliveryLedger::record_ack`] — ANY typed
+//! outcome proves the pipe and the remote daemon, `delivered` and
+//! `undeliverable` alike). From that, two derived truths:
+//!
+//! - **Suspect** ([`DeliveryLedger::is_suspect`]): ≥
+//!   [`SUSPECT_UNACKED_ATTEMPTS`] consecutive flushed-but-unacked
+//!   frames. Route refresh drops a suspect peer's connection and
+//!   re-dials instead of skipping it as "connected" — the half-open
+//!   lie dies here.
+//! - **Measured health** ([`DeliveryLedger::aggregate`]): real
+//!   `rtt_ms` / `success_ppm` for the lan-tcp health sample, replacing
+//!   `not measured` whenever at least one forward has been attempted.
+//!
+//! Pure accounting, no I/O, no clock reads of its own — callers pass
+//! `now_ms` (one wall-clock read per refresh, matching discovery's
+//! discipline).
+
+use airc_core::PeerId;
+use dashmap::DashMap;
+
+/// Consecutive flushed-but-unacked forwards after which a peer's
+/// "connected" state is no longer believed. Each attempt already waited
+/// the forwarder's full ack timeout (10s default), so 2 means ≥ ~20s of
+/// proven non-delivery — decisive for a half-open socket, tolerant of a
+/// single dropped ack frame.
+pub const SUSPECT_UNACKED_ATTEMPTS: u32 = 2;
+
+/// Per-peer delivery accounting. All counters are lifetime totals for
+/// this daemon process; recency is carried by the `*_ms` stamps.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PeerDeliveryStats {
+    /// Frames actually flushed to this peer's connection (post
+    /// `send_to` success — kernel buffer, not enqueue).
+    pub attempts: u64,
+    /// Typed delivery acks received from this peer (any outcome).
+    pub acked: u64,
+    /// Flushed frames since the last ack — the suspect trigger.
+    pub attempts_since_ack: u32,
+    pub last_attempt_ms: Option<u64>,
+    pub last_ack_ms: Option<u64>,
+    /// Exponential moving average of send→ack round trips.
+    pub rtt_ema_ms: Option<u32>,
+}
+
+impl PeerDeliveryStats {
+    /// True when enough consecutive flushed frames went unacked that
+    /// this peer's live connection is presumed half-open. Pure — unit
+    /// tested without a forwarder.
+    pub fn suspect(&self) -> bool {
+        self.attempts_since_ack >= SUSPECT_UNACKED_ATTEMPTS
+    }
+}
+
+/// Cross-peer aggregate for the transport-health sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeliveryAggregate {
+    pub attempts: u64,
+    pub acked: u64,
+    /// Success rate in parts-per-million over all attempts.
+    pub success_ppm: u32,
+    /// Best (minimum) per-peer RTT EMA — the latency of the healthiest
+    /// live route, the number an operator compares against ping.
+    pub best_rtt_ms: Option<u32>,
+    /// Every peer we have attempted delivery to is currently suspect —
+    /// the "all pipes lie" state that must surface as Degraded.
+    pub all_suspect: bool,
+}
+
+/// Shared per-daemon delivery ledger. One instance per process,
+/// created by the [`RoutedForwarder`](crate::RoutedForwarder) and
+/// shared with the daemon's route-refresh handle.
+#[derive(Debug, Default)]
+pub struct DeliveryLedger {
+    peers: DashMap<PeerId, PeerDeliveryStats>,
+}
+
+impl DeliveryLedger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A frame was flushed to `peer`'s connection.
+    pub fn record_attempt(&self, peer: PeerId, now_ms: u64) {
+        let mut stats = self.peers.entry(peer).or_default();
+        stats.attempts += 1;
+        stats.attempts_since_ack = stats.attempts_since_ack.saturating_add(1);
+        stats.last_attempt_ms = Some(now_ms);
+    }
+
+    /// A typed delivery ack arrived from `peer`. ANY outcome counts —
+    /// `undeliverable` still proves the pipe and the remote daemon; the
+    /// forwarder's own retry/diagnostic logic handles the outcome.
+    pub fn record_ack(&self, peer: PeerId, now_ms: u64, rtt_ms: Option<u32>) {
+        let mut stats = self.peers.entry(peer).or_default();
+        stats.acked += 1;
+        stats.attempts_since_ack = 0;
+        stats.last_ack_ms = Some(now_ms);
+        if let Some(sample) = rtt_ms {
+            stats.rtt_ema_ms = Some(match stats.rtt_ema_ms {
+                // EMA α=1/4: smooth enough to ignore one slow ack,
+                // fresh enough to track a route change within ~4 acks.
+                Some(ema) => (ema / 4).saturating_mul(3).saturating_add(sample / 4),
+                None => sample,
+            });
+        }
+    }
+
+    /// See [`PeerDeliveryStats::suspect`].
+    pub fn is_suspect(&self, peer: PeerId) -> bool {
+        self.peers
+            .get(&peer)
+            .map(|stats| stats.suspect())
+            .unwrap_or(false)
+    }
+
+    /// A suspect peer's connection was dropped for re-dial. Reset the
+    /// unacked run so the FRESH connection gets a full
+    /// [`SUSPECT_UNACKED_ATTEMPTS`] window to prove itself instead of
+    /// being purged again on its first frame.
+    pub fn note_purged(&self, peer: PeerId) {
+        if let Some(mut stats) = self.peers.get_mut(&peer) {
+            stats.attempts_since_ack = 0;
+        }
+    }
+
+    pub fn stats(&self, peer: PeerId) -> Option<PeerDeliveryStats> {
+        self.peers.get(&peer).map(|stats| *stats)
+    }
+
+    /// All peers with any recorded activity, for surfacing ("last
+    /// confirmed delivery to X: N ago").
+    pub fn snapshot(&self) -> Vec<(PeerId, PeerDeliveryStats)> {
+        let mut rows: Vec<_> = self
+            .peers
+            .iter()
+            .map(|entry| (*entry.key(), *entry.value()))
+            .collect();
+        rows.sort_by_key(|(peer, _)| peer.as_uuid());
+        rows
+    }
+
+    /// Cross-peer aggregate, `None` until the first attempt — callers
+    /// keep their unmeasured fallback for the no-traffic case.
+    pub fn aggregate(&self) -> Option<DeliveryAggregate> {
+        let mut attempts = 0u64;
+        let mut acked = 0u64;
+        let mut best_rtt_ms: Option<u32> = None;
+        let mut attempted_peers = 0u32;
+        let mut suspect_peers = 0u32;
+        for entry in self.peers.iter() {
+            let stats = entry.value();
+            if stats.attempts == 0 {
+                continue;
+            }
+            attempted_peers += 1;
+            attempts += stats.attempts;
+            acked += stats.acked;
+            if stats.suspect() {
+                suspect_peers += 1;
+            }
+            if let Some(rtt) = stats.rtt_ema_ms {
+                best_rtt_ms = Some(best_rtt_ms.map_or(rtt, |best| best.min(rtt)));
+            }
+        }
+        if attempts == 0 {
+            return None;
+        }
+        let success_ppm =
+            u32::try_from(acked.saturating_mul(1_000_000) / attempts).unwrap_or(1_000_000);
+        Some(DeliveryAggregate {
+            attempts,
+            acked,
+            success_ppm: success_ppm.min(1_000_000),
+            best_rtt_ms,
+            all_suspect: attempted_peers > 0 && suspect_peers == attempted_peers,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(n: u128) -> PeerId {
+        PeerId::from_u128(n)
+    }
+
+    /// what this catches: the suspect trigger — the exact half-open
+    /// signature (frames flushed, acks absent) must flip the verdict at
+    /// the threshold, and one ack must clear the whole run.
+    #[test]
+    fn unacked_run_flips_suspect_and_one_ack_clears_it() {
+        let ledger = DeliveryLedger::new();
+        let p = peer(1);
+        assert!(!ledger.is_suspect(p), "no traffic = no verdict");
+        ledger.record_attempt(p, 1_000);
+        assert!(!ledger.is_suspect(p), "one unacked attempt is tolerated");
+        ledger.record_attempt(p, 2_000);
+        assert!(ledger.is_suspect(p), "threshold reached");
+        ledger.record_ack(p, 3_000, Some(40));
+        assert!(!ledger.is_suspect(p), "any ack proves the pipe");
+        let stats = ledger.stats(p).expect("stats recorded");
+        assert_eq!(stats.attempts, 2);
+        assert_eq!(stats.acked, 1);
+        assert_eq!(stats.attempts_since_ack, 0);
+    }
+
+    /// what this catches: the purge reset — a re-dialed peer must get a
+    /// fresh SUSPECT_UNACKED_ATTEMPTS window, not be instantly purged
+    /// again on its first frame.
+    #[test]
+    fn note_purged_resets_the_unacked_run() {
+        let ledger = DeliveryLedger::new();
+        let p = peer(2);
+        ledger.record_attempt(p, 1_000);
+        ledger.record_attempt(p, 2_000);
+        assert!(ledger.is_suspect(p));
+        ledger.note_purged(p);
+        assert!(!ledger.is_suspect(p));
+        ledger.record_attempt(p, 3_000);
+        assert!(!ledger.is_suspect(p), "fresh window after purge");
+        ledger.record_attempt(p, 4_000);
+        assert!(ledger.is_suspect(p), "suspect re-earned honestly");
+    }
+
+    /// what this catches: aggregate truth for the health sample — ppm
+    /// arithmetic, best-RTT selection, and the all-suspect degraded
+    /// signal (one healthy peer must veto it).
+    #[test]
+    fn aggregate_reports_ppm_best_rtt_and_all_suspect() {
+        let ledger = DeliveryLedger::new();
+        assert_eq!(ledger.aggregate(), None, "no attempts = unmeasured");
+
+        let good = peer(3);
+        let bad = peer(4);
+        ledger.record_attempt(good, 1_000);
+        ledger.record_ack(good, 1_050, Some(50));
+        ledger.record_attempt(bad, 1_000);
+        ledger.record_attempt(bad, 2_000);
+
+        let agg = ledger.aggregate().expect("attempts recorded");
+        assert_eq!(agg.attempts, 3);
+        assert_eq!(agg.acked, 1);
+        assert_eq!(agg.success_ppm, 333_333);
+        assert_eq!(agg.best_rtt_ms, Some(50));
+        assert!(!agg.all_suspect, "one acking peer vetoes all-suspect");
+
+        ledger.record_attempt(good, 3_000);
+        ledger.record_attempt(good, 4_000);
+        assert!(
+            ledger.aggregate().expect("attempts recorded").all_suspect,
+            "every attempted peer suspect = all_suspect"
+        );
+    }
+
+    /// what this catches: RTT EMA smoothing — one slow ack must not
+    /// replace the average wholesale (α=1/4 blend).
+    #[test]
+    fn rtt_ema_smooths_rather_than_replaces() {
+        let ledger = DeliveryLedger::new();
+        let p = peer(5);
+        ledger.record_attempt(p, 1_000);
+        ledger.record_ack(p, 1_040, Some(40));
+        ledger.record_attempt(p, 2_000);
+        ledger.record_ack(p, 3_000, Some(1_000));
+        let ema = ledger.stats(p).expect("stats").rtt_ema_ms.expect("rtt");
+        assert!(
+            ema > 40 && ema < 1_000,
+            "one outlier blends, never replaces: got {ema}"
+        );
+    }
+}

--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -10,7 +10,7 @@ use futures::stream::StreamExt;
 use crate::error::AircError;
 use crate::route::health::{TransportHealthSample, TransportHealthState};
 use crate::route::invite::RouteEndpoint;
-use crate::route::policy::TransportKind;
+use crate::route::policy::{TransportKind, TransportRole};
 use crate::Airc;
 
 /// Card 625abe6d slice 1 — per-dial deadline. LAN/tailnet targets
@@ -156,6 +156,41 @@ pub struct RouteDiscoverySnapshot {
     /// burn a `PEER_DIAL_TIMEOUT` and bury live peers in failure noise), and a
     /// single count is surfaced rather than one skip per ghost (anti-spam).
     pub ghost_peers_skipped: usize,
+    /// #1306: peers whose live connection was force-dropped this refresh
+    /// because their flushed frames went unacked (the half-open purge —
+    /// see [`crate::route::delivery_ledger::DeliveryLedger`]). Each is
+    /// immediately eligible for re-dial in the SAME refresh pass.
+    pub suspect_connections_dropped: Vec<PeerId>,
+}
+
+/// #1306: the lan-tcp health sample, derived from delivery accounting
+/// when any exists. Pure — the decision is unit-tested independent of
+/// forwarder/adapter machinery.
+///
+/// - `None` aggregate (no ledger, or no forward ever attempted): the
+///   honest pre-traffic fallback — `Healthy`, rtt/success unmeasured.
+/// - Some acks coming back: `Healthy`, with MEASURED rtt + success_ppm
+///   (this is what retires `state=healthy (not measured)`).
+/// - Every attempted peer currently suspect: `Degraded` — frames are
+///   being flushed and nothing acks; the transport must stop being
+///   advertised as usable-now even though sockets "exist".
+pub(crate) fn lan_health_sample(
+    aggregate: Option<super::delivery_ledger::DeliveryAggregate>,
+) -> TransportHealthSample {
+    let Some(aggregate) = aggregate else {
+        return TransportHealthSample::healthy_direct(TransportKind::LanTcp);
+    };
+    TransportHealthSample {
+        kind: TransportKind::LanTcp,
+        role: TransportRole::Direct,
+        state: if aggregate.all_suspect {
+            TransportHealthState::Degraded
+        } else {
+            TransportHealthState::Healthy
+        },
+        rtt_ms: aggregate.best_rtt_ms,
+        success_ppm: Some(aggregate.success_ppm),
+    }
 }
 
 impl RouteDiscoverySnapshot {
@@ -215,6 +250,13 @@ impl Airc {
         // verifier sees the newly-enrolled pubkeys.
         self.sync_account_peer_registry().await?;
 
+        // #1306: BEFORE trusting the connection map, drop sessions the
+        // delivery ledger has proven half-open (flushed frames, no acks).
+        // The dropped peers vanish from `connected`, so the dial pass
+        // below re-dials them THIS refresh instead of skipping them as
+        // "connected" forever — the half-open immortality bug.
+        let suspect_connections_dropped = self.purge_suspect_connections().await;
+
         let (peer_dial_failures, peer_dial_skips, ghost_peers_skipped) =
             self.dial_stored_peer_endpoints().await?;
 
@@ -224,8 +266,14 @@ impl Airc {
             .any(|endpoint| matches!(endpoint, RouteEndpoint::LanTcp { .. }));
         let connected_lan_peers = self.connected_lan_peers().await;
         if lan_has_endpoint || !connected_lan_peers.is_empty() {
-            self.upsert_transport_health(TransportHealthSample::healthy_direct(
-                TransportKind::LanTcp,
+            // #1306: MEASURED health when delivery accounting exists —
+            // real rtt/success_ppm and Degraded when every attempted
+            // peer is suspect. `healthy (not measured)` only as the
+            // honest no-traffic fallback.
+            self.upsert_transport_health(lan_health_sample(
+                self.delivery_ledger()
+                    .as_deref()
+                    .and_then(super::delivery_ledger::DeliveryLedger::aggregate),
             ))?;
         }
 
@@ -236,7 +284,44 @@ impl Airc {
             peer_dial_failures,
             peer_dial_skips,
             ghost_peers_skipped,
+            suspect_connections_dropped,
         })
+    }
+
+    /// #1306: force-drop every connected peer the delivery ledger marks
+    /// SUSPECT (≥ [`super::delivery_ledger::SUSPECT_UNACKED_ATTEMPTS`]
+    /// flushed-but-unacked frames). Emits one warn diagnostic per drop —
+    /// this is the moment a silent half-open socket becomes a visible,
+    /// self-healing event. No-op on handles without a ledger (non-daemon).
+    async fn purge_suspect_connections(&self) -> Vec<PeerId> {
+        let Some(ledger) = self.delivery_ledger() else {
+            return Vec::new();
+        };
+        let adapter = self.inner.lan_tcp.lock().await.clone();
+        let Some(adapter) = adapter else {
+            return Vec::new();
+        };
+        let mut dropped = Vec::new();
+        for peer in adapter.connected_peers().await {
+            if !ledger.is_suspect(peer) {
+                continue;
+            }
+            if adapter.drop_connection(peer).await {
+                ledger.note_purged(peer);
+                self.diag_sink().emit(
+                    airc_diagnostics::DiagnosticEvent::warn(
+                        airc_diagnostics::DiagnosticComponent::Transport,
+                        airc_diagnostics::DiagnosticCode::SuspectConnectionDropped,
+                        "live connection dropped: flushed frames went unacked — the \
+                         session was presumed half-open and the peer will be re-dialed \
+                         this refresh",
+                    )
+                    .with_field("peer", peer),
+                );
+                dropped.push(peer);
+            }
+        }
+        dropped
     }
 
     /// Card 625abe6d slice 1 — outbound-dial every enrolled peer with
@@ -891,6 +976,7 @@ impl Airc {
             peer_dial_failures: Vec::new(),
             peer_dial_skips: Vec::new(),
             ghost_peers_skipped: 0,
+            suspect_connections_dropped: Vec::new(),
         })
     }
 
@@ -1199,6 +1285,7 @@ mod tests {
             peer_dial_failures: Vec::new(),
             peer_dial_skips: Vec::new(),
             ghost_peers_skipped: 0,
+            suspect_connections_dropped: Vec::new(),
         }
     }
 
@@ -1231,5 +1318,42 @@ mod tests {
     #[test]
     fn grid_of_one_never_elects() {
         assert!(!snapshot(Vec::new(), Vec::new()).should_self_elect_as_relay(0));
+    }
+
+    /// what this catches (#1306): the health-sample decision. No
+    /// delivery accounting keeps today's honest unmeasured fallback;
+    /// any accounting yields MEASURED rtt/success (retiring
+    /// `state=healthy (not measured)`); an all-suspect ledger — frames
+    /// flushing, nothing acking — must degrade the transport even
+    /// though sockets "exist".
+    #[test]
+    fn lan_health_sample_measures_and_degrades_from_delivery_truth() {
+        use crate::route::delivery_ledger::DeliveryAggregate;
+
+        let unmeasured = lan_health_sample(None);
+        assert_eq!(unmeasured.state, TransportHealthState::Healthy);
+        assert_eq!(unmeasured.rtt_ms, None);
+        assert_eq!(unmeasured.success_ppm, None);
+
+        let measured = lan_health_sample(Some(DeliveryAggregate {
+            attempts: 4,
+            acked: 3,
+            success_ppm: 750_000,
+            best_rtt_ms: Some(12),
+            all_suspect: false,
+        }));
+        assert_eq!(measured.state, TransportHealthState::Healthy);
+        assert_eq!(measured.rtt_ms, Some(12));
+        assert_eq!(measured.success_ppm, Some(750_000));
+
+        let half_open = lan_health_sample(Some(DeliveryAggregate {
+            attempts: 3,
+            acked: 0,
+            success_ppm: 0,
+            best_rtt_ms: None,
+            all_suspect: true,
+        }));
+        assert_eq!(half_open.state, TransportHealthState::Degraded);
+        assert_eq!(half_open.success_ppm, Some(0));
     }
 }

--- a/crates/airc-lib/src/route/mod.rs
+++ b/crates/airc-lib/src/route/mod.rs
@@ -5,6 +5,7 @@
 //! routes. App and CLI layers consume this through `Airc`; they do
 //! not construct transport adapters or route frames themselves.
 
+pub mod delivery_ledger;
 pub mod dial_quarantine;
 pub mod discovery;
 pub mod health;

--- a/crates/airc-lib/src/route_forwarder.rs
+++ b/crates/airc-lib/src/route_forwarder.rs
@@ -83,6 +83,7 @@ use airc_transport::transport::Transport;
 use airc_transport::LanTcpAdapter;
 use tokio::sync::mpsc;
 
+use crate::route::delivery_ledger::DeliveryLedger;
 use crate::Airc;
 
 /// Tunables for a [`RoutedForwarder`]. Defaults fit the production
@@ -138,6 +139,11 @@ struct ForwarderInner {
     forwarded: AtomicU64,
     /// Forwards confirmed `delivered` by the remote's ack.
     confirmed: AtomicU64,
+    /// #1306: per-peer end-to-end delivery accounting — every flushed
+    /// frame and every ack lands here so route refresh can distrust
+    /// "connected" peers whose frames go unacked, and health can carry
+    /// measured rtt/success instead of `not measured`.
+    ledger: Arc<DeliveryLedger>,
     /// The drain task, aborted when the last forwarder handle drops
     /// (RAII — hermetic tests must not leak forward workers).
     drain_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -174,6 +180,7 @@ impl RoutedForwarder {
             diag: std::sync::RwLock::new(Arc::new(StderrJsonDiagnosticSink)),
             forwarded: AtomicU64::new(0),
             confirmed: AtomicU64::new(0),
+            ledger: Arc::new(DeliveryLedger::new()),
             drain_task: std::sync::Mutex::new(None),
         });
         // The task holds only a Weak — the forwarder handles own the
@@ -210,6 +217,13 @@ impl RoutedForwarder {
     /// Forwards the remote confirmed `delivered`.
     pub fn confirmed_count(&self) -> u64 {
         self.inner.confirmed.load(Ordering::SeqCst)
+    }
+
+    /// #1306: the per-peer delivery ledger. The daemon shares this with
+    /// its route-refresh handle ([`Airc::set_delivery_ledger`]) so
+    /// refresh can purge suspect connections and stamp measured health.
+    pub fn delivery_ledger(&self) -> Arc<DeliveryLedger> {
+        Arc::clone(&self.inner.ledger)
     }
 }
 
@@ -526,12 +540,22 @@ async fn forward_one(inner: &ForwarderInner, peer: PeerId, env: Arc<Envelope>) {
             continue;
         }
         inner.forwarded.fetch_add(1, Ordering::SeqCst);
+        // #1306: the frame is in the kernel buffer — that's an attempt.
+        // Whether an ack comes back is the ONLY end-to-end truth about
+        // this peer; the ledger turns that into route-refresh distrust
+        // of half-open "connected" sessions. Wall stamp is recency-only
+        // (0 on a clock error is harmless accounting); RTT is monotonic.
+        let now_ms = crate::time::now_ms().unwrap_or(0);
+        let sent_at = tokio::time::Instant::now();
+        inner.ledger.record_attempt(peer, now_ms);
         match wait_for_ack(&mut ack_rx, env.event_id, peer, inner.config.ack_timeout).await {
             AckWait::Delivered => {
                 inner.confirmed.fetch_add(1, Ordering::SeqCst);
+                record_ack(inner, peer, sent_at);
                 return;
             }
             AckWait::Undeliverable(UndeliverableReason::UnknownChannel) => {
+                record_ack(inner, peer, sent_at);
                 // The remote holds the frame durably; no scope there
                 // binds the channel. Retrying cannot change that — a
                 // late-joining scope replays it (proven in #1156).
@@ -555,7 +579,10 @@ async fn forward_one(inner: &ForwarderInner, peer: PeerId, env: Arc<Envelope>) {
                 // did NOT take the frame. Its recent-ids entry was
                 // unmarked (#1156 poisoning fix), so retrying the same
                 // event_id is a real publish there — never a false
-                // `Duplicate`/`delivered`.
+                // `Duplicate`/`delivered`. The PIPE is proven though —
+                // an undeliverable ack still came back — so the ledger
+                // records it (suspect measures transport, not outcome).
+                record_ack(inner, peer, sent_at);
                 last_failure = format!("remote undeliverable: {}", reason.as_str());
                 continue;
             }
@@ -582,6 +609,15 @@ async fn forward_one(inner: &ForwarderInner, peer: PeerId, env: Arc<Envelope>) {
         .with_field("attempts", max_attempts)
         .with_field("last_failure", last_failure),
     );
+}
+
+/// #1306: an ack of ANY outcome proves the pipe end-to-end — stamp the
+/// ledger with the measured send→ack round trip.
+fn record_ack(inner: &ForwarderInner, peer: PeerId, sent_at: tokio::time::Instant) {
+    let rtt_ms = u32::try_from(sent_at.elapsed().as_millis()).ok();
+    inner
+        .ledger
+        .record_ack(peer, crate::time::now_ms().unwrap_or(0), rtt_ms);
 }
 
 async fn wait_for_ack(

--- a/crates/airc-lib/tests/daemon_routed_forward.rs
+++ b/crates/airc-lib/tests/daemon_routed_forward.rs
@@ -400,27 +400,13 @@ async fn remote_persist_failure_then_retry_is_exactly_once_visible() {
     );
 }
 
-/// Backpressure + failure loudness: a connected peer that NEVER acks
-/// (hollow listener — accepts TLS, persists nothing, answers nothing).
-/// With a 1-deep per-peer queue and a worker pinned on the ack wait,
-/// a burst must overflow the queue (typed `RoutedForwardQueueSaturated`)
-/// and every unconfirmed forward must end in a typed
-/// `RoutedForwardFailed`. Nothing is silent, and local delivery is
-/// untouched.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn saturated_forward_queue_and_unconfirmed_forwards_are_loud() {
-    let a = boot_linked(RoutedForwarderConfig {
-        peer_queue_capacity: 1,
-        ack_timeout: Duration::from_millis(800),
-        max_attempts: 1,
-        retry_backoff: Duration::from_millis(50),
-        ..RoutedForwarderConfig::default()
-    })
-    .await;
-    let diag = MemoryDiagnosticSink::default();
-    a.forwarder.set_diagnostic_sink(Arc::new(diag.clone()));
-
-    // Hollow peer: TLS-pinned listener with NO ingest behind it.
+/// A "hollow" peer: TLS-pinned listener that accepts the connection but
+/// has NO ingest behind it — persists nothing, acks nothing. The
+/// in-process stand-in for a half-open session (frames flush into the
+/// kernel buffer, nothing ever answers). Returns the adapter alongside
+/// the id — dropping it closes the listener, which would surface as an
+/// OBSERVED disconnect instead of the silent no-ack this simulates.
+async fn connect_hollow_peer(a: &LinkedMachine) -> (airc_core::PeerId, LanTcpAdapter) {
     let hollow_id = airc_core::PeerId::from_u128(0x710c_1998_f6cb);
     let hollow_kp = PeerKeypair::generate();
     let hollow_pubkey = hollow_kp.public_bytes();
@@ -449,6 +435,31 @@ async fn saturated_forward_queue_and_unconfirmed_forwards_are_loud() {
         .connect_lan(hollow_addr, hollow_id)
         .await
         .expect("gateway dials hollow");
+    (hollow_id, hollow)
+}
+
+/// Backpressure + failure loudness: a connected peer that NEVER acks
+/// (hollow listener — accepts TLS, persists nothing, answers nothing).
+/// With a 1-deep per-peer queue and a worker pinned on the ack wait,
+/// a burst must overflow the queue (typed `RoutedForwardQueueSaturated`)
+/// and every unconfirmed forward must end in a typed
+/// `RoutedForwardFailed`. Nothing is silent, and local delivery is
+/// untouched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn saturated_forward_queue_and_unconfirmed_forwards_are_loud() {
+    let a = boot_linked(RoutedForwarderConfig {
+        peer_queue_capacity: 1,
+        ack_timeout: Duration::from_millis(800),
+        max_attempts: 1,
+        retry_backoff: Duration::from_millis(50),
+        ..RoutedForwarderConfig::default()
+    })
+    .await;
+    let diag = MemoryDiagnosticSink::default();
+    a.forwarder.set_diagnostic_sink(Arc::new(diag.clone()));
+
+    // Hollow peer: TLS-pinned listener with NO ingest behind it.
+    let (_hollow_id, _hollow) = connect_hollow_peer(&a).await;
 
     let op_a = a.machine.attach("op-a").await;
     op_a.join(ROOM).await.expect("op-a joins");
@@ -503,6 +514,80 @@ async fn saturated_forward_queue_and_unconfirmed_forwards_are_loud() {
 
     // And nothing was ever confirmed: the ack vocabulary stayed truthful.
     assert_eq!(a.forwarder.confirmed_count(), 0);
+}
+
+/// what this catches (#1306): the delivery ledger's healthy leg — a
+/// real ack-confirmed forward must land in per-peer accounting with a
+/// MEASURED round trip and no suspect verdict. This is the signal that
+/// retires `state=healthy (not measured)` route health.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn delivery_ledger_records_measured_acks_for_a_live_peer() {
+    let a = boot_linked(RoutedForwarderConfig::default()).await;
+    let b = boot_linked(RoutedForwarderConfig::default()).await;
+    link(&a.gateway, &b.gateway).await;
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+    let op_b = b.machine.attach("op-b").await;
+    op_b.join(ROOM).await.expect("op-b joins");
+
+    let id = op_a.say("ledger proof").await.expect("op-a says");
+    assert_eq!(wait_for_copies(&op_b, id).await, 1);
+    assert!(wait_for_confirmed(&a.forwarder, 1).await >= 1);
+
+    let ledger = a.forwarder.delivery_ledger();
+    let stats = ledger
+        .stats(b.gateway.peer_id())
+        .expect("delivery stats recorded for the confirmed peer");
+    assert!(stats.attempts >= 1, "the flushed frame was an attempt");
+    assert!(stats.acked >= 1, "the delivered ack was recorded");
+    assert!(
+        stats.rtt_ema_ms.is_some(),
+        "the send→ack round trip was MEASURED"
+    );
+    assert!(!stats.suspect(), "an acking peer is never suspect");
+    let aggregate = ledger.aggregate().expect("aggregate after traffic");
+    assert!(
+        aggregate.success_ppm > 0 && !aggregate.all_suspect,
+        "aggregate must reflect the confirmed delivery"
+    );
+}
+
+/// what this catches (#1306): the half-open signature — a connected
+/// peer whose flushed frames go unacked must earn the SUSPECT verdict
+/// in the ledger. Route refresh reads exactly this to drop + re-dial
+/// the session instead of trusting the connection map forever.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn hollow_peer_earns_suspect_after_unacked_attempts() {
+    let a = boot_linked(RoutedForwarderConfig {
+        ack_timeout: Duration::from_millis(400),
+        max_attempts: 2,
+        retry_backoff: Duration::from_millis(50),
+        ..RoutedForwarderConfig::default()
+    })
+    .await;
+    let (hollow_id, _hollow) = connect_hollow_peer(&a).await;
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+    op_a.say("into the void")
+        .await
+        .expect("local send keeps working while the peer is half-open");
+
+    // 2 attempts × 400ms unacked waits → suspect. Poll: the forward
+    // worker runs asynchronously to the send.
+    let ledger = a.forwarder.delivery_ledger();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while !ledger.is_suspect(hollow_id) {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "hollow peer must be marked suspect after unacked attempts; stats: {:?}",
+            ledger.stats(hollow_id)
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let stats = ledger.stats(hollow_id).expect("stats for hollow peer");
+    assert!(stats.attempts >= 2 && stats.acked == 0);
 }
 
 /// #1247 slice 3 — a room send traverses a RELAY, not LAN. This is the

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -113,6 +113,23 @@ impl LanTcpAdapter {
         }
     }
 
+    /// #1306: forcibly terminate `peer`'s live session — the SUSPECT
+    /// purge. A half-open TCP connection (peer force-killed, NAT state
+    /// dropped) keeps its map entry forever because removal otherwise
+    /// happens only when the read loop OBSERVES termination — which a
+    /// half-open socket never delivers. Route refresh calls this for a
+    /// peer whose flushed frames go unacked, so the peer stops looking
+    /// "connected" and gets re-dialed on the same refresh pass. Returns
+    /// whether a session existed. Fires the disconnect observer via the
+    /// same path as an observed termination.
+    pub async fn drop_connection(&self, peer: PeerId) -> bool {
+        if !self.inner.connections.lock().await.contains_key(&peer) {
+            return false;
+        }
+        connection::disconnect(&self.inner, peer).await;
+        true
+    }
+
     /// Snapshot of currently-connected peers. Useful for diagnostics
     /// (`airc-core peers`) + tests.
     pub async fn connected_peers(&self) -> Vec<PeerId> {


### PR DESCRIPTION
Closes the fundamental behind #1306 (and the daily breakage class behind #1299/#1305 forensics): **airc verified pipes, never delivery.**

## What was wrong
- Delivery acks existed end-to-end (cards 39d37629 + 1998f6cb) but terminated in a global `confirmed` counter — nothing fed route health or route refresh.
- `refresh_route_discovery` stamped lan-tcp `Healthy` from "listener bound OR connection map non-empty" → the literal `state=healthy (not measured)`.
- Route refresh **skipped** any peer present in the connection map → a half-open session (peer force-killed, NAT dropped) was immortal: "connected" forever, zero delivery, both doctors clean. Lived twice on 2026-07-31.

## The one signal
`DeliveryLedger` — per-peer delivery accounting fed by the `RoutedForwarder` at the only two points that know end-to-end truth (frame flushed to kernel buffer; typed ack returned — any outcome proves the pipe):

1. **Suspect purge**: ≥2 consecutive flushed-but-unacked frames (each already waited the full 10s ack timeout) ⇒ refresh force-drops the connection (`LanTcpAdapter::drop_connection`, reusing the observed-termination path), emits typed `SuspectConnectionDropped`, and re-dials in the SAME pass. The half-open lie becomes a visible, self-healing event.
2. **Measured health**: lan-tcp sample carries real `rtt_ms` (send→ack EMA) + `success_ppm` once any forward was attempted; `Degraded` when every attempted peer is suspect. `not measured` survives only as the honest no-traffic fallback.

Wiring: daemon shares the forwarder's ledger with its refresh handle (`Airc::set_delivery_ledger`, OnceLock shared across daemon-derived handles). `airc transport health` prints each purge.

## Tests
- Ledger unit tests: suspect threshold + ack-clears, purge reset window, aggregate ppm/best-RTT/all-suspect, RTT EMA smoothing.
- Pure `lan_health_sample` decision test (unmeasured fallback / measured healthy / all-suspect degraded).
- Integration on production wiring (`daemon_routed_forward`): live peer records measured acks + never suspect; hollow peer (accepts TLS, acks nothing — the in-process half-open) earns suspect. Hollow setup extracted to a shared helper.
- Full airc-lib (333), transport (33), routed-forward (8), lan_delivery_ack (3) green; both clippy gates + fmt clean.

## Follow-up (slice 2)
Per-peer "last confirmed delivery to X: N ago" over daemon IPC so `airc doctor --health` reports delivery truth instead of TCP state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo