### PR TITLE
feat(inbox): kinds filter before limit — newest-N-of-kind paging (continuum #297: stream chunks deafened working personas)

### DIFF
--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -38,7 +38,7 @@ use tokio::sync::mpsc;
 use airc_core::{PeerId, RoomId};
 
 use crate::clock::Clock;
-use crate::envelope::{Cursor, Envelope};
+use crate::envelope::{Cursor, Envelope, Kind};
 use crate::ephemeral::EphemeralCache;
 use crate::filter::Filter;
 use crate::ring::HotRing;
@@ -729,9 +729,47 @@ impl EventRouter {
         channel: RoomId,
         limit: usize,
     ) -> crate::Result<Vec<Arc<Envelope>>> {
+        self.durable_tail_filtered(channel, None, limit).await
+    }
+
+    /// **Continuum #297.** [`Self::durable_tail`] restricted to
+    /// envelopes whose [`Kind`] is in `kinds` — "the newest N durable
+    /// events OF THESE KINDS", with the kind predicate applied on both
+    /// legs (ring scan + [`DurableSink::page_tail_of_kinds`]) BEFORE the
+    /// limit. The inbox path that keeps a chunk-flooded room's page
+    /// from evicting every `Message`: newest-N-raw-then-filter yields
+    /// crumbs; this yields the newest N matching.
+    ///
+    /// `kinds` must be non-empty — filtering to nothing is never what a
+    /// caller means, and the IPC boundary normalizes empty to the
+    /// unfiltered [`Self::durable_tail`]. An empty slice here returns
+    /// an empty page (the vacuous filter, honestly answered).
+    pub async fn durable_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        kinds: &[Kind],
+        limit: usize,
+    ) -> crate::Result<Vec<Arc<Envelope>>> {
+        self.durable_tail_filtered(channel, Some(kinds), limit)
+            .await
+    }
+
+    /// The one merge implementation behind [`Self::durable_tail`] /
+    /// [`Self::durable_tail_of_kinds`] — `kinds: None` means no kind
+    /// predicate. See `durable_tail` for the merge contract; the kind
+    /// filter composes with it unchanged (ring durables of a kind are
+    /// exactly the channel's newest durables of that kind, everything
+    /// older is in the sink).
+    async fn durable_tail_filtered(
+        &self,
+        channel: RoomId,
+        kinds: Option<&[Kind]>,
+        limit: usize,
+    ) -> crate::Result<Vec<Arc<Envelope>>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
+        let matches_kind = |env: &Envelope| kinds.is_none_or(|kinds| kinds.contains(&env.kind));
         let (mut tail, ring_oldest) = {
             let shard = self.shard_for(channel);
             let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
@@ -741,7 +779,7 @@ impl EventRouter {
                         .ring
                         .replay_after(None)
                         .into_iter()
-                        .filter(|env| env.delivery.is_durable())
+                        .filter(|env| env.delivery.is_durable() && matches_kind(env))
                         .collect::<Vec<_>>(),
                     state.ring.oldest_cursor(),
                 ),
@@ -756,11 +794,21 @@ impl EventRouter {
         // than anything the ring still retains. Sink rows strictly
         // before `ring_oldest` cannot also be in the ring, so the two
         // legs concatenate with no dup and no gap.
-        let older = self
-            .inner
-            .sink
-            .page_tail(channel, ring_oldest, limit - tail.len())
-            .await?;
+        let remainder = limit - tail.len();
+        let older = match kinds {
+            None => {
+                self.inner
+                    .sink
+                    .page_tail(channel, ring_oldest, remainder)
+                    .await?
+            }
+            Some(kinds) => {
+                self.inner
+                    .sink
+                    .page_tail_of_kinds(channel, ring_oldest, kinds, remainder)
+                    .await?
+            }
+        };
         let mut out: Vec<Arc<Envelope>> = older.into_iter().map(Arc::new).collect();
         out.append(&mut tail);
         Ok(out)

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 
 use airc_core::RoomId;
 
-use crate::envelope::{Cursor, Envelope};
+use crate::envelope::{Cursor, Envelope, Kind};
 use crate::error::Result;
 
 /// The durable event tier. `append` persists one `Durable` envelope; `page`
@@ -97,6 +97,31 @@ pub trait DurableSink: Send + Sync {
         &self,
         channel: RoomId,
         before: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>>;
+
+    /// **Continuum #297.** [`DurableSink::page_tail`] restricted to
+    /// envelopes whose [`crate::envelope::Kind`] is in `kinds` — the
+    /// sink leg of "newest N events OF THESE KINDS". The kind predicate
+    /// is applied by the STORE, before `limit`, so a chunk-flooded room
+    /// still answers with the newest N matching events; a client-side
+    /// newest-N-raw-then-filter yields crumbs (three personas streaming
+    /// ~4 chunks/sec evict every `Message` from a 50-event page).
+    ///
+    /// Same order/bound contract as `page_tail`: ascending total order,
+    /// work bounded by the matching rows (SQLite: the composite
+    /// `(room_id, epoch, counter, event_id)` index scanned DESC with the
+    /// kind predicate; in-memory: a reverse filtered scan). There is
+    /// deliberately NO default impl (same posture as `page_tail`, card
+    /// 8428ae8c): a sink that cannot kind-filter its reverse page is a
+    /// compile error, never a silent fetch-everything-then-filter.
+    /// `kinds` is never empty — callers normalize empty to the
+    /// unfiltered [`DurableSink::page_tail`].
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[Kind],
         limit: usize,
     ) -> Result<Vec<Envelope>>;
 
@@ -239,6 +264,34 @@ impl DurableSink for InMemoryDurableSink {
         };
         let start = end.saturating_sub(limit);
         Ok(bucket[start..end].to_vec())
+    }
+
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[Kind],
+        limit: usize,
+    ) -> Result<Vec<Envelope>> {
+        let guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(bucket) = guard.events.get(&channel.0.as_u128()) else {
+            return Ok(Vec::new());
+        };
+        let end = match &before {
+            None => bucket.len(),
+            Some(b) => bucket.partition_point(|e| e.cursor().is_before(b)),
+        };
+        // Newest-first over the pre-cursor slice, kind predicate BEFORE
+        // `take(limit)` — then back to ascending for the caller.
+        let mut out: Vec<Envelope> = bucket[..end]
+            .iter()
+            .rev()
+            .filter(|e| kinds.contains(&e.kind))
+            .take(limit)
+            .cloned()
+            .collect();
+        out.reverse();
+        Ok(out)
     }
 
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool> {

--- a/crates/airc-bus/tests/common/mod.rs
+++ b/crates/airc-bus/tests/common/mod.rs
@@ -150,6 +150,18 @@ impl DurableSink for GatedSink {
         self.inner.page_tail(channel, before, limit).await
     }
 
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[airc_bus::envelope::Kind],
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner
+            .page_tail_of_kinds(channel, before, kinds, limit)
+            .await
+    }
+
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
         self.inner.contains(event_id).await
     }

--- a/crates/airc-bus/tests/durable_tail.rs
+++ b/crates/airc-bus/tests/durable_tail.rs
@@ -97,6 +97,22 @@ impl DurableSink for CountingSink {
         self.inner.page_tail(channel, before, limit).await
     }
 
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[Kind],
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        // Counted into the same reverse-page ledger: the zero-scan
+        // structural proof covers the kinds-filtered leg too.
+        self.page_tail_calls.fetch_add(1, Ordering::SeqCst);
+        self.max_page_tail_limit.fetch_max(limit, Ordering::SeqCst);
+        self.inner
+            .page_tail_of_kinds(channel, before, kinds, limit)
+            .await
+    }
+
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
         self.inner.contains(event_id).await
     }
@@ -135,6 +151,16 @@ impl DurableSink for FailingTailSink {
         Err(BusError::Sink("reverse index unavailable".to_string()))
     }
 
+    async fn page_tail_of_kinds(
+        &self,
+        _channel: RoomId,
+        _before: Option<Cursor>,
+        _kinds: &[Kind],
+        _limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        Err(BusError::Sink("reverse index unavailable".to_string()))
+    }
+
     async fn contains(&self, _event_id: airc_core::EventId) -> Result<bool, BusError> {
         Ok(false)
     }
@@ -161,10 +187,14 @@ fn counted_router(ring_capacity: usize) -> (EventRouter, Arc<CountingSink>) {
 }
 
 fn event(channel: RoomId, marker: u128, delivery: DeliveryClass) -> Envelope {
+    kinded_event(channel, marker, Kind::Message, delivery)
+}
+
+fn kinded_event(channel: RoomId, marker: u128, kind: Kind, delivery: DeliveryClass) -> Envelope {
     Envelope::new(
         channel,
         (PeerId::from_u128(1), ClientId::from_u128(1)),
-        Kind::Message,
+        kind,
         delivery,
         Bytes::from_static(b"tail-page"),
     )
@@ -319,6 +349,97 @@ async fn non_durable_traffic_is_excluded_from_the_tail() {
         "stream chunks do not ride the durable tail"
     );
     assert_eq!(sink.page_calls(), 0);
+}
+
+/// Continuum #297 — the flood case across the sink→ring seam: three
+/// durable `Message`s buried under 200 newer durable `StreamChunk`s
+/// (ring capacity 64, so the messages genuinely live only in the sink).
+/// `durable_tail_of_kinds` must return exactly the messages — the kind
+/// predicate runs BEFORE the limit on both legs — with the same bounded
+/// store work as the unfiltered tail (zero forward scans, at most one
+/// reverse page, requested limit ≤ N).
+// what this catches: the kinds-filtered tail regressing to
+// newest-N-raw-then-filter (which returns crumbs: the raw newest-50
+// here is all chunks, so a persona paging Messages goes deaf to
+// direction) — or the filtered leg silently forward-scanning the room.
+#[tokio::test]
+async fn kinds_filtered_tail_pages_newest_n_of_kind_with_bounded_work() {
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0x297);
+
+    for n in 0..3u128 {
+        router
+            .publish(event(channel, n, DeliveryClass::Durable))
+            .await
+            .expect("publish message");
+    }
+    for n in 3..203u128 {
+        router
+            .publish(kinded_event(
+                channel,
+                n,
+                Kind::StreamChunk,
+                DeliveryClass::Durable,
+            ))
+            .await
+            .expect("publish durable chunk");
+        if n % 64 == 0 {
+            // Let the write-behind drain so the bounded queue never sheds.
+            tokio::task::yield_now().await;
+        }
+    }
+
+    // The flood shape this fixes: the raw newest-50 is all chunks.
+    let raw = router.durable_tail(channel, 50).await.expect("raw tail");
+    assert!(
+        raw.iter().all(|e| e.kind == Kind::StreamChunk),
+        "precondition: the raw newest-50 page is chunk-flooded"
+    );
+
+    sink.reset();
+    let tail = router
+        .durable_tail_of_kinds(channel, &[Kind::Message], 50)
+        .await
+        .expect("kinds tail");
+    let expected: Vec<u128> = (0..3).collect();
+    assert_eq!(
+        markers(&tail),
+        expected,
+        "the newest 50 OF KIND Message are exactly the 3 buried messages, ascending"
+    );
+    assert_eq!(
+        sink.page_calls(),
+        0,
+        "the filtered tail must not forward-scan the room"
+    );
+    assert!(
+        sink.page_tail_calls() <= 1,
+        "at most one reverse page, got {}",
+        sink.page_tail_calls()
+    );
+    assert!(
+        sink.max_page_tail_limit() <= 50,
+        "the reverse page is bounded by N, asked for {}",
+        sink.max_page_tail_limit()
+    );
+
+    // A limit below the match count still caps: newest 2 messages.
+    let capped = router
+        .durable_tail_of_kinds(channel, &[Kind::Message], 2)
+        .await
+        .expect("capped kinds tail");
+    assert_eq!(markers(&capped), vec![1, 2], "limit caps the matches");
+
+    // Multi-kind filter admitting every published kind == the raw tail.
+    let both = router
+        .durable_tail_of_kinds(channel, &[Kind::Message, Kind::StreamChunk], 50)
+        .await
+        .expect("multi-kind tail");
+    assert_eq!(
+        markers(&both),
+        markers(&raw),
+        "a filter admitting all kinds behaves exactly like the raw tail"
+    );
 }
 
 /// §3.8 write-behind lag: a durable still pending persistence (the

--- a/crates/airc-bus/tests/durable_tip.rs
+++ b/crates/airc-bus/tests/durable_tip.rs
@@ -82,6 +82,18 @@ impl DurableSink for CountingSink {
         self.inner.page_tail(channel, before, limit).await
     }
 
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[Kind],
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner
+            .page_tail_of_kinds(channel, before, kinds, limit)
+            .await
+    }
+
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
         self.inner.contains(event_id).await
     }
@@ -114,6 +126,16 @@ impl DurableSink for FailingHeadSink {
         &self,
         _channel: RoomId,
         _before: Option<Cursor>,
+        _limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        Err(BusError::Sink("index unavailable".to_string()))
+    }
+
+    async fn page_tail_of_kinds(
+        &self,
+        _channel: RoomId,
+        _before: Option<Cursor>,
+        _kinds: &[Kind],
         _limit: usize,
     ) -> Result<Vec<Envelope>, BusError> {
         Err(BusError::Sink("index unavailable".to_string()))

--- a/crates/airc-bus/tests/publish_if_new.rs
+++ b/crates/airc-bus/tests/publish_if_new.rs
@@ -177,6 +177,18 @@ impl DurableSink for FlakyContainsSink {
         self.inner.page_tail(channel, before, limit).await
     }
 
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[airc_bus::envelope::Kind],
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner
+            .page_tail_of_kinds(channel, before, kinds, limit)
+            .await
+    }
+
     async fn contains(&self, event_id: EventId) -> Result<bool, BusError> {
         if self.fail_next_contains.swap(false, Ordering::SeqCst) {
             return Err(BusError::Sink("transient store outage".into()));

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -221,19 +221,46 @@ async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Respons
         }
     };
     let limit = request.limit.unwrap_or(INBOX_DEFAULT_LIMIT);
+    // Continuum #297: the kinds filter is applied BEFORE `limit`, so
+    // the page is "the newest N events OF THESE KINDS" — never the
+    // survivors of a raw newest-N (three personas streaming ~4
+    // StreamChunk frames/sec evict every Message from a 50-event page,
+    // deafening working personas to direction; post-filtering
+    // client-side yields crumbs). `None` AND the empty vec both mean
+    // unfiltered: filtering to nothing is never what a caller means,
+    // so an empty list is treated as absent rather than answered with
+    // a vacuously empty page.
+    let kinds: Option<Vec<Kind>> = request
+        .kinds
+        .as_ref()
+        .filter(|kinds| !kinds.is_empty())
+        .map(|kinds| kinds.iter().map(|k| map_kind(*k)).collect());
     let events = match request.since {
         // "Most recent N" when no cursor (card 8428ae8c): reverse-paged
         // at the store layer — work bounded by N (ring tail + at most
         // one indexed `page_tail`), NEVER a full-room replay truncated
-        // in memory. `durable_tail` is durable-only by contract.
-        None => match state.router.durable_tail(channel, limit).await {
-            Ok(events) => events,
-            Err(error) => {
-                return Response::Error {
-                    message: format!("inbox: {error}"),
+        // in memory. `durable_tail` is durable-only by contract; the
+        // kinds-filtered leg rides the same merge with the kind
+        // predicate pushed into both the ring scan and the sink query.
+        None => {
+            let tail = match &kinds {
+                None => state.router.durable_tail(channel, limit).await,
+                Some(kinds) => {
+                    state
+                        .router
+                        .durable_tail_of_kinds(channel, kinds, limit)
+                        .await
+                }
+            };
+            match tail {
+                Ok(events) => events,
+                Err(error) => {
+                    return Response::Error {
+                        message: format!("inbox: {error}"),
+                    }
                 }
             }
-        },
+        }
         // "First N after the cursor" when resuming.
         Some(c) => {
             let from = Some(Cursor::new(Seq::new(c.epoch, c.counter), c.event_id));
@@ -249,8 +276,14 @@ async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Respons
             // merges the hot ring (which transiently holds every class,
             // incl. StreamChunk / EphemeralLatest for live attach-replay)
             // with the sink, so filter to durable here — non-durable
-            // classes never belong in a replay (§3.4).
-            events.retain(|env| env.delivery.is_durable());
+            // classes never belong in a replay (§3.4). The kinds filter
+            // composes the same way, and BOTH run before `truncate`, so
+            // `since` + `kinds` still means "the first N matching events
+            // after the cursor."
+            events.retain(|env| {
+                env.delivery.is_durable()
+                    && kinds.as_ref().is_none_or(|kinds| kinds.contains(&env.kind))
+            });
             events.truncate(limit);
             events
         }

--- a/crates/airc-daemon/tests/inbox_paging.rs
+++ b/crates/airc-daemon/tests/inbox_paging.rs
@@ -122,34 +122,44 @@ fn stream_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
     }
 }
 
+/// A DURABLE chunk-kind envelope — the continuum #297 flood shape:
+/// persona-turn stream chunks that persist to the transcript, so they
+/// genuinely occupy the durable newest-N page a raw inbox returns.
+fn durable_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
+    PublishRequest {
+        delivery: IpcDelivery::Durable,
+        ..stream_chunk(channel, bytes)
+    }
+}
+
+/// Publish one request, honouring §3.8 back-pressure: the write-behind
+/// queue is bounded, and on a slow runner a tight publish loop can
+/// outpace the SQLite drain — the daemon sheds with a LOUD typed error
+/// (the designed signal, never a silent drop). Back off and retry the
+/// same event, the way a real producer would. Any other error is a real
+/// failure.
+async fn publish_with_backoff(client: &DaemonClient, request: PublishRequest) -> PublishResponse {
+    for _ in 0..500 {
+        match client.publish(request.clone()).await {
+            Ok(receipt) => return receipt,
+            Err(error) => {
+                let message = error.to_string();
+                assert!(
+                    message.contains("saturated"),
+                    "unexpected publish error: {message}"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+    panic!("publish kept saturating after 500 backoff retries");
+}
+
 async fn publish_n(client: &DaemonClient, channel: RoomId, n: usize) -> PublishResponse {
     let mut last = None;
     for i in 0..n {
         let request = durable_text(channel, &format!("event {i}"));
-        // The write-behind queue is bounded: on a slow runner a tight
-        // publish loop can outpace the SQLite drain, and the daemon
-        // sheds with a LOUD typed error (§3.8 — the designed
-        // back-pressure signal, never a silent drop). Honour the
-        // contract the way a real producer would: back off and retry
-        // the same event. Any other error is a real failure.
-        let mut receipt = None;
-        for _ in 0..500 {
-            match client.publish(request.clone()).await {
-                Ok(r) => {
-                    receipt = Some(r);
-                    break;
-                }
-                Err(error) => {
-                    let message = error.to_string();
-                    assert!(
-                        message.contains("saturated"),
-                        "unexpected publish error: {message}"
-                    );
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-            }
-        }
-        last = Some(receipt.expect("publish kept saturating after 500 backoff retries"));
+        last = Some(publish_with_backoff(client, request).await);
     }
     last.expect("n > 0")
 }
@@ -175,6 +185,7 @@ async fn inbox_most_recent_n_returns_exact_ascending_tail() {
             since: None,
             channel: Some(channel),
             limit: Some(10),
+            kinds: None,
         })
         .await
         .expect("inbox on empty room");
@@ -197,6 +208,7 @@ async fn inbox_most_recent_n_returns_exact_ascending_tail() {
             since: None,
             channel: Some(channel),
             limit: Some(10),
+            kinds: None,
         })
         .await
         .expect("inbox limit 10");
@@ -216,6 +228,7 @@ async fn inbox_most_recent_n_returns_exact_ascending_tail() {
             since: None,
             channel: Some(channel),
             limit: Some(500),
+            kinds: None,
         })
         .await
         .expect("inbox limit 500");
@@ -253,6 +266,7 @@ async fn deep_room_most_recent_n_costs_by_n_not_room_depth() {
                 since: None,
                 channel: Some(channel),
                 limit: Some(N),
+                kinds: None,
             })
             .await
             .expect("inbox limit N");
@@ -272,6 +286,7 @@ async fn deep_room_most_recent_n_costs_by_n_not_room_depth() {
                 since: None,
                 channel: Some(channel),
                 limit: Some(DEEP),
+                kinds: None,
             })
             .await
             .expect("inbox limit DEEP");
@@ -316,6 +331,118 @@ async fn deep_room_most_recent_n_costs_by_n_not_room_depth() {
         "most-recent-{N} ({paged_us} µs/op) must be at least 10x cheaper than \
          materializing the {DEEP}-deep room ({full_us} µs/op) — a fall-back to \
          full-room replay sits ~6x under it and must fail here"
+    );
+
+    daemon.stop().await;
+}
+
+/// Continuum #297, against the LIVE daemon: three active personas
+/// stream ~4 durable StreamChunk frames/sec, so a room's raw newest-50
+/// page is all chunks and every durable Message is evicted — working
+/// personas go deaf to direction (a resident asked the same question 3×
+/// because four direction messages never entered her page). The daemon
+/// must filter kinds BEFORE the limit: "newest N events OF THESE
+/// KINDS", on both inbox legs (fresh page and cursor resume).
+// what this catches: `InboxRequest.kinds` regressing to a post-limit
+// filter (the page comes back empty under a chunk flood instead of
+// containing the buried messages), the empty-vec normalization drifting
+// from None (a vacuously empty page), or kinds=None diverging from
+// today's raw behavior.
+#[tokio::test]
+async fn inbox_kinds_filter_returns_buried_messages_under_chunk_flood() {
+    use airc_bus::envelope::Kind;
+
+    let daemon = start_daemon().await;
+    let client = DaemonClient::new(daemon.socket.clone());
+    let channel = RoomId::from_u128(0x297);
+
+    // Three direction messages…
+    let mut message_cursors = Vec::new();
+    for i in 0..3 {
+        let receipt =
+            publish_with_backoff(&client, durable_text(channel, &format!("direction {i}"))).await;
+        message_cursors.push(airc_ipc::IpcCursor {
+            epoch: receipt.epoch,
+            counter: receipt.counter,
+            event_id: receipt.event_id,
+        });
+    }
+    // …buried under 200 newer durable stream chunks.
+    for _ in 0..200 {
+        publish_with_backoff(&client, durable_chunk(channel, b"\x01\x02\x03")).await;
+    }
+
+    // Precondition — the bug shape: the raw newest-50 page is ALL
+    // chunks; post-filtering it client-side would yield zero messages.
+    let raw = client
+        .inbox(InboxRequest {
+            since: None,
+            channel: Some(channel),
+            limit: Some(50),
+            kinds: None,
+        })
+        .await
+        .expect("raw inbox");
+    assert_eq!(raw.envelopes.len(), 50);
+    assert!(
+        raw.envelopes
+            .iter()
+            .map(|bytes| airc_wire::decode(bytes.clone().into()).expect("decode"))
+            .all(|env| env.kind == Kind::StreamChunk),
+        "precondition: the raw newest-50 page is chunk-flooded"
+    );
+
+    // The fix: kinds=[Message] filters BEFORE the limit — exactly the
+    // three buried messages, ascending.
+    let filtered = client
+        .inbox(InboxRequest {
+            since: None,
+            channel: Some(channel),
+            limit: Some(50),
+            kinds: Some(vec![IpcKind::Message]),
+        })
+        .await
+        .expect("filtered inbox");
+    let texts: Vec<String> = filtered.envelopes.into_iter().map(payload_text).collect();
+    assert_eq!(
+        texts,
+        vec!["direction 0", "direction 1", "direction 2"],
+        "newest 50 OF KIND Message are the 3 buried messages, ascending"
+    );
+
+    // Empty vec is normalized to None — filtering to nothing is never
+    // what a caller means, so it must be byte-identical to the raw page.
+    let empty_kinds = client
+        .inbox(InboxRequest {
+            since: None,
+            channel: Some(channel),
+            limit: Some(50),
+            kinds: Some(vec![]),
+        })
+        .await
+        .expect("empty-kinds inbox");
+    assert_eq!(
+        empty_kinds.envelopes, raw.envelopes,
+        "kinds: Some([]) behaves exactly like kinds: None"
+    );
+
+    // `since` + `kinds` compose: resuming after the first message with
+    // kinds=[Message] skips the chunk flood and returns the remaining
+    // two messages.
+    let resumed = client
+        .inbox(InboxRequest {
+            since: Some(message_cursors[0]),
+            channel: Some(channel),
+            limit: Some(50),
+            kinds: Some(vec![IpcKind::Message]),
+        })
+        .await
+        .expect("resumed filtered inbox");
+    let texts: Vec<String> = resumed.envelopes.into_iter().map(payload_text).collect();
+    assert_eq!(
+        texts,
+        vec!["direction 1", "direction 2"],
+        "cursor + kinds: the first N matching events after the cursor"
     );
 
     daemon.stop().await;

--- a/crates/airc-daemon/tests/owner_core_proof.rs
+++ b/crates/airc-daemon/tests/owner_core_proof.rs
@@ -300,6 +300,7 @@ async fn streamchunk_raw_bytes_route_live_byte_identical_and_never_persist() {
             since: None,
             channel: Some(channel),
             limit: Some(100),
+            kinds: None,
         })
         .await
         .expect("inbox");
@@ -328,6 +329,7 @@ async fn durable_publishes_replay_via_inbox_in_order_and_page_by_cursor() {
             since: None,
             channel: Some(channel),
             limit: Some(100),
+            kinds: None,
         })
         .await
         .expect("inbox");
@@ -343,6 +345,7 @@ async fn durable_publishes_replay_via_inbox_in_order_and_page_by_cursor() {
             since: inbox.newest,
             channel: Some(channel),
             limit: Some(100),
+            kinds: None,
         })
         .await
         .expect("inbox after cursor");
@@ -518,6 +521,7 @@ async fn continuum_webrtc_room_mixed_traffic_only_chat_persists() {
             since: None,
             channel: Some(channel),
             limit: Some(1000),
+            kinds: None,
         })
         .await
         .expect("inbox");
@@ -553,6 +557,7 @@ async fn chat_send_is_durable_and_text_round_trips() {
             since: None,
             channel: Some(channel),
             limit: Some(10),
+            kinds: None,
         })
         .await
         .expect("inbox");

--- a/crates/airc-daemon/tests/room_tip_probe.rs
+++ b/crates/airc-daemon/tests/room_tip_probe.rs
@@ -254,6 +254,7 @@ async fn deep_room_tip_probe_matches_inbox_newest() {
                 since: None,
                 channel: Some(channel),
                 limit: Some(1),
+                kinds: None,
             })
             .await
             .expect("inbox");

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -179,6 +179,19 @@ pub struct InboxRequest {
     /// reasonable cap (32) so a slow client doesn't pull megabytes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
+    /// **Continuum #297.** When set, the daemon filters to these kinds
+    /// BEFORE applying `limit` — the page is the newest N events *of
+    /// these kinds*, not the survivors of a raw newest-N. Post-filtering
+    /// client-side cannot express that: three personas streaming ~4
+    /// `StreamChunk` frames/sec evict every durable `Message` from a
+    /// 50-event page, deafening working personas to direction.
+    ///
+    /// `None` (and, on the daemon side, an empty vec — filtering to
+    /// nothing is never what a caller means) is exactly today's
+    /// unfiltered behavior. Wire-compat both directions: old daemons
+    /// ignore the field; old clients omit it (`skip_serializing_if`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kinds: Option<Vec<IpcKind>>,
 }
 
 /// Parameters for `RoomTip` (card a1562dbc). The channel is mandatory:
@@ -698,10 +711,41 @@ mod tests {
             }),
             channel: Some(airc_core::RoomId::from_u128(0x42)),
             limit: Some(64),
+            kinds: None,
         });
         let encoded = serde_json::to_string(&original).unwrap();
         let decoded: Request = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, original);
+    }
+
+    /// Continuum #297: `kinds` wire contract, both halves.
+    // what this catches: a serde attribute regression that would leak
+    // `kinds: null` into every unfiltered inbox (breaking old daemons'
+    // strict decoders) or drop the kinds list on the daemon side —
+    // silently reverting the filter-before-limit fix to raw newest-N.
+    #[test]
+    fn inbox_kinds_omitted_when_none_and_roundtrips_when_set() {
+        let unfiltered = Request::Inbox(InboxRequest {
+            since: None,
+            channel: Some(airc_core::RoomId::from_u128(0x42)),
+            limit: Some(50),
+            kinds: None,
+        });
+        let encoded = serde_json::to_string(&unfiltered).unwrap();
+        assert!(
+            !encoded.contains("kinds"),
+            "unset kinds must be absent from the wire: {encoded}"
+        );
+
+        let filtered = Request::Inbox(InboxRequest {
+            since: None,
+            channel: Some(airc_core::RoomId::from_u128(0x42)),
+            limit: Some(50),
+            kinds: Some(vec![IpcKind::Message, IpcKind::Event]),
+        });
+        let decoded: Request =
+            serde_json::from_str(&serde_json::to_string(&filtered).unwrap()).unwrap();
+        assert_eq!(decoded, filtered);
     }
 
     /// Card a1562dbc: the EXACT wire bytes of `RoomTip` are the
@@ -753,6 +797,7 @@ mod tests {
                 since: None,
                 channel: Some(airc_core::RoomId::from_u128(0x42)),
                 limit: Some(1),
+                kinds: None,
             })
         );
     }

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -21,7 +21,7 @@ use airc_core::{
 };
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
-    AttachRequest, AttachStart, InboxRequest, IpcCursor, IpcDelivery, IpcTarget,
+    AttachRequest, AttachStart, InboxRequest, IpcCursor, IpcDelivery, IpcKind, IpcTarget,
     PeerIdentityCardRequest, PublishRequest, Response, RoomTipRequest, SendRequest,
 };
 use airc_protocol::FrameKind;
@@ -75,6 +75,34 @@ fn kind_to_transcript(kind: Kind) -> TranscriptKind {
         | Kind::StreamChunk
         | Kind::Control => TranscriptKind::System,
     }
+}
+
+/// Continuum #297 — the inverse of [`kind_to_transcript`], for pushing
+/// a consumer's `EventFilter::kinds` down into the daemon's inbox read
+/// ("newest N events OF THESE KINDS", filtered before the limit).
+///
+/// The push-down must be a SUPERSET of the client-side `filter.matches`
+/// — never narrower, or the daemon would drop events the consumer asked
+/// for. `kind_to_transcript` is lossy (every non-chat bus kind projects
+/// to the coarse `System`), so `Message` maps exactly and ANY other
+/// transcript kind admits every non-`Message` bus kind; `filter.matches`
+/// still refines the decoded page afterwards.
+fn transcript_kinds_to_ipc(kinds: &std::collections::BTreeSet<TranscriptKind>) -> Vec<IpcKind> {
+    let mut out = Vec::new();
+    if kinds.contains(&TranscriptKind::Message) {
+        out.push(IpcKind::Message);
+    }
+    if kinds.iter().any(|kind| *kind != TranscriptKind::Message) {
+        out.extend([
+            IpcKind::Event,
+            IpcKind::Command,
+            IpcKind::CommandResult,
+            IpcKind::Signal,
+            IpcKind::StreamChunk,
+            IpcKind::Control,
+        ]);
+    }
+    out
 }
 
 fn target_to_mention(target: &Target) -> MentionTarget {
@@ -238,6 +266,34 @@ impl Airc {
                 since: None,
                 channel: Some(room.channel),
                 limit: Some(limit),
+                kinds: None,
+            })
+            .await?;
+        response
+            .envelopes
+            .into_iter()
+            .map(decode_wire_event)
+            .collect()
+    }
+
+    /// Continuum #297: [`Airc::daemon_page_recent`] with the consumer's
+    /// kind filter pushed down into the daemon's inbox read (mapped via
+    /// [`transcript_kinds_to_ipc`]), so the daemon pages the newest
+    /// `limit` events OF THOSE KINDS instead of a raw newest-`limit`
+    /// that a StreamChunk flood fills with events the caller discards.
+    pub(crate) async fn daemon_page_recent_of_kinds(
+        &self,
+        channel: RoomId,
+        kinds: &std::collections::BTreeSet<TranscriptKind>,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        let response = self
+            .require_daemon_client()?
+            .inbox(InboxRequest {
+                since: None,
+                channel: Some(channel),
+                limit: Some(limit),
+                kinds: Some(transcript_kinds_to_ipc(kinds)),
             })
             .await?;
         response
@@ -264,6 +320,7 @@ impl Airc {
                 }),
                 channel: Some(room.channel),
                 limit: Some(limit),
+                kinds: None,
             })
             .await?;
         response
@@ -345,6 +402,7 @@ impl Airc {
                     since,
                     channel: Some(channel),
                     limit: Some(page_size),
+                    kinds: None,
                 })
                 .await?;
             let count = response.envelopes.len();

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -8,6 +8,16 @@ use crate::stream::{EventFilter, EventStream, FilteredEventStream};
 use crate::time::now_ms;
 use crate::Airc;
 
+/// Continuum #297: how many raw events the LOCAL-store filtered page
+/// reads per requested match. The local store has no kind-pushdown
+/// query (the daemon does — see [`Airc::daemon_page_recent_of_kinds`]),
+/// so [`Airc::page_recent_filtered`] pages `limit * 8` raw, filters,
+/// and keeps the newest `limit` matches — a bounded overscan instead of
+/// the old newest-`limit`-raw-then-filter, whose page a StreamChunk
+/// flood fills with events the filter discards. Exhausting the window
+/// before `limit` matches is logged (no silent caps).
+const STORE_FILTER_OVERSCAN: usize = 8;
+
 /// Event metadata returned by [`Airc::send_frame_to_room`]. Carries
 /// enough to build a typed receipt for the public publish API.
 #[derive(Debug, Clone, Copy)]
@@ -278,20 +288,61 @@ impl Airc {
 
     /// Fetch recent events matching `filter`. If the filter does not
     /// specify a channel, it is scoped to the current room.
+    ///
+    /// Continuum #297: the kind filter is applied BEFORE the limit, so
+    /// the page is the newest `limit` events OF THOSE KINDS — never the
+    /// survivors of a raw newest-`limit` (a persona-turn StreamChunk
+    /// flood fills a raw page and evicts every durable Message,
+    /// deafening working personas to direction). Daemon-attached, the
+    /// kinds are pushed down into the daemon's inbox read; the local
+    /// store path uses a bounded overscan. Either way `filter.matches`
+    /// still runs on the result (headers / self-echo are client-side).
     pub async fn page_recent_filtered(
         &self,
         filter: EventFilter,
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let filter = self.scope_filter_to_current_room(filter).await?;
-        Ok(self
+        if self.is_daemon_attached() && !filter.kinds.is_empty() {
+            if let Some(channel) = filter.channel {
+                return Ok(self
+                    .daemon_page_recent_of_kinds(channel, &filter.kinds, limit)
+                    .await?
+                    .into_iter()
+                    .filter(|event| filter.matches(event))
+                    .collect());
+            }
+        }
+        // Local store path: bounded overscan — page a wider raw window,
+        // filter, keep the newest `limit` matches. With a pass-all
+        // filter this is exactly the newest `limit` (today's behavior).
+        let overscan = limit.saturating_mul(STORE_FILTER_OVERSCAN);
+        let raw = self
             .inner
             .store
-            .page_recent(filter.channel, limit)
-            .await?
+            .page_recent(filter.channel, overscan)
+            .await?;
+        let scanned = raw.len();
+        let mut matches: Vec<TranscriptEvent> = raw
             .into_iter()
             .filter(|event| filter.matches(event))
-            .collect())
+            .collect();
+        if matches.len() < limit && scanned == overscan {
+            // No silent caps: the overscan window filled before finding
+            // `limit` matches — older matching events may exist beyond it.
+            tracing::debug!(
+                target: "airc::messaging",
+                limit,
+                overscan,
+                found = matches.len(),
+                "page_recent_filtered: overscan window exhausted before \
+                 finding `limit` matching events"
+            );
+        }
+        if matches.len() > limit {
+            matches.drain(..matches.len() - limit);
+        }
+        Ok(matches)
     }
 
     /// Fetch recent events from the subscribed room set.

--- a/crates/airc-lib/tests/daemon_cursor_reads.rs
+++ b/crates/airc-lib/tests/daemon_cursor_reads.rs
@@ -79,3 +79,65 @@ async fn attached_subscription_cursor_is_the_daemon_tip() {
         "unsubscribed channel stays None"
     );
 }
+
+/// Continuum #297: a daemon-attached `page_recent_filtered` with a
+/// kind filter pushes the kinds DOWN into the daemon's inbox read, so
+/// the page is the newest N events OF THOSE KINDS — not the survivors
+/// of a raw newest-N. The discriminating flood: three direction
+/// messages buried under 200 newer durable stream chunks. Newest-50
+/// raw is all chunks, so both failure modes answer wrong here: the old
+/// local-store read returns nothing (attached scopes have stale local
+/// stores — same class as the cursor reads above), and a
+/// newest-50-raw-then-filter returns crumbs.
+// what this catches: the kinds push-down regressing to client-side
+// post-filtering (or to the stale local store), which deafens working
+// personas to direction under persona-turn chunk floods.
+#[tokio::test]
+async fn attached_filtered_page_pushes_kinds_down_to_the_daemon() {
+    use airc_ipc::{DaemonClient, IpcDelivery, IpcKind, IpcTarget, PublishRequest};
+    use airc_lib::{EventFilter, TranscriptKind};
+
+    let machine = Machine::boot().await;
+    let (alice, bob) = machine.pair_in("kinds-pushdown").await;
+
+    let mut direction_ids = Vec::new();
+    for text in ["direction one", "direction two", "direction three"] {
+        direction_ids.push(alice.say(text).await.expect("say direction"));
+    }
+
+    // Flood the room with newer DURABLE chunk-kind envelopes through
+    // the daemon's IPC surface (the persona-turn stream shape).
+    let channel = alice.current_room().await.expect("current room").channel;
+    let client = DaemonClient::new(machine.daemon.socket.clone());
+    for _ in 0..200 {
+        client
+            .publish(PublishRequest {
+                channel: channel.as_uuid(),
+                from_peer: alice.peer_id().as_uuid(),
+                from_client: alice.client_id().as_uuid(),
+                kind: IpcKind::StreamChunk,
+                delivery: IpcDelivery::Durable,
+                target: IpcTarget::All,
+                correlation_id: None,
+                coalesce_key: None,
+                payload: b"\x01\x02\x03".to_vec(),
+                headers: airc_core::Headers::new(),
+            })
+            .await
+            .expect("publish durable chunk");
+    }
+
+    // Bob never wrote to his local store; only the kinds push-down can
+    // find the buried messages.
+    let mut filter = EventFilter::current_room();
+    filter.kinds.insert(TranscriptKind::Message);
+    let page = bob
+        .page_recent_filtered(filter, 50)
+        .await
+        .expect("filtered page");
+    assert_eq!(
+        page.iter().map(|e| e.event_id).collect::<Vec<_>>(),
+        direction_ids,
+        "the newest 50 OF KIND Message are the 3 buried direction messages, ascending"
+    );
+}

--- a/crates/airc-store/src/bus_sink.rs
+++ b/crates/airc-store/src/bus_sink.rs
@@ -234,26 +234,8 @@ impl DurableSink for SqliteDurableSink {
         let mut query =
             bus_event::Entity::find().filter(bus_event::Column::RoomId.eq(channel.as_uuid()));
 
-        // Strictly before the cursor in generational order — the exact
-        // mirror of `page`'s strictly-after predicate:
-        //   epoch < c.epoch
-        //   OR (epoch == c.epoch AND counter < c.counter)
-        //   OR (epoch == c.epoch AND counter == c.counter
-        //       AND event_id < c.event_id).
         if let Some(c) = before {
-            let epoch = c.seq.epoch as i64;
-            let counter = c.seq.counter as i64;
-            let event_id = c.event_id.as_uuid();
-            let strictly_before = Expr::col(bus_event::Column::Epoch)
-                .lt(epoch)
-                .or(Expr::col(bus_event::Column::Epoch)
-                    .eq(epoch)
-                    .and(Expr::col(bus_event::Column::Counter).lt(counter)))
-                .or(Expr::col(bus_event::Column::Epoch)
-                    .eq(epoch)
-                    .and(Expr::col(bus_event::Column::Counter).eq(counter))
-                    .and(Expr::col(bus_event::Column::EventId).lt(event_id)));
-            query = query.filter(strictly_before);
+            query = query.filter(strictly_before(c));
         }
 
         let rows = query
@@ -266,6 +248,43 @@ impl DurableSink for SqliteDurableSink {
             .map_err(|e| BusError::Sink(e.to_string()))?;
 
         // DESC off the index, ascending to the caller.
+        rows.into_iter().rev().map(from_model).collect()
+    }
+
+    /// Continuum #297: `page_tail` with the kind predicate applied by
+    /// the DATABASE, before `LIMIT` — the store leg of "newest N events
+    /// of these kinds". Same composite-index DESC scan as
+    /// [`Self::page_tail`] plus one indexed-column `IN` predicate; a
+    /// chunk-flooded room answers with the newest N matching rows
+    /// instead of N chunks the caller would throw away.
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[Kind],
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        let bounded = u64::try_from(limit)
+            .unwrap_or(u64::MAX)
+            .min(i64::MAX as u64);
+
+        let mut query = bus_event::Entity::find()
+            .filter(bus_event::Column::RoomId.eq(channel.as_uuid()))
+            .filter(bus_event::Column::Kind.is_in(kinds.iter().map(|k| kind_to_text(*k))));
+
+        if let Some(c) = before {
+            query = query.filter(strictly_before(c));
+        }
+
+        let rows = query
+            .order_by_desc(bus_event::Column::Epoch)
+            .order_by_desc(bus_event::Column::Counter)
+            .order_by_desc(bus_event::Column::EventId)
+            .limit(bounded)
+            .all(&self.db)
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+
         rows.into_iter().rev().map(from_model).collect()
     }
 
@@ -368,6 +387,30 @@ fn from_model(m: bus_event::Model) -> Result<Envelope, BusError> {
     })
 }
 
+/// Strictly-before-`c` in the generational total order — the exact
+/// mirror of `page`'s strictly-after predicate:
+///   epoch < c.epoch
+///   OR (epoch == c.epoch AND counter < c.counter)
+///   OR (epoch == c.epoch AND counter == c.counter
+///       AND event_id < c.event_id).
+/// Shared by both reverse-paging legs ([`DurableSink::page_tail`],
+/// [`DurableSink::page_tail_of_kinds`]) so the ordering contract has
+/// exactly one home.
+fn strictly_before(c: Cursor) -> sea_orm::sea_query::SimpleExpr {
+    let epoch = c.seq.epoch as i64;
+    let counter = c.seq.counter as i64;
+    let event_id = c.event_id.as_uuid();
+    Expr::col(bus_event::Column::Epoch)
+        .lt(epoch)
+        .or(Expr::col(bus_event::Column::Epoch)
+            .eq(epoch)
+            .and(Expr::col(bus_event::Column::Counter).lt(counter)))
+        .or(Expr::col(bus_event::Column::Epoch)
+            .eq(epoch)
+            .and(Expr::col(bus_event::Column::Counter).eq(counter))
+            .and(Expr::col(bus_event::Column::EventId).lt(event_id)))
+}
+
 fn kind_to_text(kind: Kind) -> &'static str {
     match kind {
         Kind::Message => "message",
@@ -461,10 +504,16 @@ mod tests {
     /// real random UUIDs) it must be globally unique across channels —
     /// the channel is mixed into the high half.
     fn durable_at(channel: RoomId, epoch: u64, counter: u64) -> Envelope {
+        durable_kind_at(channel, Kind::Message, epoch, counter)
+    }
+
+    /// [`durable_at`] with an explicit [`Kind`] — for the kinds-filtered
+    /// reverse page (continuum #297).
+    fn durable_kind_at(channel: RoomId, kind: Kind, epoch: u64, counter: u64) -> Envelope {
         let mut e = Envelope::new(
             channel,
             (PeerId::from_u128(0xa1), ClientId::from_u128(0xc1)),
-            Kind::Message,
+            kind,
             DeliveryClass::Durable,
             Bytes::from(format!("payload-{epoch}-{counter}")),
         )
@@ -657,6 +706,67 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    /// Continuum #297: the kind predicate runs in the DATABASE, before
+    /// `LIMIT` — the store leg of "newest N events OF THESE KINDS".
+    // what this catches: `page_tail_of_kinds` regressing to a raw DESC
+    // page truncated before the kind filter — under a StreamChunk flood
+    // the newest-N raw rows are all chunks, so the filtered page would
+    // come back empty ("crumbs") and personas go deaf to direction.
+    #[tokio::test]
+    async fn page_tail_of_kinds_filters_in_the_database_before_limit() {
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(0x297);
+        // 3 messages, then 200 newer chunk-kind durable rows.
+        for c in 0..3u64 {
+            sink.append(&durable_at(ch, 1, c)).await.unwrap();
+        }
+        for c in 3..203u64 {
+            sink.append(&durable_kind_at(ch, Kind::StreamChunk, 1, c))
+                .await
+                .unwrap();
+        }
+
+        // Newest 50 of kind Message: exactly the 3 buried messages,
+        // ascending — a raw newest-50 contains zero of them.
+        let tail = sink
+            .page_tail_of_kinds(ch, None, &[Kind::Message], 50)
+            .await
+            .unwrap();
+        let counters: Vec<u64> = tail.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(counters, vec![0, 1, 2], "newest N OF KIND, ascending");
+        assert!(tail.iter().all(|e| e.kind == Kind::Message));
+
+        // `limit` still caps the matches.
+        let capped = sink
+            .page_tail_of_kinds(ch, None, &[Kind::Message], 2)
+            .await
+            .unwrap();
+        let counters: Vec<u64> = capped.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(counters, vec![1, 2], "newest 2 of the kind");
+
+        // `before` composes with the kind predicate (same
+        // strictly-before contract as `page_tail`).
+        let before = durable_at(ch, 1, 2).cursor();
+        let older = sink
+            .page_tail_of_kinds(ch, Some(before), &[Kind::Message], 50)
+            .await
+            .unwrap();
+        let counters: Vec<u64> = older.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(counters, vec![0, 1], "strictly before the cursor");
+
+        // A filter admitting every stored kind == the raw reverse page.
+        let both = sink
+            .page_tail_of_kinds(ch, None, &[Kind::Message, Kind::StreamChunk], 5)
+            .await
+            .unwrap();
+        let raw = sink.page_tail(ch, None, 5).await.unwrap();
+        assert_eq!(
+            both.iter().map(|e| e.event_id).collect::<Vec<_>>(),
+            raw.iter().map(|e| e.event_id).collect::<Vec<_>>(),
+            "all-kinds filter behaves exactly like page_tail"
+        );
     }
 
     #[tokio::test]

--- a/crates/airc-store/tests/bus_router_durable_tier.rs
+++ b/crates/airc-store/tests/bus_router_durable_tier.rs
@@ -88,6 +88,18 @@ impl DurableSink for GatedSqliteSink {
         self.inner.page_tail(channel, before, limit).await
     }
 
+    async fn page_tail_of_kinds(
+        &self,
+        channel: RoomId,
+        before: Option<Cursor>,
+        kinds: &[Kind],
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner
+            .page_tail_of_kinds(channel, before, kinds, limit)
+            .await
+    }
+
     async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
         self.inner.contains(event_id).await
     }


### PR DESCRIPTION
## The bug (continuum #297, glass-boxed live)

Persona perception pages the room via the `Inbox` IPC verb, which returned the raw newest-N events. Persona turns stream ~4 durable StreamChunk frames/sec; three active personas produce hundreds of chunk events, evicting every durable Message from a 50-event page — working personas went DEAF to direction (a resident asked the same question 3× because four direction messages never entered her page while the attach cursor advanced normally). Post-filtering client-side can't fix it: newest-50-raw then filter yields crumbs.

## The fix: filter kinds BEFORE the limit, at every layer that truncates

- **airc-ipc** — `InboxRequest.kinds: Option<Vec<IpcKind>>` (`serde(default, skip_serializing_if)`). Wire-compat both directions: old daemons ignore the field, old clients omit it. The pinned legacy inbox bytes decode unchanged.
- **airc-bus** — `DurableSink::page_tail_of_kinds` (required, **no scan default** — same posture as `page_tail`, card 8428ae8c: a sink that cannot kind-filter its reverse page is a compile error, never a silent fetch-then-filter) + `EventRouter::durable_tail_of_kinds`. One merge impl behind both tail faces; the kind predicate runs on the ring scan AND the sink leg, before the limit, with the same bounded store work (zero forward scans, ≤ 1 reverse page, requested limit ≤ N — pinned by the counting-sink proof).
- **airc-store** — SQLite `page_tail_of_kinds`: the same composite-index DESC scan plus one indexed `IN` predicate; the strictly-before cursor predicate is extracted to one shared home.
- **airc-daemon** — `handle_inbox` maps kinds via the existing `map_kind` and filters both legs (fresh tail + cursor resume) before truncation. `since` + `kinds` compose. Empty vec is normalized to `None` — filtering to nothing is never what a caller means.
- **airc-lib** — `page_recent_filtered` pushes non-empty `filter.kinds` down into the daemon inbox read (superset `TranscriptKind→IpcKind` mapping, the inverse of `kind_to_transcript`; client-side `filter.matches` still refines — headers/self-echo aren't pushed down). The non-daemon store path does a bounded `limit * 8` overscan with a `tracing::debug!` when the window exhausts before `limit` matches (no silent caps).

## Tests (extending existing mods only, each with `// what this catches:`)

- `airc-daemon/tests/inbox_paging.rs` — live-daemon flood: 200 durable chunks bury 3 messages; `kinds=[Message], limit=50` → exactly the 3, ascending; raw newest-50 is all chunks (the bug shape); `Some([])` byte-identical to `None`; `since`+`kinds` composition.
- `airc-bus/tests/durable_tail.rs` — the sink→ring seam under flood + the bounded-work structural proof for the filtered leg.
- `airc-store/src/bus_sink.rs` — DB-side filter-before-LIMIT, `before`-cursor composition, all-kinds ≡ raw `page_tail`.
- `airc-ipc/src/request.rs` — round-trip with kinds set, omitted-when-None pin, legacy-bytes pin unchanged.
- `airc-lib/tests/daemon_cursor_reads.rs` — attached `page_recent_filtered` push-down through the real daemon loopback (`Machine`); discriminates against both the stale-local-store read and client-side post-filtering.

`cargo test -p airc-ipc -p airc-bus -p airc-store -p airc-daemon -p airc-lib` green; `cargo clippy --all-targets` clean; `cargo fmt --check` clean. (One unrelated flake observed once under full-suite parallel load: `room_roster_cards` identity-index race — that path uses unfiltered `page_recent` + the durable identity index, untouched here; green on re-runs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo