### PR TITLE
fix(test): harden room_roster test isolation — pin Operator mesh identity (task #114)

### DIFF
--- a/crates/airc-lib/tests/common/mod.rs
+++ b/crates/airc-lib/tests/common/mod.rs
@@ -204,6 +204,18 @@ impl Machine {
         self.root.path()
     }
 
+    /// Pin this machine's mesh identity (Operator-source, never
+    /// re-resolved) into the shared coordinator store every attached
+    /// scope resolves against. Call BEFORE the first `attach`/`join`
+    /// so no scope ever falls through to the live gh/git resolver.
+    /// See [`pin_identity`] for the shared-state class this kills.
+    pub async fn pin_identity(&self, identity: &str) {
+        let store = SqliteEventStore::open_path(&self.root.path().join("events.sqlite"))
+            .await
+            .expect("open machine coordinator store for identity pin");
+        pin_identity(&store, identity).await;
+    }
+
     /// Attach a new scope ("tab"/agent) to this machine's daemon.
     pub async fn attach(&self, scope: &str) -> Airc {
         let home = self.root.path().join(scope);
@@ -233,6 +245,32 @@ impl Machine {
         bob.join(room).await.expect("bob joins room");
         (alice, bob)
     }
+}
+
+/// Pin a mesh identity into `store` with an `Operator`-source cache
+/// entry — trusted as-is, never expired, never re-resolved — so
+/// identity-sensitive tests are hermetic. Shared-state class this
+/// kills: the default mesh-identity resolver reads LIVE HOST STATE
+/// shared by every parallel test — `gh api user` (network + gh auth,
+/// 3s kill-deadline), `git config user.email`, and on total probe
+/// failure the REAL `~/.airc/machine-id` — so its outcome varies with
+/// suite load and box configuration, and a provisional (non-gh) result
+/// re-probes `gh` on every later resolve. An Operator pin short-circuits
+/// all of it: no shell-outs, no real-home writes, deterministic RoomId
+/// derivation on any box.
+pub async fn pin_identity(store: &dyn EventStore, identity: &str) {
+    airc_lib::mesh_identity::save(
+        store,
+        &airc_lib::CachedIdentity {
+            version: 1,
+            identity: identity.to_string(),
+            source: airc_lib::mesh_identity::Source::Operator,
+            resolved_at_ms: 1,
+            ttl_ms: airc_lib::mesh_identity::DEFAULT_TTL_MS,
+        },
+    )
+    .await
+    .expect("pin mesh identity");
 }
 
 /// Mutually trust two scopes (each enrols the other's pinned key) so

--- a/crates/airc-lib/tests/daemon_lan_visibility.rs
+++ b/crates/airc-lib/tests/daemon_lan_visibility.rs
@@ -49,7 +49,7 @@ use airc_lib::{
 };
 use airc_protocol::{Envelope as ProtoEnvelope, Frame, FrameKind, Signature};
 use airc_store::{EventStore, SqliteEventStore};
-use common::Machine;
+use common::{pin_identity, Machine};
 use tempfile::TempDir;
 
 /// The store every scope on this simulated machine publishes presence
@@ -161,25 +161,6 @@ fn inbound_frame_with_headers(
             .insert((*key).to_string(), (*value).to_string());
     }
     frame
-}
-
-/// Pin a mesh identity into `store` with an `Operator`-source cache
-/// entry — trusted as-is, never re-resolved — so identity-sensitive
-/// tests are hermetic (no gh/git shell-outs, deterministic RoomId
-/// derivation on any CI box).
-async fn pin_identity(store: &dyn EventStore, identity: &str) {
-    airc_lib::mesh_identity::save(
-        store,
-        &airc_lib::CachedIdentity {
-            version: 1,
-            identity: identity.to_string(),
-            source: airc_lib::mesh_identity::Source::Operator,
-            resolved_at_ms: 1,
-            ttl_ms: airc_lib::mesh_identity::DEFAULT_TTL_MS,
-        },
-    )
-    .await
-    .expect("pin mesh identity");
 }
 
 /// THE test (the card): a cross-machine room message arrives over a

--- a/crates/airc-lib/tests/room_roster.rs
+++ b/crates/airc-lib/tests/room_roster.rs
@@ -30,6 +30,12 @@ async fn room_roster_joins_presence_and_agrees_with_canonical_name_resolver() {
     // One agent attached to a daemon + joined to a room (the route its
     // heartbeat frames need to land in the transcript).
     let machine = Machine::boot().await;
+    // Isolation: pin an Operator mesh identity BEFORE any scope
+    // attaches. Kills the shared-state class "live host identity
+    // resolution" — gh/git shell-outs + real ~/.airc fallback shared
+    // by every parallel test (see common::pin_identity). Unique per
+    // test so RoomId derivation never collides across tests either.
+    machine.pin_identity("roster-presence-join-test").await;
     let airc = machine.solo("general").await;
 
     // Presence: a heartbeat with a self-reported availability.
@@ -99,6 +105,10 @@ async fn peer_name_survives_identity_card_scrolling_past_the_recent_window() {
     // `room_roster` still resolve it — it FAILS against any
     // window-bounded scan.
     let machine = Machine::boot().await;
+    // Isolation: Operator-pinned mesh identity before first attach —
+    // kills the live gh/git/~/.airc shared-state class (see
+    // common::pin_identity); unique per test.
+    machine.pin_identity("roster-name-burial-test").await;
     let airc = machine.solo("general").await;
     let me = airc.peer_id();
 
@@ -174,6 +184,12 @@ async fn room_roster_cards_carries_the_full_identity_and_agrees_with_peer_alias(
     // that read the wrong index, dropped a field, or diverged the name
     // from `peer_alias` fails here before it reaches a rendered roster.
     let machine = Machine::boot().await;
+    // Isolation: Operator-pinned mesh identity before first attach —
+    // kills the live gh/git/~/.airc shared-state class (see
+    // common::pin_identity); unique per test.
+    machine
+        .pin_identity("roster-cards-full-identity-test")
+        .await;
     let airc = machine.solo("general").await;
     let me = airc.peer_id();
 


### PR DESCRIPTION
## Summary

The `room_roster` suite (`room_roster_cards_carries_the_full_identity_and_agrees_with_peer_alias` + siblings) was flaky under full-suite parallelism — the named gate on the canary→main promotion. This makes the tests hermetic without weakening a single assertion and without `#[ignore]`.

## Root cause — the shared global state

Every `Machine::boot()` + `join` in these tests fell through to the **live mesh-identity resolver** (`mesh_identity::resolve` → `default_resolver`), which reads host state shared by every parallel test:

- `gh api user --jq .login` — a real network call with a **3s kill-deadline** that blocks the runtime thread inside `join` (`run_command` polls `try_wait` synchronously);
- `git config user.email` fallback;
- on total probe failure, the **real `~/.airc/machine-id`** (a write outside the test sandbox);
- a provisional (non-gh) result **re-probes gh on every later resolve** — identity outcome varies with suite load, gh auth, and network.

**Reproduced:** under a hostile-host shim (hanging `gh`, failing `git` — exactly what a loaded full-suite run degrades to), the pre-fix binary pinned at ~3.3s (the gh deadline inside `join`) and intermittently FAILED `peer_name_survives_identity_card_scrolling_past_the_recent_window` (2 of the first 5 shim runs). Post-fix, the same shim runs green in **0.11s** — zero shell-outs left on the path.

## Fix — the repo's established pattern

`daemon_lan_visibility.rs` already had the answer: `pin_identity` (an `Operator`-source mesh-identity cache entry — trusted as-is, never expired, never re-resolved). This PR:

- **hoists `pin_identity` into `tests/common/mod.rs`** (one copy; the `daemon_lan_visibility` duplicate is deleted — compression, not a second pattern);
- adds **`Machine::pin_identity`** — pins the machine's shared coordinator store **before any scope attaches**;
- each `room_roster` test pins a **unique** Operator identity, so RoomId derivation never touches host state and never collides across tests. Each pin carries a comment naming the shared-state class it kills.

## Proof runs

- `cargo test -p airc-lib` ×2 at default parallelism: **both fully green** (336-test lib + all integration binaries, 0 failures).
- `cargo test --workspace --all-features` ×1: **exit 0**, 121 green test-result blocks, 0 failures.
- Hostile-host shim (hanging gh + broken git): pre-fix **2/5 failed @ ~3.3s**; post-fix **0 failures @ 0.11s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo