### PR TITLE
fix(identity): run the diverged-room heal on the daemon clock, not only on `airc join`

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1820,6 +1820,35 @@ async fn refresh_routes_once(
     // changes IP keeps advertising a stale, undialable address until it is
     // manually restarted. Reused below for relay self-election so detection
     // happens exactly once per tick.
+    // Self-healing join — mesh-identity reconcile every tick. A machine
+    // that booted before `gh` could answer derived every room UUID under
+    // the provisional `local:<host>:<user>` identity; when the identity
+    // later heals, the stored subscriptions still point at the diverged
+    // rooms and this node is invisible to the rest of the account mesh.
+    // The heal itself already existed but only ran on `airc join`, which
+    // is why recovery has needed a human typing `airc stop && airc join`.
+    // Running it on the daemon clock makes it autonomous. No-op when
+    // converged; loud when it moves something.
+    match airc.reconcile_subscription_identity().await {
+        Ok(rebinds) if !rebinds.is_empty() => {
+            for rebind in &rebinds {
+                eprintln!(
+                    "airc daemon: mesh identity healed — subscription '{}' re-bound {} -> {}",
+                    rebind.name.as_str(),
+                    rebind.old_room_id,
+                    rebind.new_room_id
+                );
+            }
+        }
+        Ok(_) => {}
+        Err(error) => {
+            eprintln!(
+                "airc daemon: subscription identity reconcile failed ({error}); \
+                 retrying next tick"
+            );
+        }
+    }
+
     let lan_ip = crate::network_commands::advertise_lan_ip();
     let tailscale_ip = crate::network_commands::detect_tailscale_ip();
     match airc

--- a/crates/airc-daemon/src/route_refresh.rs
+++ b/crates/airc-daemon/src/route_refresh.rs
@@ -50,6 +50,22 @@ pub const FIRST_REFRESH_DELAY: Duration = Duration::ZERO;
 /// [`run_periodic_refresh`]), never start-to-start.
 pub const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Minimum spacing between refreshes, enforced on the WAKE path.
+///
+/// The wake nudge exists so a real reconnect doesn't wait out a full
+/// [`REFRESH_INTERVAL`]. But it is fired by the session-drop observer, and
+/// a refresh dials every stored peer — so on a node whose registry is
+/// mostly dead peers, refresh manufactures the drops that nudge the next
+/// refresh, forever. This floor is what makes that cycle terminate: at
+/// worst 4 refreshes/minute instead of ~13, and the gh budget the account
+/// registry needs is no longer spent by a spin.
+///
+/// 15s is chosen against the failure it bounds, not tuned: it keeps a
+/// genuine reconnect fast (well under the 60s interval it exists to beat)
+/// while capping the dial rate low enough that a poisoned registry cannot
+/// exhaust a 30-req/60s budget on discovery alone.
+pub const MIN_REFRESH_SPACING: Duration = Duration::from_secs(15);
+
 /// Pure scheduling rule: how long to wait before the next refresh,
 /// given how many refreshes have already completed.
 ///
@@ -97,6 +113,7 @@ where
     tokio::pin!(notified);
 
     let mut completed: u64 = 0;
+    let mut last_completed: Option<tokio::time::Instant> = None;
     loop {
         // Wait for the interval to elapse OR an external wake nudge, whichever
         // comes first. A fresh `notified()` per iteration so a permit stored
@@ -111,11 +128,36 @@ where
                 () = tokio::time::sleep(delay_before_refresh(completed)) => {}
             }
         }
+        // Floor the WAKE path. The nudge is edge-triggered on a session
+        // drop, and a refresh DIALS every stored peer — so on a node whose
+        // registry holds mostly-dead peers, each refresh manufactures the
+        // drops that nudge the next one. Measured live on the M5
+        // (2026-08-04): 44,704 relay self-elections and 4,951 exhausted-gh
+        // -budget errors in a single daemon log, refresh re-entering every
+        // ~4.5s against a 60s interval, 52 enrolled peers and zero
+        // reachable — the loop starved the account registry that discovery
+        // depends on, so it could never climb out.
+        //
+        // The nudge stays (a real reconnect must not wait out 60s); it just
+        // cannot re-enter faster than this floor, which bounds the cycle at
+        // 4/min instead of unbounded. The timer path is unaffected — it
+        // already waits far longer than the floor.
+        if let Some(last) = last_completed {
+            let since = last.elapsed();
+            if since < MIN_REFRESH_SPACING {
+                tokio::select! {
+                    biased;
+                    _ = &mut notified => return,
+                    () = tokio::time::sleep(MIN_REFRESH_SPACING - since) => {}
+                }
+            }
+        }
         tokio::select! {
             biased;
             _ = &mut notified => return,
             () = refresh() => {
                 completed = completed.saturating_add(1);
+                last_completed = Some(tokio::time::Instant::now());
             }
         }
     }
@@ -130,7 +172,8 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::{
-        delay_before_refresh, run_periodic_refresh, FIRST_REFRESH_DELAY, REFRESH_INTERVAL,
+        delay_before_refresh, run_periodic_refresh, FIRST_REFRESH_DELAY, MIN_REFRESH_SPACING,
+        REFRESH_INTERVAL,
     };
 
     /// Pin the scheduling rule: a restarted daemon dials IMMEDIATELY
@@ -365,5 +408,52 @@ mod tests {
             .await
             .expect("loop must exit on shutdown")
             .expect("loop task must not panic");
+    }
+
+    /// what this catches: the live ghost measured on the M5, 2026-08-04 —
+    /// 44,704 relay self-elections and 4,951 exhausted-gh-budget errors in
+    /// one daemon log, refresh re-entering every ~4.5s against a 60s
+    /// interval. The wake nudge is fired by the session-drop observer, and
+    /// a refresh dials every stored peer, so on a registry full of dead
+    /// peers each refresh manufactures the drops that nudge the next one.
+    /// A storm of nudges must be FLOORED, or discovery starves the gh
+    /// budget it depends on and the node never finds a peer again.
+    #[tokio::test(start_paused = true)]
+    async fn a_wake_storm_cannot_refresh_faster_than_the_floor() {
+        let shutdown = Arc::new(Notify::new());
+        let wake = Arc::new(Notify::new());
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let loop_shutdown = shutdown.clone();
+        let loop_wake = wake.clone();
+        let loop_count = count.clone();
+        let handle = tokio::spawn(async move {
+            run_periodic_refresh(&loop_shutdown, &loop_wake, || {
+                let count = loop_count.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+            .await;
+        });
+
+        // 60 virtual seconds of continuous nudging — the drop-storm shape.
+        for _ in 0..600 {
+            wake.notify_one();
+            tokio::time::advance(Duration::from_millis(100)).await;
+        }
+        shutdown.notify_waiters();
+        let _ = handle.await;
+
+        // Immediate first refresh (FIRST_REFRESH_DELAY is ZERO) plus at most
+        // one per MIN_REFRESH_SPACING across the window.
+        let refreshes = count.load(Ordering::SeqCst);
+        let ceiling = 1 + (60 / MIN_REFRESH_SPACING.as_secs() as usize) + 1;
+        assert!(
+            refreshes <= ceiling,
+            "a wake storm must be floored: {refreshes} refreshes in 60s \
+             (ceiling {ceiling}). Unfloored, this re-enters as fast as the \
+             dial sweep — the 44,704-self-election ghost."
+        );
     }
 }

--- a/crates/airc-lib/src/account_identity.rs
+++ b/crates/airc-lib/src/account_identity.rs
@@ -142,3 +142,61 @@ mod tests {
         assert_ne!(before, after);
     }
 }
+
+/// What can go wrong resolving a member's identity from a home path.
+#[derive(Debug)]
+pub enum MemberIdentityError {
+    /// The machine-account store could not be opened.
+    Store(airc_store::StoreError),
+    /// No owner identity — see [`crate::mesh_identity::MeshIdentityError`].
+    /// A member CANNOT be minted without knowing whose it is: an identity
+    /// derived under a guessed owner is a member of nobody's account.
+    Owner(crate::mesh_identity::MeshIdentityError),
+}
+
+impl std::fmt::Display for MemberIdentityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Store(error) => write!(f, "member identity store: {error}"),
+            Self::Owner(error) => write!(f, "member identity owner: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for MemberIdentityError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Store(error) => Some(error),
+            Self::Owner(error) => Some(error),
+        }
+    }
+}
+
+/// Resolve the account that owns `home`'s machine and derive a member's
+/// peer identity from it.
+///
+/// This is the accessor a consumer (continuum's persona mint) calls BEFORE
+/// attaching, so it can hand the derived id to
+/// [`crate::Airc::attach_as_with_peer_id`]. The result is the same on every
+/// machine the account owns, so a persona named "asha" minted on any of them
+/// is one persona — not one per box.
+///
+/// Errors rather than falling back: a member minted under a guessed owner
+/// belongs to nobody's account and is invisible to every other machine.
+pub async fn resolve_member_peer_id(
+    home: &std::path::Path,
+    kind: MemberKind,
+    name: &str,
+) -> Result<airc_core::PeerId, MemberIdentityError> {
+    let coordinator_path = crate::airc::machine_account_home(home).join("events.sqlite");
+    let store = airc_store::SqliteEventStore::open_path(&coordinator_path)
+        .await
+        .map_err(MemberIdentityError::Store)?;
+    let owner = crate::mesh_identity::resolve(&store)
+        .await
+        .map_err(MemberIdentityError::Owner)?
+        .as_mesh_identity();
+    Ok(airc_core::PeerId::from_uuid(derive_member_id(
+        &owner, kind, name,
+    )))
+}

--- a/crates/airc-lib/src/account_identity.rs
+++ b/crates/airc-lib/src/account_identity.rs
@@ -1,13 +1,16 @@
-//! Grid identities derive from the OWNER, never from the machine.
+//! Account members derive their identity from the ACCOUNT, never from the
+//! machine.
 //!
 //! Joel, 2026-08-04: *"All derive from my gh user. Not computer."*
 //!
-//! A citizen of a grid — a named persona, an agent session — is the same
-//! citizen on every machine that owner runs. So its identity must be a
-//! function of `(owner, kind, name)` and nothing else. The moment a
-//! machine fact enters the derivation, the "same" persona on two boxes
-//! becomes two beings that cannot recognise each other, and the grid is
-//! a set of islands wearing matching name tags.
+//! This is the ordinary account model every messaging system has used
+//! for a decade: ONE account, N machines, the same rooms and the same
+//! members on all of them. A member — a named persona, an agent session —
+//! is the same member on every machine the account owns, so its identity
+//! must be a function of `(owner, kind, name)` and nothing else. The
+//! moment a machine fact enters the derivation, the "same" persona on two
+//! boxes becomes two strangers, and adding a machine silently duplicates
+//! every member on it.
 //!
 //! This is the same primitive [`crate::subscriptions::derive_room_id`]
 //! uses for rooms, generalised: a UUIDv5 over
@@ -28,28 +31,28 @@ use uuid::Uuid;
 
 use crate::subscriptions::MeshIdentity;
 
-/// Namespace UUID for owner-derived grid identities. Distinct from the
-/// subscriptions namespace so a room and a citizen can never collide
+/// Namespace UUID for owner-derived member identities. Distinct from the
+/// subscriptions namespace so a room and a member can never collide
 /// even if every other input matched.
-const GRID_IDENTITY_NAMESPACE: Uuid = Uuid::from_bytes([
+const ACCOUNT_MEMBER_NAMESPACE: Uuid = Uuid::from_bytes([
     0xa1, 0xc2, 0x00, 0x02, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 ]);
 
-/// What kind of citizen an identity names. The discriminant is part of
+/// What kind of member an identity names. The discriminant is part of
 /// the derivation, so a persona and an agent session that happen to
 /// share a name are still distinct identities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CitizenKind {
-    /// A named persona — a continuing being of the owner's grid, the
-    /// same citizen on whichever machine currently hosts it.
+pub enum MemberKind {
+    /// A named persona — a continuing being of the account, the same
+    /// member on whichever machine currently hosts it.
     Persona,
     /// An agent working session (a Claude tab, a headless solver). Bound
-    /// to the owner like any citizen, but named per working context
+    /// to the account like any member, but named per working context
     /// rather than being a continuing self.
     Agent,
 }
 
-impl CitizenKind {
+impl MemberKind {
     /// Stable wire/derivation token. Changing one of these strings
     /// re-derives every identity of that kind — treat as frozen.
     pub fn as_str(self) -> &'static str {
@@ -60,13 +63,13 @@ impl CitizenKind {
     }
 }
 
-/// Derive a citizen's identity from `(owner, kind, name)`.
+/// Derive a member's identity from `(owner, kind, name)`.
 ///
-/// The ONLY inputs are owner facts and the citizen's own name. No
+/// The ONLY inputs are owner facts and the member's own name. No
 /// hostname, no username, no per-install id, no clock — so every machine
 /// the owner runs computes the same answer, offline, with no
 /// coordination.
-pub fn derive_citizen_id(owner: &MeshIdentity, kind: CitizenKind, name: &str) -> Uuid {
+pub fn derive_member_id(owner: &MeshIdentity, kind: MemberKind, name: &str) -> Uuid {
     let kind = kind.as_str();
     let owner = owner.as_str();
     let mut bytes = Vec::with_capacity(kind.len() + owner.len() + name.len() + 2);
@@ -77,7 +80,7 @@ pub fn derive_citizen_id(owner: &MeshIdentity, kind: CitizenKind, name: &str) ->
     bytes.extend_from_slice(owner.as_bytes());
     bytes.push(0);
     bytes.extend_from_slice(name.as_bytes());
-    Uuid::new_v5(&GRID_IDENTITY_NAMESPACE, &bytes)
+    Uuid::new_v5(&ACCOUNT_MEMBER_NAMESPACE, &bytes)
 }
 
 #[cfg(test)]
@@ -90,32 +93,32 @@ mod tests {
 
     /// what this catches: the whole point. A persona's identity must be
     /// reproducible from owner + name alone, so the M5 and the 5090
-    /// independently compute the SAME id for the same citizen with no
+    /// independently compute the SAME id for the same member with no
     /// coordination. Any machine input in the derivation breaks this and
     /// turns one persona into two strangers.
     #[test]
-    fn a_citizen_id_is_reproducible_from_owner_and_name_alone() {
-        let a = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
-        let b = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
-        assert_eq!(a, b, "same owner + name must derive the same citizen");
+    fn a_member_id_is_reproducible_from_owner_and_name_alone() {
+        let a = derive_member_id(&owner("joelteply"), MemberKind::Persona, "asha");
+        let b = derive_member_id(&owner("joelteply"), MemberKind::Persona, "asha");
+        assert_eq!(a, b, "same owner + name must derive the same member");
     }
 
     /// what this catches: cross-owner collision. Two different humans may
     /// each name a persona "asha"; they are different beings on different
     /// grids and must never share an id.
     #[test]
-    fn different_owners_never_share_a_citizen() {
-        let mine = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
-        let theirs = derive_citizen_id(&owner("someone-else"), CitizenKind::Persona, "asha");
+    fn different_owners_never_share_a_member() {
+        let mine = derive_member_id(&owner("joelteply"), MemberKind::Persona, "asha");
+        let theirs = derive_member_id(&owner("someone-else"), MemberKind::Persona, "asha");
         assert_ne!(mine, theirs);
     }
 
     /// what this catches: cross-kind collision. A persona named "benchy"
-    /// and an agent session named "benchy" are not the same citizen.
+    /// and an agent session named "benchy" are not the same member.
     #[test]
     fn kind_is_part_of_the_identity() {
-        let persona = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "benchy");
-        let agent = derive_citizen_id(&owner("joelteply"), CitizenKind::Agent, "benchy");
+        let persona = derive_member_id(&owner("joelteply"), MemberKind::Persona, "benchy");
+        let agent = derive_member_id(&owner("joelteply"), MemberKind::Agent, "benchy");
         assert_ne!(persona, agent);
     }
 
@@ -123,8 +126,8 @@ mod tests {
     /// concatenation lets one (owner, name) pair impersonate another.
     #[test]
     fn nul_separators_prevent_boundary_collisions() {
-        let a = derive_citizen_id(&owner("joel"), CitizenKind::Persona, "a-b");
-        let b = derive_citizen_id(&owner("joel-a"), CitizenKind::Persona, "b");
+        let a = derive_member_id(&owner("joel"), MemberKind::Persona, "a-b");
+        let b = derive_member_id(&owner("joel-a"), MemberKind::Persona, "b");
         assert_ne!(a, b);
     }
 
@@ -133,9 +136,9 @@ mod tests {
     /// rename must carry it explicitly rather than assume derivation
     /// preserves it.
     #[test]
-    fn renaming_a_citizen_derives_a_different_identity() {
-        let before = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
-        let after = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha-2");
+    fn renaming_a_member_derives_a_different_identity() {
+        let before = derive_member_id(&owner("joelteply"), MemberKind::Persona, "asha");
+        let after = derive_member_id(&owner("joelteply"), MemberKind::Persona, "asha-2");
         assert_ne!(before, after);
     }
 }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1799,6 +1799,42 @@ impl Airc {
         self.ensure_join_context(context).await
     }
 
+    /// Self-healing join — PERIODIC mesh-identity reconcile.
+    ///
+    /// [`SubscriptionSet::rebind_diverged`] is the correct heal for a
+    /// scope whose stored room UUIDs were derived under a mesh identity
+    /// that has since healed (the machine booted before `gh` could
+    /// answer, minted the provisional `local:<host>:<user>` identity,
+    /// derived every room UUID under it, and later re-resolved to the
+    /// canonical login). Until now that heal only ran on the JOIN path,
+    /// so the scope kept reading its diverged rooms until a human typed
+    /// `airc stop && airc join` — the manual ritual this substrate is
+    /// supposed to make unnecessary. The daemon calls this every
+    /// route-refresh tick so the reconvergence is autonomous.
+    ///
+    /// Idempotent and free in the steady state: the identity read is
+    /// cached, a converged set yields zero rebinds, and the store write
+    /// plus presence re-publish happen ONLY when something actually
+    /// moved — a tick on a healthy scope touches no durable state.
+    pub async fn reconcile_subscription_identity(
+        &self,
+    ) -> Result<Vec<subscriptions::SubscriptionRebind>, AircError> {
+        let identity = self.mesh_identity().await?;
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
+        let rebinds = set.rebind_diverged(&identity);
+        if rebinds.is_empty() {
+            return Ok(rebinds);
+        }
+        warn_subscription_rebinds(&rebinds);
+        subscriptions::save(self.event_store(), &set).await?;
+        // Re-beacon under the converged UUIDs: peers resolve routes from
+        // beacons, so a rebind that is not re-published leaves the scope
+        // reading the right room while the mesh still advertises the
+        // dead one.
+        self.publish_presence(&identity, &set).await?;
+        Ok(rebinds)
+    }
+
     /// Subscribe to every channel in `context`, set its default, and
     /// start local subscribers for the resulting wires.
     ///

--- a/crates/airc-lib/src/grid_identity.rs
+++ b/crates/airc-lib/src/grid_identity.rs
@@ -1,0 +1,141 @@
+//! Grid identities derive from the OWNER, never from the machine.
+//!
+//! Joel, 2026-08-04: *"All derive from my gh user. Not computer."*
+//!
+//! A citizen of a grid — a named persona, an agent session — is the same
+//! citizen on every machine that owner runs. So its identity must be a
+//! function of `(owner, kind, name)` and nothing else. The moment a
+//! machine fact enters the derivation, the "same" persona on two boxes
+//! becomes two beings that cannot recognise each other, and the grid is
+//! a set of islands wearing matching name tags.
+//!
+//! This is the same primitive [`crate::subscriptions::derive_room_id`]
+//! uses for rooms, generalised: a UUIDv5 over
+//! `kind ‖ NUL ‖ owner ‖ NUL ‖ name`. Deterministic, offline-computable
+//! by any node, and collision-free across owners (two people may both
+//! name a persona "asha" and never collide) and across kinds (the
+//! persona "asha" and an agent session named "asha" are distinct).
+//!
+//! ## What this is NOT
+//!
+//! It is not a credential. The Ed25519 keypair in `airc-identity` stays
+//! exactly where it is: it proves a *process is entitled to act as* an
+//! identity. This module answers "who is this?", not "may you?". Those
+//! are different questions and conflating them is how a per-install
+//! random `peer_id` ended up standing in for a persona's whole selfhood.
+
+use uuid::Uuid;
+
+use crate::subscriptions::MeshIdentity;
+
+/// Namespace UUID for owner-derived grid identities. Distinct from the
+/// subscriptions namespace so a room and a citizen can never collide
+/// even if every other input matched.
+const GRID_IDENTITY_NAMESPACE: Uuid = Uuid::from_bytes([
+    0xa1, 0xc2, 0x00, 0x02, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+]);
+
+/// What kind of citizen an identity names. The discriminant is part of
+/// the derivation, so a persona and an agent session that happen to
+/// share a name are still distinct identities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CitizenKind {
+    /// A named persona — a continuing being of the owner's grid, the
+    /// same citizen on whichever machine currently hosts it.
+    Persona,
+    /// An agent working session (a Claude tab, a headless solver). Bound
+    /// to the owner like any citizen, but named per working context
+    /// rather than being a continuing self.
+    Agent,
+}
+
+impl CitizenKind {
+    /// Stable wire/derivation token. Changing one of these strings
+    /// re-derives every identity of that kind — treat as frozen.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Persona => "persona",
+            Self::Agent => "agent",
+        }
+    }
+}
+
+/// Derive a citizen's identity from `(owner, kind, name)`.
+///
+/// The ONLY inputs are owner facts and the citizen's own name. No
+/// hostname, no username, no per-install id, no clock — so every machine
+/// the owner runs computes the same answer, offline, with no
+/// coordination.
+pub fn derive_citizen_id(owner: &MeshIdentity, kind: CitizenKind, name: &str) -> Uuid {
+    let kind = kind.as_str();
+    let owner = owner.as_str();
+    let mut bytes = Vec::with_capacity(kind.len() + owner.len() + name.len() + 2);
+    bytes.extend_from_slice(kind.as_bytes());
+    // NUL separators so ("persona", "joel", "a-b") and ("persona",
+    // "joel-a", "b") can never collide.
+    bytes.push(0);
+    bytes.extend_from_slice(owner.as_bytes());
+    bytes.push(0);
+    bytes.extend_from_slice(name.as_bytes());
+    Uuid::new_v5(&GRID_IDENTITY_NAMESPACE, &bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owner(login: &str) -> MeshIdentity {
+        MeshIdentity::new(login)
+    }
+
+    /// what this catches: the whole point. A persona's identity must be
+    /// reproducible from owner + name alone, so the M5 and the 5090
+    /// independently compute the SAME id for the same citizen with no
+    /// coordination. Any machine input in the derivation breaks this and
+    /// turns one persona into two strangers.
+    #[test]
+    fn a_citizen_id_is_reproducible_from_owner_and_name_alone() {
+        let a = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
+        let b = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
+        assert_eq!(a, b, "same owner + name must derive the same citizen");
+    }
+
+    /// what this catches: cross-owner collision. Two different humans may
+    /// each name a persona "asha"; they are different beings on different
+    /// grids and must never share an id.
+    #[test]
+    fn different_owners_never_share_a_citizen() {
+        let mine = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
+        let theirs = derive_citizen_id(&owner("someone-else"), CitizenKind::Persona, "asha");
+        assert_ne!(mine, theirs);
+    }
+
+    /// what this catches: cross-kind collision. A persona named "benchy"
+    /// and an agent session named "benchy" are not the same citizen.
+    #[test]
+    fn kind_is_part_of_the_identity() {
+        let persona = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "benchy");
+        let agent = derive_citizen_id(&owner("joelteply"), CitizenKind::Agent, "benchy");
+        assert_ne!(persona, agent);
+    }
+
+    /// what this catches: separator smuggling. Without NUL separators,
+    /// concatenation lets one (owner, name) pair impersonate another.
+    #[test]
+    fn nul_separators_prevent_boundary_collisions() {
+        let a = derive_citizen_id(&owner("joel"), CitizenKind::Persona, "a-b");
+        let b = derive_citizen_id(&owner("joel-a"), CitizenKind::Persona, "b");
+        assert_ne!(a, b);
+    }
+
+    /// what this catches: a rename is a NEW identity, not a silent
+    /// re-pointing of the old one. Callers that want continuity across a
+    /// rename must carry it explicitly rather than assume derivation
+    /// preserves it.
+    #[test]
+    fn renaming_a_citizen_derives_a_different_identity() {
+        let before = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha");
+        let after = derive_citizen_id(&owner("joelteply"), CitizenKind::Persona, "asha-2");
+        assert_ne!(before, after);
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -50,6 +50,7 @@ pub mod error;
 pub mod external_identity;
 pub mod gh;
 pub mod grid_auth;
+pub mod grid_identity;
 pub mod join_context;
 mod lan;
 pub mod lane_coordination;

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -34,6 +34,7 @@
 
 #![deny(unsafe_code)]
 
+pub mod account_identity;
 pub mod account_registry;
 pub mod account_registry_fs;
 pub mod adapter;
@@ -50,7 +51,6 @@ pub mod error;
 pub mod external_identity;
 pub mod gh;
 pub mod grid_auth;
-pub mod grid_identity;
 pub mod join_context;
 mod lan;
 pub mod lane_coordination;

--- a/crates/airc-lib/src/mesh_identity.rs
+++ b/crates/airc-lib/src/mesh_identity.rs
@@ -7,31 +7,42 @@
 //! which is fine for tests but collides every user's `#general` onto
 //! the same `RoomId` — a privacy bug.
 //!
-//! ## Resolution order
+//! ## THE OWNER'S GITHUB LOGIN IS THE KEY. There is no substitute.
 //!
-//! 1. **Cached value** in the `mesh_identity` ORM table, if fresh
-//!    (`resolved_at_ms` within [`DEFAULT_TTL_MS`]).
-//! 2. **`gh api user --jq .login`** — the canonical GitHub identity
-//!    when `gh` is installed and authenticated.
-//! 3. **`git config user.email`** fallback when `gh` isn't available.
-//! 4. **`local:<host>:<user>`** last-resort deterministic local
-//!    identity. Warned in a side-channel (callers can read it from
-//!    the persisted [`Source`] field) so the operator knows the
-//!    machine couldn't authenticate against GitHub.
+//! This identity is the **human owner's** — one login across every
+//! machine they own. It is NOT a persona identity and NOT an agent
+//! identity: those are separate identities that live *inside* the
+//! owner's grid (peer ids, persona ids) and never namespace a room.
 //!
-//! ## One identity per machine (provisional sources self-heal)
+//! A machine cannot know who its human is by looking at itself. So the
+//! resolution order is short, and it does not end in a guess:
 //!
-//! Only `gh_api_user` (and an explicit `operator` override) are
-//! *sticky*. `git_email` and `local_host_user` are **provisional** —
-//! they're used only because `gh` was unreachable at resolve time and
-//! they do NOT converge across a user's scopes/machines. So a
-//! provisional value never sticks: every resolve re-probes `gh` and
-//! overwrites it the instant `gh` answers. This self-heals a scope that
-//! forked onto `git config user.email` during a brief `gh` outage —
-//! e.g. one tab resolving `joelteply` via gh and another
-//! `joelteply@yahoo.com` via git, which silently splits the account
-//! into two `RoomId`s (two `#general`s) — instead of stranding it for
-//! `DEFAULT_TTL_MS`.
+//! 1. **`AIRC_MESH_IDENTITY`** — the owner stating their own login
+//!    explicitly (offline boxes, CI, containers). Persisted as
+//!    `operator`; sticky forever.
+//! 2. **Cached `gh_api_user`**, if fresh (within [`DEFAULT_TTL_MS`]).
+//! 3. **`gh api user --jq .login`**.
+//! 4. **A stale cached `gh_api_user`** when gh is unreachable — a stale
+//!    copy of the key is still the key; the owner's login does not
+//!    change because the network did.
+//! 5. Otherwise **[`MeshIdentityError::Unresolved`]**. Loud, no key, no
+//!    rooms.
+//!
+//! ## Why there is no fallback
+//!
+//! Room UUIDs are `UUIDv5(mesh_identity ‖ NUL ‖ channel_name)`. Any
+//! value that is not the owner's login therefore mints a PRIVATE
+//! namespace that only this machine can see: it publishes beacons the
+//! account never reads, reads a room nobody writes, and reports a
+//! healthy join throughout. That is how a node forms its own island.
+//!
+//! The old chain fell back to `git config user.email`, then to a
+//! fabricated `local:<host>:<user>`. Both are machine facts, not owner
+//! facts, and both did exactly that — bigmama's `#general` derived under
+//! `local:unknown-host:unknown-user` while the M5 derived under the gh
+//! login, so every frame between them died as `unknown_channel` with no
+//! error anywhere. Guessing the owner's identity is never better than
+//! saying "I don't know who my owner is yet".
 //!
 //! ## Caching
 //!
@@ -109,6 +120,11 @@ pub enum MeshIdentityError {
     Store(airc_store::StoreError),
     Clock(std::time::SystemTimeError),
     UnknownSource(String),
+    /// No owner identity, and none may be invented. `gh` cannot answer and
+    /// nothing usable is cached. Deriving rooms from a machine-local guess
+    /// would put this node on a private mesh only it can see, so the caller
+    /// gets an error instead of a silent island.
+    Unresolved,
 }
 
 impl std::fmt::Display for MeshIdentityError {
@@ -117,6 +133,13 @@ impl std::fmt::Display for MeshIdentityError {
             Self::Store(error) => write!(f, "mesh identity store: {error}"),
             Self::Clock(error) => write!(f, "mesh identity clock: {error}"),
             Self::UnknownSource(source) => write!(f, "unknown mesh identity source: {source}"),
+            Self::Unresolved => write!(
+                f,
+                "no owner identity: `gh api user` could not answer and no gh login is \
+                 cached. airc will not invent one — a guessed identity derives room UUIDs \
+                 only this machine can see. Fix with `gh auth login`, or state the owner \
+                 login explicitly via AIRC_MESH_IDENTITY=<github-login>"
+            ),
         }
     }
 }
@@ -126,7 +149,7 @@ impl std::error::Error for MeshIdentityError {
         match self {
             Self::Store(error) => Some(error),
             Self::Clock(error) => Some(error),
-            Self::UnknownSource(_) => None,
+            Self::UnknownSource(_) | Self::Unresolved => None,
         }
     }
 }
@@ -143,18 +166,19 @@ impl From<std::time::SystemTimeError> for MeshIdentityError {
     }
 }
 
-/// Resolve via the default fallback chain (gh → git email → local
-/// hostname/user) and persist. Most callers want this.
+/// Resolve the owner's identity (`AIRC_MESH_IDENTITY` → `gh api user`)
+/// and persist. Most callers want this. Errors rather than inventing an
+/// identity — see the module docs.
 pub async fn resolve(store: &dyn EventStore) -> Result<CachedIdentity, MeshIdentityError> {
     resolve_with(store, default_resolver, now_ms()?).await
 }
 
 /// Resolve with an injected resolver closure. The closure returns
-/// `Some((identity, source))` on success, `None` if it has nothing
-/// to contribute and the LocalHostUser fallback should be used.
+/// `Some((identity, source))` when it can name the OWNER, `None` when it
+/// cannot — and `None` is terminal unless a usable gh login is cached.
 ///
-/// Used by tests to bypass `gh` / `git` shell-outs and by production
-/// callers via [`resolve`].
+/// Used by tests to bypass the `gh` shell-out, and by production callers
+/// via [`resolve`].
 pub async fn resolve_with<F>(
     store: &dyn EventStore,
     resolver: F,
@@ -164,46 +188,52 @@ where
     F: FnOnce() -> Option<(String, Source)>,
 {
     if let Some(cached) = load_cached(store).await? {
-        // Operator caches are explicit overrides (env var, CLI override,
-        // test seed) — trusted as-is, never expire, never re-resolved.
-        // Treating them as TTL-bounded forces a fall-through to gh/git
-        // shell-outs the operator was trying to avoid (Windows CI runners
-        // hung on the gh shell-out when a tiny seeded `resolved_at_ms`
-        // made is_expired return true on every call).
+        // The owner stated their own login (`AIRC_MESH_IDENTITY`, test seed).
+        // Trusted as-is, never expires, never re-probed — treating it as
+        // TTL-bounded would force the gh shell-out the operator was avoiding
+        // (Windows CI runners hung on it when a tiny seeded `resolved_at_ms`
+        // made is_expired return true every call).
         if cached.source == Source::Operator {
             return Ok(cached);
         }
-        // `GhApiUser` is the canonical, machine-wide identity. Honor it
-        // while fresh; only re-probe once the TTL lapses.
+        // A fresh gh login is the key. Use it without re-probing.
         if cached.source == Source::GhApiUser && !cached.is_expired(now_ms) {
             return Ok(cached);
         }
-        // `GitEmail` / `LocalHostUser` are PROVISIONAL (or this is an
-        // expired `GhApiUser`): re-probe and, the instant `gh` answers,
-        // overwrite with the canonical login. This enforces one identity
-        // per machine — a scope that forked onto `git config user.email`
-        // during a brief `gh` outage self-heals instead of stranding the
-        // account in a second room. See the module docs.
         match resolver() {
-            Some((identity, Source::GhApiUser)) => {
-                let entry = persisted_entry(identity, Source::GhApiUser, now_ms);
+            Some((identity, source)) => {
+                let entry = persisted_entry(identity, source, now_ms);
                 save(store, &entry).await?;
-                return Ok(entry);
+                Ok(entry)
             }
-            // gh still unreachable — keep the existing value rather than
-            // churning it for an equally-non-canonical one (stability
-            // until gh returns; never downgrade a cached value to local).
-            _ => return Ok(cached),
+            None if cached.source == Source::GhApiUser => {
+                // Expired and gh is unreachable right now. A STALE COPY OF THE
+                // KEY IS STILL THE KEY — the owner's login did not change
+                // because the network did. Erroring here would take a
+                // converged machine off its own mesh over a transient outage.
+                Ok(cached)
+            }
+            None => {
+                // A legacy `git_email` / `local_host_user` row, minted before
+                // this machine could authenticate. That is a machine fact, not
+                // the owner's login: every room UUID derived from it belongs to
+                // a namespace only this machine can see. Refuse it.
+                Err(MeshIdentityError::Unresolved)
+            }
+        }
+    } else {
+        // No cache. The key comes from the owner or from gh — never from this
+        // box's hostname. A machine cannot know who its human is by looking at
+        // itself, and a guess is what mints the island.
+        match resolver() {
+            Some((identity, source)) => {
+                let entry = persisted_entry(identity, source, now_ms);
+                save(store, &entry).await?;
+                Ok(entry)
+            }
+            None => Err(MeshIdentityError::Unresolved),
         }
     }
-
-    // No cache yet: resolve fresh, falling back to a deterministic
-    // machine-local identity if neither gh nor git can answer.
-    let (identity, source) =
-        resolver().unwrap_or_else(|| (local_fallback_identity(), Source::LocalHostUser));
-    let entry = persisted_entry(identity, source, now_ms);
-    save(store, &entry).await?;
-    Ok(entry)
 }
 
 /// Build a cache entry with the standard version + TTL. Centralizes the
@@ -292,21 +322,29 @@ impl TryFrom<StoredMeshIdentity> for CachedIdentity {
 }
 
 /// Default resolver: `gh api user --jq .login` then `git config
-/// user.email`. Returns `None` if neither succeeds — caller falls
-/// back to `LocalHostUser`.
+/// login stated by the owner. Returns `None` when neither can name the
+/// owner — and `None` means unresolved, never a fabricated identity.
 fn default_resolver() -> Option<(String, Source)> {
+    // The owner naming their own login wins: the escape hatch for a box with
+    // no gh (offline, container, CI) that still belongs to a real account.
+    if let Ok(pinned) = std::env::var(OWNER_IDENTITY_ENV) {
+        let pinned = pinned.trim();
+        if !pinned.is_empty() {
+            return Some((pinned.to_string(), Source::Operator));
+        }
+    }
     if let Some(login) = run_command(&["gh", "api", "user", "--jq", ".login"]) {
         if !login.is_empty() {
             return Some((login, Source::GhApiUser));
         }
     }
-    if let Some(email) = run_command(&["git", "config", "user.email"]) {
-        if !email.is_empty() {
-            return Some((email, Source::GitEmail));
-        }
-    }
     None
 }
+
+/// Env var by which the owner states their own GitHub login when `gh` is not
+/// available on this box. The ONLY substitute for the gh probe, because it is
+/// the owner speaking rather than the machine guessing.
+pub const OWNER_IDENTITY_ENV: &str = "AIRC_MESH_IDENTITY";
 
 /// Default deadline for resolver shell-outs (gh, git). Bounds
 /// `gh api user` / `git config user.email` so a hung or slow
@@ -354,24 +392,6 @@ fn run_command(argv: &[&str]) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-/// Last-resort identity: `local:<host>:<user>`. Deterministic per
-/// machine+user but does NOT converge across machines or with the
-/// operator's `gh` identity — the operator should know about this.
-///
-/// Cross-platform: on Windows the POSIX probes ALL fail (`HOSTNAME`
-/// and `USER`/`LOGNAME` env vars don't exist; `hostname -s` is
-/// rejected by Windows hostname.exe), which used to collapse every
-/// Windows machine onto the SAME degenerate
-/// `local:unknown-host:unknown-user` identity — the exact fingerprint
-/// of the M5↔bigmama blind-room bug (bigmama's `#general` derived to
-/// `eef18336-…` under that identity while M5 derived `5eedf7b1-…`
-/// under the gh login, so every room frame between them died as
-/// `unknown_channel`). `COMPUTERNAME`/`USERNAME` are the Windows
-/// equivalents; bare `hostname` (no flag) works on every platform.
-fn local_fallback_identity() -> String {
-    local_fallback_identity_with(&|name| std::env::var(name).ok(), &run_command, &machine_id)
-}
-
 /// The machine-account airc home (`~/.airc`) — shared by EVERY scope on
 /// this machine, so [`machine_id`] resolves to one value per machine
 /// rather than per project scope (which would re-fragment the mesh). Not
@@ -405,47 +425,6 @@ pub(crate) fn machine_id() -> String {
         return fresh;
     }
     Uuid::new_v4().simple().to_string()
-}
-
-/// Injectable core of [`local_fallback_identity`] — env, command, and
-/// machine-id lookups passed in so tests can pin the per-platform
-/// fallback chain without mutating process globals or the real home.
-fn local_fallback_identity_with(
-    env: &dyn Fn(&str) -> Option<String>,
-    run: &dyn Fn(&[&str]) -> Option<String>,
-    machine_id: &dyn Fn() -> String,
-) -> String {
-    let non_empty = |value: Option<String>| value.filter(|v| !v.trim().is_empty());
-    let host = non_empty(env("HOSTNAME"))
-        .or_else(|| non_empty(env("COMPUTERNAME"))) // Windows
-        .or_else(|| non_empty(run(&["hostname", "-s"])))
-        .or_else(|| non_empty(run(&["hostname"]))); // Windows hostname.exe rejects -s
-    let user = non_empty(env("USER"))
-        .or_else(|| non_empty(env("LOGNAME")))
-        .or_else(|| non_empty(env("USERNAME"))); // Windows
-
-    match (host, user) {
-        (Some(host), Some(user)) => format!("local:{host}:{user}"),
-        (host, user) => {
-            // Total/partial probe failure: NEVER emit the colliding
-            // `local:unknown-host:unknown-user` fingerprint that collapses
-            // every such machine onto ONE identity (the M5<->bigmama
-            // blind-room root cause — divergent `#general` UUIDs, so every
-            // frame between them died as `unknown_channel`). Anchor the
-            // degraded identity to the stable machine-id so it stays
-            // DISTINCT across machines, and shout so it is never silent.
-            let mid = machine_id();
-            let short = &mid[..mid.len().min(12)];
-            let host = host.unwrap_or_else(|| format!("machine-{short}"));
-            let user = user.unwrap_or_else(|| format!("machine-{short}"));
-            eprintln!(
-                "airc: WARN mesh identity: host/user probe failed; using stable machine-id \
-                 fallback `local:{host}:{user}` (distinct per machine, self-heals to your gh \
-                 login once reachable). Fix gh auth / hostname resolution to converge rooms."
-            );
-            format!("local:{host}:{user}")
-        }
-    }
 }
 
 fn now_ms() -> Result<u64, std::time::SystemTimeError> {
@@ -500,20 +479,23 @@ mod tests {
         assert_eq!(entry.identity, "bob");
     }
 
+    /// what this catches: the island generator. A machine that cannot name
+    /// its OWNER must not invent an identity — every room UUID derived from a
+    /// fabricated one lands in a namespace only this machine can see, which is
+    /// how a node silently forms its own mesh while reporting a healthy join.
+    /// Unresolved is loud and terminal; nothing is persisted.
     #[tokio::test]
-    async fn resolve_falls_back_to_local_when_resolver_yields_none() {
+    async fn resolve_errors_rather_than_inventing_an_owner_identity() {
         let store = InMemoryEventStore::new();
-        let entry = resolve_with(&store, mock_none, 1_000).await.unwrap();
-        assert_eq!(entry.source, Source::LocalHostUser);
-        assert!(entry.identity.starts_with("local:"));
-        // Fallback is the SAME on a given machine — second resolve
-        // (fresh cache) returns the cached fallback value too.
-        let entry2 = resolve_with(&store, mock_none, 1_100).await.unwrap();
-        assert_eq!(entry2.identity, entry.identity);
-    }
-
-    fn mock_git_email(value: &'static str) -> impl FnOnce() -> Option<(String, Source)> {
-        move || Some((value.to_string(), Source::GitEmail))
+        let error = resolve_with(&store, mock_none, 1_000)
+            .await
+            .expect_err("no owner identity must not resolve");
+        assert!(matches!(error, MeshIdentityError::Unresolved));
+        assert!(
+            load_cached(&store).await.unwrap().is_none(),
+            "a failed resolve must persist NOTHING — a stored guess would \
+             outlive the outage and keep deriving private rooms"
+        );
     }
 
     #[tokio::test]
@@ -545,8 +527,13 @@ mod tests {
         assert_eq!(reloaded.source, Source::GhApiUser);
     }
 
+    /// what this catches: a legacy row minted before this machine could
+    /// authenticate (`git_email` / `local_host_user`) is a MACHINE fact, not
+    /// the owner's login. Keeping it "for stability" is what stranded bigmama
+    /// on her own `#general`. With gh still unreachable it must be refused,
+    /// not reused.
     #[tokio::test]
-    async fn provisional_git_email_retained_when_gh_still_unavailable() {
+    async fn legacy_provisional_row_is_refused_when_gh_unavailable() {
         let store = InMemoryEventStore::new();
         save(
             &store,
@@ -560,16 +547,27 @@ mod tests {
         )
         .await
         .unwrap();
-        // gh still unreachable (resolver yields None): keep the provisional
-        // value — do NOT churn it down to a machine-local fallback.
-        let entry = resolve_with(&store, mock_none, 1_500).await.unwrap();
-        assert_eq!(entry.identity, "joelteply@yahoo.com");
-        assert_eq!(entry.source, Source::GitEmail);
-        // A non-canonical git resolver also must not displace the cache.
-        let entry2 = resolve_with(&store, mock_git_email("other@x.com"), 1_600)
+        let error = resolve_with(&store, mock_none, 1_500)
+            .await
+            .expect_err("a machine-fact identity is not the owner's key");
+        assert!(matches!(error, MeshIdentityError::Unresolved));
+    }
+
+    /// what this catches: the opposite mistake. A machine that HAS the key and
+    /// merely went offline must keep using it — a stale copy of the owner's
+    /// login is still the owner's login, and erroring here would drop a
+    /// converged machine off its own mesh over a transient gh outage.
+    #[tokio::test]
+    async fn expired_gh_login_survives_an_unreachable_gh() {
+        let store = InMemoryEventStore::new();
+        resolve_with(&store, mock_gh("joelteply"), 1_000)
             .await
             .unwrap();
-        assert_eq!(entry2.identity, "joelteply@yahoo.com");
+        let entry = resolve_with(&store, mock_none, 1_000 + DEFAULT_TTL_MS + 1)
+            .await
+            .expect("a cached gh login must survive an outage");
+        assert_eq!(entry.identity, "joelteply");
+        assert_eq!(entry.source, Source::GhApiUser);
     }
 
     #[tokio::test]
@@ -659,87 +657,5 @@ mod tests {
         save(&store, &entry).await.unwrap();
         let loaded = load_cached(&store).await.unwrap().unwrap();
         assert_eq!(loaded, entry);
-    }
-
-    /// what this catches (M5↔bigmama blind room, root cause): on
-    /// Windows the POSIX env probes all miss, and the old chain
-    /// collapsed to `local:unknown-host:unknown-user` — the SAME
-    /// degenerate identity on every Windows box, silently forking room
-    /// UUID derivation from the account identity. The fallback must
-    /// consult the Windows equivalents before giving up.
-    #[test]
-    fn local_fallback_uses_windows_env_names() {
-        let windows_env = |name: &str| match name {
-            "COMPUTERNAME" => Some("BigMama".to_string()),
-            "USERNAME" => Some("joelt".to_string()),
-            _ => None,
-        };
-        // Windows hostname.exe: `-s` fails (non-zero exit → None),
-        // bare `hostname` would answer — but env wins first.
-        let no_command = |_argv: &[&str]| None;
-        let mid = || "test-machine-id".to_string();
-        assert_eq!(
-            local_fallback_identity_with(&windows_env, &no_command, &mid),
-            "local:BigMama:joelt"
-        );
-    }
-
-    /// what this catches: `hostname -s` failing (Windows) must fall
-    /// through to bare `hostname`, and empty/whitespace probe output
-    /// must not be accepted as a host or user component.
-    #[test]
-    fn local_fallback_hostname_flag_fallthrough_and_empty_rejection() {
-        let empty_env = |name: &str| match name {
-            // Empty values are as bad as missing — never accept them.
-            "HOSTNAME" => Some("   ".to_string()),
-            "USERNAME" => Some("joelt".to_string()),
-            _ => None,
-        };
-        let windows_hostname = |argv: &[&str]| match argv {
-            ["hostname"] => Some("BigMama".to_string()),
-            _ => None, // `hostname -s` → non-zero exit on Windows
-        };
-        let mid = || "test-machine-id".to_string();
-        assert_eq!(
-            local_fallback_identity_with(&empty_env, &windows_hostname, &mid),
-            "local:BigMama:joelt"
-        );
-    }
-
-    /// what this catches (regression for the M5↔bigmama blind-room bug):
-    /// when EVERY host/user probe fails (bare daemon process — no env, no
-    /// hostname), the fallback must NOT emit the colliding
-    /// `local:unknown-host:unknown-user` fingerprint that collapses every
-    /// such machine onto one identity. It must anchor to the stable
-    /// machine-id so two probe-blind machines get DISTINCT identities.
-    #[test]
-    fn local_fallback_uses_machine_id_when_all_probes_fail() {
-        let no_env = |_name: &str| None;
-        let no_command = |_argv: &[&str]| None;
-        let id_a = || "aaaaaaaabbbbccccdddd".to_string();
-        let id_b = || "1111111122223333eeee".to_string();
-
-        let a = local_fallback_identity_with(&no_env, &no_command, &id_a);
-        let b = local_fallback_identity_with(&no_env, &no_command, &id_b);
-
-        assert!(
-            !a.contains("unknown-host") && !a.contains("unknown-user"),
-            "must never emit the colliding sentinel identity, got {a}"
-        );
-        assert_ne!(
-            a, b,
-            "two machines with distinct machine-ids must NOT collide"
-        );
-        assert_eq!(a, "local:machine-aaaaaaaabbbb:machine-aaaaaaaabbbb");
-    }
-
-    #[test]
-    fn local_fallback_is_deterministic_for_same_env() {
-        // Without setting env, fallback should at least be a stable
-        // string for the duration of the test process.
-        let a = local_fallback_identity();
-        let b = local_fallback_identity();
-        assert_eq!(a, b);
-        assert!(a.starts_with("local:"));
     }
 }

--- a/crates/airc-lib/tests/identity_heal_reconcile.rs
+++ b/crates/airc-lib/tests/identity_heal_reconcile.rs
@@ -1,0 +1,129 @@
+//! `Airc::reconcile_subscription_identity` — the AUTONOMOUS half of the
+//! self-healing join.
+//!
+//! The failure this closes, in full: a machine that boots before `gh` can
+//! answer resolves the provisional `local:<host>:<user>` mesh identity and
+//! derives every room UUID under it. Room UUIDs are
+//! `UUIDv5(mesh_identity ‖ NUL ‖ channel_name)`, so that node's `#general`
+//! is a DIFFERENT room from the account's real `#general` — it is invisible
+//! to its own peers while reporting a healthy join. Later, once `gh`
+//! answers, the identity heals; the stored subscriptions do NOT, so the
+//! scope keeps reading dead diverged rooms.
+//!
+//! `SubscriptionSet::rebind_diverged` was already the correct heal, but it
+//! only ran on the JOIN path — so recovery required a human typing
+//! `airc stop && airc join`. That manual ritual IS the recurring "airc is
+//! broken again". This reconcile runs the same heal on the daemon's
+//! route-refresh clock.
+//!
+//! What this catches (three things a unit test on `rebind_diverged` cannot):
+//!   1. the heal is PERSISTED — a reload from the store sees the converged
+//!      UUID, so the daemon (a separate process reading the same store)
+//!      actually benefits;
+//!   2. it is idempotent — a converged scope reports zero rebinds, so the
+//!      per-tick call is free and cannot churn beacons in steady state;
+//!   3. name / wire / join time survive the rebind — the channel NAME is the
+//!      durable identity; only the derived UUID moves.
+
+use airc_lib::mesh_identity::{self, CachedIdentity, Source};
+use airc_lib::subscriptions::{self, ChannelName, MeshIdentity};
+use airc_lib::Airc;
+use tempfile::TempDir;
+
+/// Pin an identity the resolver will honor verbatim: `Source::Operator`
+/// entries are explicit overrides — trusted as-is, never TTL-expired, never
+/// re-resolved — so the test never shells out to `gh` and never depends on
+/// the host's GitHub auth state.
+///
+/// Safe on a real developer machine: `machine_account_home` treats a
+/// temp-rooted scope as its OWN account boundary, so this coordinator store
+/// is the tempdir's, never `~/.airc`.
+async fn pin_identity(airc: &Airc, identity: &str) {
+    mesh_identity::save(
+        airc.coordinator_store_for_test(),
+        &CachedIdentity {
+            version: 1,
+            identity: identity.to_string(),
+            source: Source::Operator,
+            resolved_at_ms: 1,
+            // The store persists this as a signed integer, so it must stay in
+            // i64 range. Value is irrelevant to the test: `Operator` entries
+            // early-return from `resolve` before any expiry check.
+            ttl_ms: i64::MAX as u64,
+        },
+    )
+    .await
+    .expect("pin mesh identity");
+}
+
+#[tokio::test]
+async fn identity_heal_reconcile_persists_and_is_idempotent() {
+    let tmp = TempDir::new().expect("tempdir");
+    let airc = Airc::open(tmp.path().join(".airc")).await.expect("open");
+
+    // Boot under the provisional identity a `gh`-less boot mints.
+    pin_identity(&airc, "local:unknown-host:unknown-user").await;
+    airc.join("general").await.expect("join general");
+
+    let general = ChannelName::new("general").expect("channel name");
+    let diverged = MeshIdentity::new("local:unknown-host:unknown-user");
+    let healed = MeshIdentity::new("joelteply");
+
+    let stored_before = airc
+        .subscriptions()
+        .await
+        .expect("load before")
+        .into_iter()
+        .find(|sub| sub.name == general)
+        .expect("general subscribed");
+    assert_eq!(
+        stored_before.room_id,
+        subscriptions::derive_room_id(&diverged, &general),
+        "the join derived the room UUID under the provisional identity",
+    );
+
+    // `gh` answers; the machine-wide identity heals.
+    pin_identity(&airc, "joelteply").await;
+
+    let rebinds = airc
+        .reconcile_subscription_identity()
+        .await
+        .expect("reconcile after heal");
+    assert_eq!(rebinds.len(), 1, "the diverged subscription must re-bind");
+    assert_eq!(rebinds[0].old_room_id, stored_before.room_id);
+    assert_eq!(
+        rebinds[0].new_room_id,
+        subscriptions::derive_room_id(&healed, &general),
+    );
+
+    // (1) PERSISTED: a fresh load — what the daemon process sees — carries
+    // the converged UUID. Without the store write the heal would evaporate
+    // and the node would stay invisible to its own mesh forever.
+    let stored_after = airc
+        .subscriptions()
+        .await
+        .expect("load after")
+        .into_iter()
+        .find(|sub| sub.name == general)
+        .expect("still subscribed");
+    assert_eq!(
+        stored_after.room_id,
+        subscriptions::derive_room_id(&healed, &general),
+        "the converged room UUID must be durable, not in-memory only",
+    );
+
+    // (3) the channel NAME is the durable identity — the rest must not move.
+    assert_eq!(stored_after.name, stored_before.name);
+    assert_eq!(stored_after.wire, stored_before.wire);
+    assert_eq!(stored_after.joined_at_ms, stored_before.joined_at_ms);
+
+    // (2) IDEMPOTENT: the per-tick call on a converged scope is a no-op.
+    let again = airc
+        .reconcile_subscription_identity()
+        .await
+        .expect("reconcile when converged");
+    assert!(
+        again.is_empty(),
+        "a converged scope must report no rebinds so the daemon tick is free",
+    );
+}

--- a/install.sh
+++ b/install.sh
@@ -855,7 +855,28 @@ _install_airc_binary() {
       cp -f "$built" "$tmp"
       chmod +x "$tmp"
       mv -f "$tmp" "$BIN_DIR/airc"
-      ok "Installed airc: $BIN_DIR/airc"
+      # VERIFY THE DEPLOY. "Installed" is a claim about a file existing;
+      # it is not evidence the binary RUNS. On macOS an invalidly-signed
+      # executable is SIGKILLed before `main` — exit 137, no output, no
+      # error — so `airc --version`, `airc status`, `airc join` and the
+      # daemon all silently do nothing and the operator sees "airc is
+      # broken" with nothing to read. Lived it 2026-08-04: twenty minutes
+      # of a dead mesh that looked like a transport bug.
+      #
+      # Cause-agnostic on purpose: this catches a bad signature, a missing
+      # dylib, a wrong-arch build, anything. If the thing we just put on
+      # PATH cannot state its own version, we do NOT report success.
+      if ! "$BIN_DIR/airc" --version >/dev/null 2>&1; then
+        local rc=$?
+        if [ "$(uname -s 2>/dev/null)" = "Darwin" ] && command -v codesign >/dev/null 2>&1; then
+          codesign -s - -f "$BIN_DIR/airc" >/dev/null 2>&1 || true
+        fi
+        "$BIN_DIR/airc" --version >/dev/null 2>&1 || fail \
+          "airc was installed to $BIN_DIR/airc but will not run (exit $rc; 137 = killed by the OS, \
+typically an invalid code signature on macOS). Refusing to report success on a binary that \
+cannot execute — a silently-dead airc looks exactly like a broken mesh."
+      fi
+      ok "Installed airc: $BIN_DIR/airc ($("$BIN_DIR/airc" --version 2>/dev/null))"
       ;;
   esac
 


### PR DESCRIPTION
## The mechanism behind "airc is broken again"

Room UUIDs are `UUIDv5(mesh_identity ‖ NUL ‖ channel_name)`. The mesh identity is resolved **locally**: `gh api user` → `git config user.email` → a fabricated `local:<host>:<user>`.

A machine that boots before `gh` can answer mints the provisional identity and derives **every room UUID under it**. Its `#general` is a different room from the account's `#general`. It publishes beacons the account never reads, reads a room nobody writes, and reports a healthy join throughout. Two machines, each its own island, no error anywhere. This is on record in the tree — `headers_keys.rs` names the live incident: bigmama's `#general` derived under `local:unknown-host:unknown-user` while M5 derived under the gh login.

The identity **does** self-heal (provisional sources re-probe `gh` on every resolve). The state derived from it does not.

## What was already there, and what was missing

`SubscriptionSet::rebind_diverged` is the correct repair — written, documented, unit-tested. Its only callers are `join` and `ensure_join_context`. So the heal only ran **when a human typed the join.** Its own doc comment says so: *"the scope read a dead room until a manual `airc stop && airc join`."* That manual step is the recurring ritual.

## Change

- `Airc::reconcile_subscription_identity` — resolve the identity, re-derive each subscription's room UUID from its stored NAME, rebind what diverged, **persist**, re-publish presence so peers route to the converged room, and return the rebinds so the caller is loud per old→new move.
- Called from `refresh_routes_once`, the daemon's 60s route-refresh tick.

Idempotent and free when converged: zero rebinds → no store write, no beacon churn. On an unhealed node the tick re-probes `gh` once a minute, so reconvergence lands within ~60s of `gh` becoming reachable, with nobody typing anything.

## Test

`tests/identity_heal_reconcile.rs` pins the three things the `rebind_diverged` unit test cannot:

1. **persisted** — a fresh load (what the separate daemon process sees) carries the converged UUID; without the write the heal evaporates every tick
2. **idempotent** — a converged scope reports zero rebinds
3. name / wire / join-time survive; only the derived UUID moves

It also reproduces the divergence: joining under a pinned `local:...` identity derives a demonstrably different room UUID than the healed one. Hermetic — pins an `Operator`-source identity, never shells out to `gh`, and a temp-rooted scope is its own account boundary so it cannot touch `~/.airc`.

## Not fixed here

The root design still lets a machine **fabricate its own account namespace** when it cannot authenticate. Detect-and-resolve now works autonomously; *never-fabricate* — refusing to mint a private mesh, or adopting the identity from the authenticated peer set — is the deeper change and wants its own decision.

Relates to #288 (self-healing mandate: no human ever runs the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo