### PR TITLE
feat(attach): backlog_tail — one page back at the catch-up seam (card 7d5b6a65 extension)

### DIFF
--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -13,6 +13,7 @@
 //! the loop runs the transport's `cleanup` (unlinks the socket file
 //! on Unix; no-op on Windows) and returns.
 
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -22,7 +23,7 @@ use fs2::FileExt;
 use futures::StreamExt;
 use tokio::io::AsyncWriteExt;
 
-use airc_bus::envelope::{Cursor, DeliveryClass, Kind};
+use airc_bus::envelope::{Cursor, DeliveryClass, Envelope, Kind};
 use airc_bus::{Filter, Seq};
 use airc_diagnostics::{
     DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
@@ -545,7 +546,14 @@ where
             Some(c) => Some(c),
             None => state.router.sink_head_cursor(channel).await,
         };
-        Some(BacklogCatchup::new(edge))
+        // "One page back" (Discord analogy): `backlog_tail` asks for
+        // the N most-recent backlog events at the seam; everything
+        // older stays coalesced into the summary. 0/None = today's
+        // all-or-nothing coalesce.
+        Some(BacklogCatchup::new(
+            edge,
+            parts.backlog_tail.unwrap_or(0) as usize,
+        ))
     } else {
         None
     };
@@ -579,23 +587,50 @@ where
                     Some(env) => {
                         from = Some(env.cursor());
                         let suppressed = match catchup.as_mut() {
-                            Some(c) => c.observe(env.cursor()),
+                            Some(c) => c.observe(&env),
                             None => false,
                         };
                         if suppressed {
-                            // Inside catch-up window — count and skip,
-                            // a single AttachCursorAdvanced will flush
-                            // when we cross the live edge.
+                            // Inside catch-up window — count and skip
+                            // (buffering the tail_cap most recent),
+                            // the seam flush happens when we cross the
+                            // live edge.
                         } else {
-                            // Flush a pending summary BEFORE the first
-                            // live event so the client sees the seam.
-                            if let Some(summary) =
+                            // Flush the pending seam BEFORE the first
+                            // live event so the client sees the
+                            // catch-up boundary. Order: (a) buffered
+                            // tail envelopes as normal Event frames,
+                            // oldest first, (b) the summary carrying
+                            // the watermark, (c) the live event below.
+                            //
+                            // INVARIANT (continuum #261 discipline):
+                            // the summary's `advanced_to` is the LAST
+                            // suppressed cursor, which is ≥ every tail
+                            // cursor, and the tail is written BEFORE
+                            // the summary — so a consumer that
+                            // persists the watermark from the summary
+                            // never persists past an event it was not
+                            // delivered.
+                            //
+                            // Known limitation (same as the summary
+                            // since day one, not fixed here): the seam
+                            // only flushes when the first LIVE event
+                            // arrives — on an idle room the tail and
+                            // summary wait for live traffic.
+                            if let Some(seam) =
                                 catchup.as_mut().and_then(BacklogCatchup::take_summary)
                             {
-                                if summary.skipped > 0 {
-                                    write_response(&mut writer, &summary.into_response())
-                                        .await?;
+                                for buffered in &seam.tail {
+                                    write_response(
+                                        &mut writer,
+                                        &Response::Event {
+                                            envelope: airc_wire::encode(buffered).to_vec(),
+                                        },
+                                    )
+                                    .await?;
                                 }
+                                write_response(&mut writer, &seam.summary.into_response())
+                                    .await?;
                             }
                             write_response(
                                 &mut writer,
@@ -657,22 +692,33 @@ struct BacklogCatchup {
     /// Set once when we cross the live edge so subsequent events skip
     /// the per-cursor comparison and stream as live.
     crossed: bool,
+    /// "One page back" (card 7d5b6a65 extension): how many of the
+    /// most-recent suppressed envelopes to deliver as real Event
+    /// frames at the seam. 0 = classic all-or-nothing coalesce.
+    tail_cap: usize,
+    /// The `tail_cap` most-recent suppressed envelopes, oldest first.
+    /// `skipped` keeps counting ALL suppressed envelopes; the summary
+    /// subtracts what the tail actually delivers.
+    tail: VecDeque<Arc<Envelope>>,
 }
 
 impl BacklogCatchup {
-    fn new(live_edge: Option<Cursor>) -> Self {
+    fn new(live_edge: Option<Cursor>, tail_cap: usize) -> Self {
         Self {
             live_edge,
             skipped: 0,
             last_skipped_cursor: None,
             crossed: live_edge.is_some(),
+            tail_cap,
+            tail: VecDeque::new(),
         }
     }
 
-    /// Observe one envelope's cursor. Returns `true` when the envelope
-    /// is inside the catch-up window (caller should suppress it) and
+    /// Observe one envelope. Returns `true` when the envelope is
+    /// inside the catch-up window (caller should suppress it; the
+    /// `tail_cap` most recent are buffered for the seam flush) and
     /// `false` once we've crossed the live edge.
-    fn observe(&mut self, cursor: Cursor) -> bool {
+    fn observe(&mut self, env: &Arc<Envelope>) -> bool {
         if !self.crossed {
             // No live_edge means the channel was empty at subscribe,
             // so EVERYTHING that arrives is by definition live (no
@@ -680,35 +726,63 @@ impl BacklogCatchup {
             return false;
         }
         if let Some(edge) = self.live_edge {
+            let cursor = env.cursor();
             if cursor.is_after(&edge) {
                 self.crossed = false; // we've moved past catchup
                 return false;
             }
             self.skipped = self.skipped.saturating_add(1);
             self.last_skipped_cursor = Some(cursor);
+            if self.tail_cap > 0 {
+                if self.tail.len() == self.tail_cap {
+                    self.tail.pop_front();
+                }
+                self.tail.push_back(Arc::clone(env));
+            }
             return true;
         }
         false
     }
 
-    /// Pull the catch-up summary once we've crossed the live edge.
-    /// Returns `None` if there's nothing pending (already taken or
-    /// catch-up never had backlog).
-    fn take_summary(&mut self) -> Option<BacklogSummary> {
+    /// Pull the seam flush once we've crossed the live edge: the
+    /// buffered tail plus the coalesce summary. Returns `None` if
+    /// there's nothing pending (already taken or catch-up never had
+    /// backlog). The gate is TOTAL suppressed (> 0), not the
+    /// post-tail remainder: when the whole backlog fit in the tail
+    /// the summary's `skipped` is 0 but the client still needs the
+    /// watermark frame to persist its cursor.
+    fn take_summary(&mut self) -> Option<BacklogSeam> {
         if self.crossed {
             return None;
         }
         // crossed=false at this point means either (a) we observed
-        // something past the edge — pull the summary OR (b) we never
+        // something past the edge — pull the seam OR (b) we never
         // had a live_edge to begin with. Mark crossed so we don't
         // re-emit.
-        let skipped = self.skipped;
+        let delivered = self.tail.len() as u64;
+        let total_suppressed = self.skipped;
         let advanced_to = self.last_skipped_cursor;
+        let tail = std::mem::take(&mut self.tail);
         self.skipped = 0;
         self.last_skipped_cursor = None;
         self.crossed = true;
-        advanced_to.map(|cursor| BacklogSummary { skipped, cursor })
+        advanced_to.map(|cursor| BacklogSeam {
+            tail,
+            summary: BacklogSummary {
+                // Only events NOT delivered in the tail count as
+                // skipped in the summary the client renders.
+                skipped: total_suppressed.saturating_sub(delivered),
+                cursor,
+            },
+        })
     }
+}
+
+/// Everything the daemon writes at the catch-up→live seam: the "one
+/// page back" tail (possibly empty) followed by the summary watermark.
+struct BacklogSeam {
+    tail: VecDeque<Arc<Envelope>>,
+    summary: BacklogSummary,
 }
 
 struct BacklogSummary {

--- a/crates/airc-daemon/tests/attach_backlog_coalesce.rs
+++ b/crates/airc-daemon/tests/attach_backlog_coalesce.rs
@@ -117,6 +117,35 @@ async fn publish_n(daemon: &TestDaemon, channel: RoomId, n: usize) {
     }
 }
 
+/// Read the next frame off an attach stream with a timeout, panicking
+/// with `context` on timeout/eof so failures name the phase they died in.
+async fn next_frame(stream: &mut (impl tokio::io::AsyncRead + Unpin), context: &str) -> Response {
+    tokio::time::timeout(Duration::from_secs(3), read_frame::<_, Response>(stream))
+        .await
+        .unwrap_or_else(|_| panic!("timeout waiting for frame: {context}"))
+        .expect("frame")
+        .unwrap_or_else(|| panic!("stream closed waiting for frame: {context}"))
+}
+
+/// Publish one live event so the daemon's catch-up seam flushes.
+async fn publish_live(daemon: &TestDaemon, channel: RoomId, payload: &[u8]) {
+    DaemonClient::new(daemon.socket.clone())
+        .publish(PublishRequest {
+            channel: channel.as_uuid(),
+            from_peer: daemon.peer_id.as_uuid(),
+            from_client: uuid::Uuid::new_v4(),
+            target: IpcTarget::All,
+            kind: IpcKind::Message,
+            delivery: IpcDelivery::Durable,
+            correlation_id: None,
+            coalesce_key: None,
+            payload: payload.to_vec(),
+            headers: Headers::new(),
+        })
+        .await
+        .expect("publish live");
+}
+
 /// Card 7d5b6a65 acceptance: `from_now: true` sends NO historical
 /// envelopes, only events published strictly after the attach call
 /// returns.
@@ -346,5 +375,203 @@ async fn attach_legacy_shape_still_replays_event_by_event() {
         advances_seen >= 1,
         "cursor heartbeat: at least one advance rides a legacy replay"
     );
+    daemon.stop().await;
+}
+
+/// Card 7d5b6a65 extension ("one page back"): with `backlog_tail: 2`
+/// over 5 backlog events, the seam delivers the LAST 2 as real Event
+/// frames, then ONE summary accounting for the 3 older events with the
+/// watermark at the last backlog cursor, then the live event.
+// what this catches: the seam flush order and the skipped arithmetic —
+// a tail written AFTER the summary (or a summary counting delivered
+// tail events as skipped) would let a watermark-persisting consumer
+// skip events it never received, or double-count history.
+#[tokio::test]
+async fn backlog_tail_delivers_last_n_then_summary_then_live() {
+    let daemon = start_daemon().await;
+    let channel = RoomId::new();
+    const BACKLOG_N: usize = 5;
+    const TAIL: u32 = 2;
+    publish_n(&daemon, channel, BACKLOG_N).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = DaemonClient::new(daemon.socket.clone());
+    let mut stream = client
+        .attach(
+            AttachRequest::new(channel, AttachStart::FromTranscriptStart)
+                .with_coalesced_backlog()
+                .with_backlog_tail(TAIL),
+        )
+        .await
+        .expect("attach");
+    match read_frame::<_, Response>(&mut stream).await {
+        Ok(Some(Response::Ok)) => {}
+        other => panic!("expected Ok ack from attach, got {other:?}"),
+    }
+    publish_live(&daemon, channel, b"after seam").await;
+
+    // Frames 1..=TAIL: the last TAIL backlog events, oldest first
+    // (indices 3 and 4 of the 0-indexed publish loop).
+    let mut last_tail_cursor = None;
+    for i in (BACKLOG_N - TAIL as usize)..BACKLOG_N {
+        match next_frame(&mut stream, &format!("tail event {i}")).await {
+            Response::Event { envelope } => {
+                let env = airc_wire::decode(envelope.into()).expect("decode tail");
+                assert_eq!(
+                    env.payload.to_vec(),
+                    format!("backlog event {i}").into_bytes(),
+                    "tail must be the MOST RECENT backlog events, in order"
+                );
+                last_tail_cursor = Some(env.cursor());
+            }
+            other => panic!("expected tail Event frame for backlog event {i}, got {other:?}"),
+        }
+    }
+
+    // Next frame: the summary. skipped counts ONLY the coalesced
+    // (undelivered) events; advanced_to is the last backlog cursor,
+    // which equals the last tail event's cursor (≥ every tail cursor —
+    // the no-skip watermark invariant).
+    match next_frame(&mut stream, "seam summary").await {
+        Response::AttachCursorAdvanced {
+            skipped,
+            advanced_to,
+        } => {
+            assert_eq!(
+                skipped,
+                (BACKLOG_N - TAIL as usize) as u64,
+                "summary must count only events NOT delivered in the tail"
+            );
+            let last = last_tail_cursor.expect("saw tail events");
+            assert_eq!(advanced_to.epoch, last.seq.epoch);
+            assert_eq!(advanced_to.counter, last.seq.counter);
+            assert_eq!(advanced_to.event_id, last.event_id);
+        }
+        other => panic!("expected AttachCursorAdvanced after the tail, got {other:?}"),
+    }
+
+    // Final frame: the live event that triggered the seam.
+    match next_frame(&mut stream, "live event").await {
+        Response::Event { envelope } => {
+            let env = airc_wire::decode(envelope.into()).expect("decode live");
+            assert_eq!(env.payload.to_vec(), b"after seam".to_vec());
+        }
+        other => panic!("expected live Event frame after summary, got {other:?}"),
+    }
+    daemon.stop().await;
+}
+
+/// Card 7d5b6a65 extension regression: `backlog_tail: 0` behaves
+/// exactly like plain `coalesce_backlog` — one summary counting the
+/// whole backlog, then the live event, no tail frames.
+// what this catches: the tail plumbing changing behavior for callers
+// that did not opt in — 0 (and None, covered by
+// attach_coalesce_backlog_emits_one_summary_then_live above) must stay
+// byte-identical to the pre-extension coalesce.
+#[tokio::test]
+async fn backlog_tail_zero_matches_plain_coalesce() {
+    let daemon = start_daemon().await;
+    let channel = RoomId::new();
+    const BACKLOG_N: usize = 5;
+    publish_n(&daemon, channel, BACKLOG_N).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = DaemonClient::new(daemon.socket.clone());
+    let mut stream = client
+        .attach(
+            AttachRequest::new(channel, AttachStart::FromTranscriptStart)
+                .with_coalesced_backlog()
+                .with_backlog_tail(0),
+        )
+        .await
+        .expect("attach");
+    match read_frame::<_, Response>(&mut stream).await {
+        Ok(Some(Response::Ok)) => {}
+        other => panic!("expected Ok ack from attach, got {other:?}"),
+    }
+    publish_live(&daemon, channel, b"after seam").await;
+
+    match next_frame(&mut stream, "coalesce summary").await {
+        Response::AttachCursorAdvanced { skipped, .. } => {
+            assert_eq!(
+                skipped, BACKLOG_N as u64,
+                "tail_cap=0 summary must account for EVERY backlog envelope"
+            );
+        }
+        other => panic!("expected AttachCursorAdvanced first (no tail frames), got {other:?}"),
+    }
+    match next_frame(&mut stream, "live event").await {
+        Response::Event { envelope } => {
+            let env = airc_wire::decode(envelope.into()).expect("decode live");
+            assert_eq!(env.payload.to_vec(), b"after seam".to_vec());
+        }
+        other => panic!("expected live Event after summary, got {other:?}"),
+    }
+    daemon.stop().await;
+}
+
+/// Card 7d5b6a65 extension: when the whole backlog fits inside the
+/// tail (2 events, tail_cap 5), BOTH are delivered as Event frames and
+/// the summary still arrives with skipped=0 carrying the watermark.
+// what this catches: dropping the summary when the post-tail remainder
+// is 0 — the client needs the watermark frame to persist its cursor
+// even when nothing was actually coalesced away.
+#[tokio::test]
+async fn backlog_smaller_than_tail_delivers_all_plus_watermark() {
+    let daemon = start_daemon().await;
+    let channel = RoomId::new();
+    const BACKLOG_N: usize = 2;
+    publish_n(&daemon, channel, BACKLOG_N).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = DaemonClient::new(daemon.socket.clone());
+    let mut stream = client
+        .attach(
+            AttachRequest::new(channel, AttachStart::FromTranscriptStart)
+                .with_coalesced_backlog()
+                .with_backlog_tail(5),
+        )
+        .await
+        .expect("attach");
+    match read_frame::<_, Response>(&mut stream).await {
+        Ok(Some(Response::Ok)) => {}
+        other => panic!("expected Ok ack from attach, got {other:?}"),
+    }
+    publish_live(&daemon, channel, b"after seam").await;
+
+    let mut last_tail_cursor = None;
+    for i in 0..BACKLOG_N {
+        match next_frame(&mut stream, &format!("tail event {i}")).await {
+            Response::Event { envelope } => {
+                let env = airc_wire::decode(envelope.into()).expect("decode tail");
+                assert_eq!(
+                    env.payload.to_vec(),
+                    format!("backlog event {i}").into_bytes()
+                );
+                last_tail_cursor = Some(env.cursor());
+            }
+            other => panic!("expected tail Event frame {i}, got {other:?}"),
+        }
+    }
+    match next_frame(&mut stream, "watermark summary").await {
+        Response::AttachCursorAdvanced {
+            skipped,
+            advanced_to,
+        } => {
+            assert_eq!(skipped, 0, "everything was delivered — nothing skipped");
+            let last = last_tail_cursor.expect("saw tail events");
+            assert_eq!(advanced_to.epoch, last.seq.epoch);
+            assert_eq!(advanced_to.counter, last.seq.counter);
+            assert_eq!(advanced_to.event_id, last.event_id);
+        }
+        other => panic!("expected skipped=0 watermark summary, got {other:?}"),
+    }
+    match next_frame(&mut stream, "live event").await {
+        Response::Event { envelope } => {
+            let env = airc_wire::decode(envelope.into()).expect("decode live");
+            assert_eq!(env.payload.to_vec(), b"after seam".to_vec());
+        }
+        other => panic!("expected live Event after watermark, got {other:?}"),
+    }
     daemon.stop().await;
 }

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -257,6 +257,17 @@ pub struct AttachRequest {
     /// (`Live`, or a cursor already at head).
     #[serde(default, skip_serializing_if = "is_false")]
     coalesce_backlog: bool,
+    /// Pairs with [`Self::with_coalesced_backlog`] (card 7d5b6a65
+    /// extension): the N most-recent backlog events are streamed as
+    /// normal `Event` frames at the catch-up seam, and only the OLDER
+    /// history is collapsed into the summary frame — the Discord "one
+    /// page back" shape instead of all-or-nothing. `coalesce_backlog`
+    /// remains the gate: without it this field is a no-op (legacy
+    /// replay already delivers everything). Wire-compat: omitted when
+    /// unset, so old daemons ignore the unknown field and old clients
+    /// simply never send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    backlog_tail: Option<u32>,
     /// If set, only these kinds are delivered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     kinds: Option<Vec<IpcKind>>,
@@ -286,6 +297,7 @@ impl AttachRequest {
             from,
             from_now,
             coalesce_backlog: false,
+            backlog_tail: None,
             kinds: None,
             delivery: None,
             headers: HeaderFilter::default(),
@@ -321,6 +333,12 @@ impl AttachRequest {
         self.coalesce_backlog
     }
 
+    /// How many most-recent backlog events are streamed at the seam
+    /// (the rest are coalesced). `None` = coalesce everything.
+    pub fn backlog_tail(&self) -> Option<u32> {
+        self.backlog_tail
+    }
+
     /// Deliver only these event kinds.
     pub fn with_kinds(mut self, kinds: Vec<IpcKind>) -> Self {
         self.kinds = Some(kinds);
@@ -345,6 +363,15 @@ impl AttachRequest {
         self
     }
 
+    /// Pairs with [`Self::with_coalesced_backlog`]: stream the `n`
+    /// most-recent backlog events at the catch-up seam and summarize
+    /// only the older history ("one page back"). A no-op unless
+    /// coalescing is enabled.
+    pub fn with_backlog_tail(mut self, n: u32) -> Self {
+        self.backlog_tail = Some(n);
+        self
+    }
+
     /// Destructure for the daemon's attach handler: moves the filter
     /// vectors out (no clone) with the start already decoded. One-way —
     /// there is no path from parts back to a request, so the typed
@@ -355,6 +382,7 @@ impl AttachRequest {
             channel: self.channel,
             start,
             coalesce_backlog: self.coalesce_backlog,
+            backlog_tail: self.backlog_tail,
             kinds: self.kinds,
             delivery: self.delivery,
             headers: self.headers,
@@ -368,6 +396,7 @@ pub struct AttachParts {
     pub channel: Option<airc_core::RoomId>,
     pub start: AttachStart,
     pub coalesce_backlog: bool,
+    pub backlog_tail: Option<u32>,
     pub kinds: Option<Vec<IpcKind>>,
     pub delivery: Option<Vec<IpcDelivery>>,
     pub headers: HeaderFilter,
@@ -560,10 +589,36 @@ mod tests {
         )
         .with_kinds(vec![IpcKind::Command])
         .with_coalesced_backlog()
+        .with_backlog_tail(2)
         .into_parts();
         assert_eq!(parts.start, AttachStart::After(cursor(9)));
         assert!(parts.coalesce_backlog);
+        assert_eq!(parts.backlog_tail, Some(2));
         assert_eq!(parts.kinds.as_deref(), Some(&[IpcKind::Command][..]));
+    }
+
+    /// Card 7d5b6a65 extension wire-compat: `backlog_tail` never rides
+    /// the wire when unset (old daemons see the exact pre-extension
+    /// bytes — pinned above), and roundtrips intact when set.
+    // what this catches: a serde attribute regression that would leak
+    // `backlog_tail: null` into every attach and break old daemons'
+    // strict decoders, or drop the value on the daemon side.
+    #[test]
+    fn backlog_tail_is_omitted_when_unset_and_roundtrips_when_set() {
+        let channel = airc_core::RoomId(Uuid::nil());
+        let unset = serde_json::to_string(&AttachRequest::new(channel, AttachStart::Live)).unwrap();
+        assert!(
+            !unset.contains("backlog_tail"),
+            "unset backlog_tail must be absent from the wire: {unset}"
+        );
+
+        let set = AttachRequest::new(channel, AttachStart::FromTranscriptStart)
+            .with_coalesced_backlog()
+            .with_backlog_tail(25);
+        let decoded: AttachRequest =
+            serde_json::from_str(&serde_json::to_string(&set).unwrap()).unwrap();
+        assert_eq!(decoded.backlog_tail(), Some(25));
+        assert!(decoded.coalesces_backlog());
     }
 
     #[test]


### PR DESCRIPTION
Joel's Discord analogy: "When you join a channel do you read 10 years of history? No — one page back." Today `coalesce_backlog` is all-or-nothing (zero pages back). This adds the `backlog_tail` knob: deliver the LAST N backlog events at the catch-up seam, coalescing everything older into the summary frame.

## Changes

**`crates/airc-ipc/src/request.rs`**
- `AttachRequest.backlog_tail: Option<u32>` — `#[serde(default, skip_serializing_if = "Option::is_none")]`, so it's wire-compat both ways: old daemons ignore the unknown field, old clients never send it (pinned wire-bytes tests unchanged).
- Builder `with_backlog_tail(n)` + getter `backlog_tail()`; threaded through `into_parts()` / `AttachParts`.
- `coalesce_backlog` remains the gate — `backlog_tail` without it is a documented no-op.

**`crates/airc-daemon/src/server.rs`**
- `BacklogCatchup::new(edge, tail_cap)` buffers the `tail_cap` most-recent suppressed envelopes (`VecDeque<Arc<Envelope>>`, front-popped beyond cap). `skipped` keeps counting ALL suppressed as today.
- Seam flush order (before the first live event): **(a)** tail envelopes as normal `Event` frames oldest-first, **(b)** the `AttachCursorAdvanced` summary with `skipped = total_suppressed − tail.len()` (only events NOT delivered), **(c)** the live event.
- **Invariant (continuum #261 discipline):** the summary's `advanced_to` is the last suppressed cursor, ≥ every tail cursor, and the tail is written BEFORE the summary — a consumer persisting the watermark never persists past an undelivered event.
- **Guard choice:** the seam gates on TOTAL suppressed (>0), not the post-subtraction remainder — when the whole backlog fits in the tail, the summary still ships with `skipped=0` so the client gets its watermark. (`take_summary` already keyed off `last_skipped_cursor` being set ⇔ total>0; the handler's redundant `skipped > 0` check folds into that.)
- Known limitation documented, not fixed: the seam only flushes when the first LIVE event arrives — an idle room's tail+summary wait for live traffic, same as the existing summary today.

## Tests

Extended the existing card-7d5b6a65 proof file `tests/attach_backlog_coalesce.rs` (no new mod), each with `// what this catches:`:
- `backlog_tail_delivers_last_n_then_summary_then_live` — tail=2 over 5 backlog + 1 live → `[event3, event4, summary(skipped=3, advanced_to=event4.cursor), live]`.
- `backlog_tail_zero_matches_plain_coalesce` — tail=0 regression: byte-identical to today's coalesce.
- `backlog_smaller_than_tail_delivers_all_plus_watermark` — 2 backlog < tail 5 → both delivered, `skipped=0` watermark still ships.

Plus wire-compat/roundtrip coverage in the existing `request.rs` test mod. `cargo test -p airc-daemon -p airc-ipc` green, `cargo check` clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo