### PR TITLE
feat(doctor): delivery truth over IPC — 'last confirmed delivery to X: N ago' (#1306 slice 2)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1781,12 +1781,21 @@ fn spawn_route_refresh(
     rendezvous: Arc<SharedRendezvousSlot>,
 ) -> tokio::task::JoinHandle<()> {
     let connected = state.connected_lan_peers.clone();
+    let delivery_stats = state.delivery_stats.clone();
     let endpoint_resync = state.endpoint_resync.clone();
     tokio::spawn(async move {
         airc_daemon::route_refresh::run_periodic_refresh(
             &state.shutdown,
             &state.route_wake,
-            || refresh_routes_once(&airc, &connected, &endpoint_resync, &rendezvous),
+            || {
+                refresh_routes_once(
+                    &airc,
+                    &connected,
+                    &delivery_stats,
+                    &endpoint_resync,
+                    &rendezvous,
+                )
+            },
         )
         .await;
     })
@@ -1800,6 +1809,7 @@ fn spawn_route_refresh(
 async fn refresh_routes_once(
     airc: &Airc,
     connected_lan_peers: &std::sync::atomic::AtomicUsize,
+    delivery_stats: &tokio::sync::RwLock<Vec<airc_ipc::IpcPeerDeliveryStats>>,
     endpoint_resync: &tokio::sync::Notify,
     rendezvous: &SharedRendezvousSlot,
 ) {
@@ -1909,6 +1919,29 @@ async fn refresh_routes_once(
                 snapshot.connected_lan_peers.len(),
                 std::sync::atomic::Ordering::Relaxed,
             );
+
+            // #1306 slice 2: publish the delivery-ledger snapshot for
+            // `Request::DeliveryStats` — the delivery-truth read behind
+            // doctor's "last confirmed delivery to X: N ago". Same
+            // single-writer wiring split as the counter above (the
+            // daemon crate can't reach the airc-lib ledger).
+            if let Some(ledger) = airc.delivery_ledger() {
+                let rows = ledger
+                    .snapshot()
+                    .into_iter()
+                    .map(|(peer_id, stats)| airc_ipc::IpcPeerDeliveryStats {
+                        peer_id,
+                        attempts: stats.attempts,
+                        acked: stats.acked,
+                        attempts_since_ack: stats.attempts_since_ack,
+                        last_attempt_ms: stats.last_attempt_ms,
+                        last_ack_ms: stats.last_ack_ms,
+                        rtt_ema_ms: stats.rtt_ema_ms,
+                        suspect: stats.suspect(),
+                    })
+                    .collect::<Vec<_>>();
+                *delivery_stats.write().await = rows;
+            }
 
             // #1247 slice 4b — relay self-election. When this node can
             // reach no peer directly AND has no live relay yet, but knows

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -534,7 +534,7 @@ async fn check_health(home: &Path) -> Vec<Finding> {
         .iter()
         .filter(|sample| sample.state != TransportHealthState::Healthy)
         .count();
-    if degraded == 0 {
+    let mut findings = if degraded == 0 {
         vec![Finding::ok(
             "route health",
             format!("{total} route(s) healthy"),
@@ -545,7 +545,86 @@ async fn check_health(home: &Path) -> Vec<Finding> {
             format!("{degraded} of {total} route(s) degraded"),
             "run `airc transport health` to see the row-level detail",
         )]
+    };
+    findings.extend(check_delivery_truth(home).await);
+    findings
+}
+
+/// #1306 slice 2 — the delivery-truth check. Route health above measures
+/// pipes; THIS reports whether messages actually arrive: per peer, "last
+/// confirmed delivery: N ago" from the daemon's delivery ledger. The
+/// 2026-07-31 failure shape — both doctors 8/8 clean while outbound
+/// silently queued for hours — is exactly what this line makes visible.
+/// Absent daemon or empty ledger (no cross-machine forward yet) reports
+/// as informational, never vacuously ok.
+async fn check_delivery_truth(home: &Path) -> Vec<Finding> {
+    let socket = crate::cli::default_socket_path_in(home);
+    let stats = match airc_ipc::DaemonClient::new(socket).delivery_stats().await {
+        Ok(response) => response.peers,
+        Err(_) => {
+            // No daemon (or an older build without the verb): delivery
+            // truth is unknown, not fine. Quietly informational — the
+            // daemon-liveness check above already reports the daemon.
+            return Vec::new();
+        }
+    };
+    if stats.is_empty() {
+        return vec![Finding::ok(
+            "delivery truth",
+            "no cross-machine deliveries attempted yet (nothing to confirm)",
+        )];
     }
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let age = |stamp_ms: u64| -> String {
+        let secs = now_ms.saturating_sub(stamp_ms) / 1000;
+        if secs < 120 {
+            format!("{secs}s ago")
+        } else if secs < 7200 {
+            format!("{}m ago", secs / 60)
+        } else {
+            format!("{}h ago", secs / 3600)
+        }
+    };
+    let mut findings = Vec::new();
+    for peer in &stats {
+        match (peer.suspect, peer.last_ack_ms) {
+            (true, last) => findings.push(Finding::warn(
+                "delivery truth",
+                format!(
+                    "{}: {} flushed frame(s) UNACKED since last confirmation ({}) — \
+                     connection presumed half-open, route refresh is re-dialing",
+                    peer.peer_id,
+                    peer.attempts_since_ack,
+                    last.map(&age).unwrap_or_else(|| "never confirmed".into()),
+                ),
+                "watch `airc transport health` for the suspect-drop + re-dial",
+            )),
+            (false, Some(last_ack_ms)) => findings.push(Finding::ok(
+                "delivery truth",
+                format!(
+                    "{}: last confirmed delivery {}{} ({} of {} acked)",
+                    peer.peer_id,
+                    age(last_ack_ms),
+                    peer.rtt_ema_ms
+                        .map(|rtt| format!(", rtt ~{rtt}ms"))
+                        .unwrap_or_default(),
+                    peer.acked,
+                    peer.attempts,
+                ),
+            )),
+            (false, None) => findings.push(Finding::ok(
+                "delivery truth",
+                format!(
+                    "{}: {} attempt(s), none confirmed yet (within tolerance)",
+                    peer.peer_id, peer.attempts
+                ),
+            )),
+        }
+    }
+    findings
 }
 
 async fn apply_fixes(

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -23,9 +23,9 @@ use airc_ipc::request::{
     SendRequest,
 };
 use airc_ipc::response::{
-    InboxResponse, IpcIdentityCard, IpcRoomInfo, PeerEntry, PeerIdentityCardResponse,
-    PeersResponse, PublishResponse, Response, RoomTipResponse, RoomsResponse,
-    RouteEndpointsResponse, StatusResponse,
+    DeliveryStatsResponse, InboxResponse, IpcIdentityCard, IpcRoomInfo, PeerEntry,
+    PeerIdentityCardResponse, PeersResponse, PublishResponse, Response, RoomTipResponse,
+    RoomsResponse, RouteEndpointsResponse, StatusResponse,
 };
 use bytes::Bytes;
 
@@ -64,6 +64,12 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
         Request::RemovePeer(remove) => handle_remove_peer(state, remove).await,
         Request::ListPeers => handle_list_peers(state).await,
         Request::ListRooms => handle_list_rooms(state).await,
+        // #1306 slice 2: serve the host-written delivery-ledger snapshot
+        // — the delivery-truth read behind doctor's "last confirmed
+        // delivery to X: N ago".
+        Request::DeliveryStats => Response::DeliveryStats(DeliveryStatsResponse {
+            peers: state.delivery_stats.read().await.clone(),
+        }),
         // Card 4b6a0ffa (#33): serve the endpoints the registry glue
         // recorded after binding its listener. Empty means "up but not
         // dialable" — the client decides what that implies.

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -23,7 +23,7 @@ use tokio::sync::{Mutex, Notify, RwLock};
 
 use airc_bus::{BusError, Clock, EventRouter, RouterConfig, SeqSource, SystemClock};
 use airc_core::PeerId;
-use airc_ipc::IpcRouteEndpoint;
+use airc_ipc::{IpcPeerDeliveryStats, IpcRouteEndpoint};
 use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
 use airc_store::{EventStore, SqliteDurableSink};
 
@@ -75,6 +75,13 @@ pub struct DaemonState {
     /// counter each tick — exactly the wiring split used for
     /// `route_endpoints`. `0` until the first refresh completes.
     pub connected_lan_peers: Arc<AtomicUsize>,
+    /// #1306 slice 2: per-peer delivery-ledger snapshot, served via
+    /// `Request::DeliveryStats`. Same wiring split as
+    /// `connected_lan_peers`: the concrete ledger lives on an
+    /// `airc-lib` handle this crate must not depend on, so the host's
+    /// route-refresh loop writes this snapshot each tick. Empty until
+    /// the first refresh after any cross-machine forward.
+    pub delivery_stats: Arc<RwLock<Vec<IpcPeerDeliveryStats>>>,
     /// Edge-triggered resync nudge for the account-registry loop. The
     /// route-refresh loop detects this node's own LAN/Tailscale IP
     /// changing (router swap, DHCP renew, Tailscale toggle) and, ONLY when
@@ -141,6 +148,7 @@ impl DaemonState {
             runtime,
             route_endpoints: RwLock::new(Vec::new()),
             connected_lan_peers: Arc::new(AtomicUsize::new(0)),
+            delivery_stats: Arc::new(RwLock::new(Vec::new())),
             endpoint_resync: Arc::new(Notify::new()),
             route_wake: Arc::new(Notify::new()),
         })

--- a/crates/airc-daemon/tests/delivery_stats_probe.rs
+++ b/crates/airc-daemon/tests/delivery_stats_probe.rs
@@ -1,0 +1,138 @@
+//! #1306 slice 2 — `delivery_stats` against the LIVE daemon: the
+//! per-peer delivery-ledger snapshot served over IPC.
+//!
+//! This is the delivery-truth read behind doctor's "last confirmed
+//! delivery to X: N ago". The daemon serves whatever the host's
+//! route-refresh loop wrote into `DaemonState::delivery_stats` (the
+//! same single-writer wiring split as `connected_lan_peers` — the
+//! daemon crate cannot reach the airc-lib ledger). These tests pin the
+//! IPC round trip: rows written by the host come back verbatim, and an
+//! empty snapshot (no cross-machine forward yet) is an empty list —
+//! never an error.
+//!
+//! The test model IS the production model: a real `DaemonState` on a
+//! Unix socket, driven by the real `DaemonClient` — the same shape as
+//! `list_rooms_probe.rs`.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::PeerId;
+use airc_daemon::{run, DaemonRuntimeInfo, DaemonState};
+use airc_ipc::{DaemonClient, IpcPeerDeliveryStats};
+use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_store::{EventStore, InMemoryEventStore};
+use tokio::task::JoinHandle;
+
+struct TestDaemon {
+    socket: PathBuf,
+    state: Arc<DaemonState>,
+    handle: JoinHandle<()>,
+    _home: tempfile::TempDir,
+}
+
+fn unique_socket() -> PathBuf {
+    // Short /tmp path keeps us well under macOS SUN_LEN (104 bytes).
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!("/tmp/airc-dsp-{}-{n}.sock", std::process::id()))
+}
+
+async fn start_daemon() -> TestDaemon {
+    let home = tempfile::TempDir::new().expect("tempdir");
+    let db_path = home.path().join("events.sqlite");
+    let peer_id = PeerId::new();
+    let keypair = PeerKeypair::generate();
+    let registry = PeerKeyRegistry::new();
+    registry
+        .enrol(peer_id, 0, keypair.public_bytes())
+        .expect("enrol self");
+    let coordinator: Arc<dyn EventStore> = Arc::new(InMemoryEventStore::new());
+    let state = Arc::new(
+        DaemonState::build(
+            peer_id,
+            keypair,
+            Arc::new(registry),
+            VerificationPolicy::Strict,
+            home.path().to_path_buf(),
+            &db_path,
+            coordinator,
+            DaemonRuntimeInfo::unknown(),
+        )
+        .await
+        .expect("build daemon state"),
+    );
+    let socket = unique_socket();
+    let server_state = state.clone();
+    let server_socket = socket.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run(server_state, server_socket).await;
+    });
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    TestDaemon {
+        socket,
+        state,
+        handle,
+        _home: home,
+    }
+}
+
+/// what this catches (#1306 slice 2): the delivery-truth round trip —
+/// rows the host's refresh loop writes into `DaemonState` come back
+/// verbatim over IPC, healthy and suspect alike. Doctor's "last
+/// confirmed delivery" line renders exactly these fields.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delivery_stats_round_trips_host_written_rows() {
+    let daemon = start_daemon().await;
+    let client = DaemonClient::new(daemon.socket.clone());
+
+    // Before any host write: empty, never an error.
+    let empty = client.delivery_stats().await.expect("empty stats call");
+    assert!(
+        empty.peers.is_empty(),
+        "no snapshot written yet must read as an empty list"
+    );
+
+    // The host's route-refresh loop publishes a snapshot: one confirmed
+    // peer, one suspect (the half-open signature).
+    let confirmed_peer = PeerId::from_u128(0xacc);
+    let suspect_peer = PeerId::from_u128(0xbad);
+    let rows = vec![
+        IpcPeerDeliveryStats {
+            peer_id: confirmed_peer,
+            attempts: 7,
+            acked: 7,
+            attempts_since_ack: 0,
+            last_attempt_ms: Some(1_000_000),
+            last_ack_ms: Some(1_000_040),
+            rtt_ema_ms: Some(40),
+            suspect: false,
+        },
+        IpcPeerDeliveryStats {
+            peer_id: suspect_peer,
+            attempts: 3,
+            acked: 0,
+            attempts_since_ack: 3,
+            last_attempt_ms: Some(2_000_000),
+            last_ack_ms: None,
+            rtt_ema_ms: None,
+            suspect: true,
+        },
+    ];
+    *daemon.state.delivery_stats.write().await = rows.clone();
+
+    let served = client.delivery_stats().await.expect("stats call");
+    assert_eq!(
+        served.peers, rows,
+        "the daemon must serve the host-written snapshot verbatim"
+    );
+
+    daemon.handle.abort();
+}

--- a/crates/airc-ipc/src/client.rs
+++ b/crates/airc-ipc/src/client.rs
@@ -21,8 +21,8 @@ use crate::request::{
     RemovePeerRequest, Request, RoomTipRequest, SendRequest,
 };
 use crate::response::{
-    InboxResponse, PeerIdentityCardResponse, PeersResponse, PublishResponse, Response,
-    RoomTipResponse, RoomsResponse, RouteEndpointsResponse, StatusResponse,
+    DeliveryStatsResponse, InboxResponse, PeerIdentityCardResponse, PeersResponse, PublishResponse,
+    Response, RoomTipResponse, RoomsResponse, RouteEndpointsResponse, StatusResponse,
 };
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
@@ -238,6 +238,16 @@ impl DaemonClient {
     pub async fn route_endpoints(&self) -> Result<RouteEndpointsResponse, ClientError> {
         match self.call(Request::RouteEndpoints).await? {
             Response::RouteEndpoints(response) => Ok(response),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    /// #1306 slice 2: per-peer end-to-end delivery accounting. The
+    /// delivery-truth read — doctor prints "last confirmed delivery to
+    /// X: N ago" from this instead of inferring health from TCP state.
+    pub async fn delivery_stats(&self) -> Result<DeliveryStatsResponse, ClientError> {
+        match self.call(Request::DeliveryStats).await? {
+            Response::DeliveryStats(response) => Ok(response),
             other => Err(ClientError::UnexpectedResponse(other)),
         }
     }

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -47,9 +47,9 @@ pub use request::{
     RoomTipRequest, SendRequest,
 };
 pub use response::{
-    InboxResponse, IpcIdentityCard, IpcRoomInfo, IpcRouteEndpoint, PeerIdentityCardResponse,
-    PeersResponse, PublishResponse, Response, RoomTipResponse, RoomsResponse,
-    RouteEndpointsResponse, StatusResponse,
+    DeliveryStatsResponse, InboxResponse, IpcIdentityCard, IpcPeerDeliveryStats, IpcRoomInfo,
+    IpcRouteEndpoint, PeerIdentityCardResponse, PeersResponse, PublishResponse, Response,
+    RoomTipResponse, RoomsResponse, RouteEndpointsResponse, StatusResponse,
 };
 pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};
 // IpcListener / IpcStream stay under `transport` because only the

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -146,6 +146,14 @@ pub enum Request {
     /// is in — not just the rooms that happened to emit traffic since
     /// boot. Returned via `Response::Rooms`.
     ListRooms,
+    /// **#1306 slice 2.** Per-peer end-to-end delivery accounting from
+    /// the daemon's delivery ledger — attempts, acks, last confirmed
+    /// delivery, measured RTT, suspect verdict. THE delivery-truth read:
+    /// doctor reports "last confirmed delivery to X: N ago" from this
+    /// instead of inferring health from TCP connection state. Returned
+    /// via `Response::DeliveryStats`. Empty until the routed forwarder
+    /// has attempted at least one cross-machine delivery.
+    DeliveryStats,
     /// Attach to the daemon's live event stream. Long-lived: after an
     /// initial `Response::Ok`, the daemon streams `Response::Event`
     /// frames (airc-wire bytes) until the client disconnects. Optionally

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -43,6 +43,9 @@ pub enum Response {
     /// the coordinator store's subscriptions table, never inferred from
     /// transcript traffic.
     Rooms(RoomsResponse),
+    /// **#1306 slice 2.** Response to `DeliveryStats` — per-peer
+    /// delivery-ledger rows from the daemon's routed forwarder.
+    DeliveryStats(DeliveryStatsResponse),
     /// One live event emitted by an `Attach` stream — the airc-wire
     /// encoding of the bus `Envelope`. The client decodes via
     /// `airc_wire::decode`.
@@ -152,6 +155,40 @@ pub struct IpcRoomInfo {
     pub joined_at_ms: u64,
     /// The scope's default channel (`airc msg` with no `--room`).
     pub is_default: bool,
+}
+
+/// **#1306 slice 2.** Per-peer delivery-ledger rows. The wiring split is
+/// the same as `route_endpoints` / `connected_lan_peers`: the concrete
+/// ledger lives on an `airc-lib` handle this crate must not depend on,
+/// so the host's route-refresh loop snapshots it into `DaemonState`
+/// each tick and the daemon serves that snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeliveryStatsResponse {
+    pub peers: Vec<IpcPeerDeliveryStats>,
+}
+
+/// One peer's end-to-end delivery accounting — mirrors
+/// `airc-lib`'s `PeerDeliveryStats` the way `IpcRouteEndpoint` mirrors
+/// `RouteEndpoint`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IpcPeerDeliveryStats {
+    pub peer_id: PeerId,
+    /// Frames flushed to this peer's connection (kernel buffer, not
+    /// enqueue).
+    pub attempts: u64,
+    /// Typed delivery acks received back (any outcome — each proves the
+    /// pipe and the remote daemon end-to-end).
+    pub acked: u64,
+    /// Flushed frames since the last ack — the suspect trigger.
+    pub attempts_since_ack: u32,
+    pub last_attempt_ms: Option<u64>,
+    /// Wall stamp of the last ack — "last confirmed delivery: N ago".
+    pub last_ack_ms: Option<u64>,
+    /// Measured send→ack round trip (EMA).
+    pub rtt_ema_ms: Option<u32>,
+    /// The connection is presumed half-open; route refresh will drop +
+    /// re-dial it.
+    pub suspect: bool,
 }
 
 /// Result of an `Inbox` pull: durable envelopes (airc-wire bytes) + the


### PR DESCRIPTION
Slice 2 on #1307's DeliveryLedger: surface delivery truth to the operator — doctor reports **delivery**, not TCP state.

- `Request::DeliveryStats` → `IpcPeerDeliveryStats` rows + `DaemonClient::delivery_stats()`.
- `DaemonState.delivery_stats` snapshot slot, published by the CLI route-refresh loop each tick (same wiring split as `connected_lan_peers` — the daemon crate can't reach the airc-lib ledger).
- `airc doctor --health` renders per peer: `[ok] delivery truth: <peer>: last confirmed delivery 12s ago, rtt ~40ms (7 of 7 acked)` / `[WARN] delivery truth: <peer>: 3 flushed frame(s) UNACKED since last confirmation (2h ago) — connection presumed half-open, route refresh is re-dialing`. Empty ledger = "no cross-machine deliveries attempted yet", never vacuously ok; no daemon defers to the daemon-liveness check.
- Live-daemon probe test (list_rooms_probe pattern): empty snapshot is an empty list; host-written rows (one confirmed, one suspect) round-trip verbatim over the real socket + DaemonClient.

This is the line whose absence let both doctors read 8/8 clean through hours of silent one-directional loss on 2026-07-31. With #1307's purge + this, that failure class is detected, self-healing, and visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo