### PR TITLE
fix(airc): bound the drop-nudge spin + never report an install that cannot run

### DIFF
--- a/crates/airc-daemon/src/route_refresh.rs
+++ b/crates/airc-daemon/src/route_refresh.rs
@@ -50,6 +50,22 @@ pub const FIRST_REFRESH_DELAY: Duration = Duration::ZERO;
 /// [`run_periodic_refresh`]), never start-to-start.
 pub const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Minimum spacing between refreshes, enforced on the WAKE path.
+///
+/// The wake nudge exists so a real reconnect doesn't wait out a full
+/// [`REFRESH_INTERVAL`]. But it is fired by the session-drop observer, and
+/// a refresh dials every stored peer — so on a node whose registry is
+/// mostly dead peers, refresh manufactures the drops that nudge the next
+/// refresh, forever. This floor is what makes that cycle terminate: at
+/// worst 4 refreshes/minute instead of ~13, and the gh budget the account
+/// registry needs is no longer spent by a spin.
+///
+/// 15s is chosen against the failure it bounds, not tuned: it keeps a
+/// genuine reconnect fast (well under the 60s interval it exists to beat)
+/// while capping the dial rate low enough that a poisoned registry cannot
+/// exhaust a 30-req/60s budget on discovery alone.
+pub const MIN_REFRESH_SPACING: Duration = Duration::from_secs(15);
+
 /// Pure scheduling rule: how long to wait before the next refresh,
 /// given how many refreshes have already completed.
 ///
@@ -97,6 +113,7 @@ where
     tokio::pin!(notified);
 
     let mut completed: u64 = 0;
+    let mut last_completed: Option<tokio::time::Instant> = None;
     loop {
         // Wait for the interval to elapse OR an external wake nudge, whichever
         // comes first. A fresh `notified()` per iteration so a permit stored
@@ -111,11 +128,36 @@ where
                 () = tokio::time::sleep(delay_before_refresh(completed)) => {}
             }
         }
+        // Floor the WAKE path. The nudge is edge-triggered on a session
+        // drop, and a refresh DIALS every stored peer — so on a node whose
+        // registry holds mostly-dead peers, each refresh manufactures the
+        // drops that nudge the next one. Measured live on the M5
+        // (2026-08-04): 44,704 relay self-elections and 4,951 exhausted-gh
+        // -budget errors in a single daemon log, refresh re-entering every
+        // ~4.5s against a 60s interval, 52 enrolled peers and zero
+        // reachable — the loop starved the account registry that discovery
+        // depends on, so it could never climb out.
+        //
+        // The nudge stays (a real reconnect must not wait out 60s); it just
+        // cannot re-enter faster than this floor, which bounds the cycle at
+        // 4/min instead of unbounded. The timer path is unaffected — it
+        // already waits far longer than the floor.
+        if let Some(last) = last_completed {
+            let since = last.elapsed();
+            if since < MIN_REFRESH_SPACING {
+                tokio::select! {
+                    biased;
+                    _ = &mut notified => return,
+                    () = tokio::time::sleep(MIN_REFRESH_SPACING - since) => {}
+                }
+            }
+        }
         tokio::select! {
             biased;
             _ = &mut notified => return,
             () = refresh() => {
                 completed = completed.saturating_add(1);
+                last_completed = Some(tokio::time::Instant::now());
             }
         }
     }
@@ -130,7 +172,8 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::{
-        delay_before_refresh, run_periodic_refresh, FIRST_REFRESH_DELAY, REFRESH_INTERVAL,
+        delay_before_refresh, run_periodic_refresh, FIRST_REFRESH_DELAY, MIN_REFRESH_SPACING,
+        REFRESH_INTERVAL,
     };
 
     /// Pin the scheduling rule: a restarted daemon dials IMMEDIATELY
@@ -365,5 +408,52 @@ mod tests {
             .await
             .expect("loop must exit on shutdown")
             .expect("loop task must not panic");
+    }
+
+    /// what this catches: the live ghost measured on the M5, 2026-08-04 —
+    /// 44,704 relay self-elections and 4,951 exhausted-gh-budget errors in
+    /// one daemon log, refresh re-entering every ~4.5s against a 60s
+    /// interval. The wake nudge is fired by the session-drop observer, and
+    /// a refresh dials every stored peer, so on a registry full of dead
+    /// peers each refresh manufactures the drops that nudge the next one.
+    /// A storm of nudges must be FLOORED, or discovery starves the gh
+    /// budget it depends on and the node never finds a peer again.
+    #[tokio::test(start_paused = true)]
+    async fn a_wake_storm_cannot_refresh_faster_than_the_floor() {
+        let shutdown = Arc::new(Notify::new());
+        let wake = Arc::new(Notify::new());
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let loop_shutdown = shutdown.clone();
+        let loop_wake = wake.clone();
+        let loop_count = count.clone();
+        let handle = tokio::spawn(async move {
+            run_periodic_refresh(&loop_shutdown, &loop_wake, || {
+                let count = loop_count.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+            .await;
+        });
+
+        // 60 virtual seconds of continuous nudging — the drop-storm shape.
+        for _ in 0..600 {
+            wake.notify_one();
+            tokio::time::advance(Duration::from_millis(100)).await;
+        }
+        shutdown.notify_waiters();
+        let _ = handle.await;
+
+        // Immediate first refresh (FIRST_REFRESH_DELAY is ZERO) plus at most
+        // one per MIN_REFRESH_SPACING across the window.
+        let refreshes = count.load(Ordering::SeqCst);
+        let ceiling = 1 + (60 / MIN_REFRESH_SPACING.as_secs() as usize) + 1;
+        assert!(
+            refreshes <= ceiling,
+            "a wake storm must be floored: {refreshes} refreshes in 60s \
+             (ceiling {ceiling}). Unfloored, this re-enters as fast as the \
+             dial sweep — the 44,704-self-election ghost."
+        );
     }
 }

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -75,4 +75,4 @@ ed25519-dalek = "2"
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 tempfile = "3"
 temp-env = "0.3"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "test-util"] }

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -387,6 +387,20 @@ pub enum AccountRegistryError {
         spec_peer_id: airc_core::PeerId,
     },
     Adapter(String),
+    /// The gh request governor refused this call: the 60s window is full
+    /// (or GitHub's own backoff is active). Carries the governor's own
+    /// answer to "when may I try again?" as DATA rather than prose, so
+    /// the refresh loop can actually WAIT it out.
+    ///
+    /// Before this existed the denial was formatted into `Adapter`'s
+    /// string, logged, and the loop came back on its normal cadence —
+    /// re-attempting inside a window it had just been told was closed.
+    /// Measured on the M5 2026-08-04: 4,951 denials in a single daemon
+    /// log while the account registry (how peers FIND each other) stayed
+    /// starved. Advisory backoff is not backoff.
+    RateLimited {
+        retry_after_secs: u64,
+    },
 }
 
 impl std::fmt::Display for AccountRegistryError {
@@ -406,6 +420,11 @@ impl std::fmt::Display for AccountRegistryError {
                 "account registry peer mismatch: presence {presence_peer_id} vs spec {spec_peer_id}"
             ),
             Self::Adapter(error) => write!(f, "account registry adapter: {error}"),
+            Self::RateLimited { retry_after_secs } => write!(
+                f,
+                "gh request budget exhausted; the governor asks for {retry_after_secs}s \
+                 before the next Registry call"
+            ),
         }
     }
 }

--- a/crates/airc-lib/src/gh/account_registry.rs
+++ b/crates/airc-lib/src/gh/account_registry.rs
@@ -504,9 +504,19 @@ impl GhAccountRegistryStore {
                 retry_after_secs,
                 reason,
             }) => {
-                return Err(AccountRegistryError::Adapter(format!(
-                    "gh governor: {reason}; retry in {retry_after_secs}s"
-                )));
+                // Typed, not formatted — the caller must be able to HONOR
+                // the wait, which it cannot do with a message string.
+                tracing::debug!(
+                    target: "airc::gh",
+                    retry_after_secs,
+                    %reason,
+                    "gh governor denied a Registry request"
+                );
+                return Err(AccountRegistryError::RateLimited {
+                    // Governor reports i64; a negative wait is nonsense,
+                    // clamp rather than panic on a clock oddity.
+                    retry_after_secs: retry_after_secs.max(0) as u64,
+                });
             }
             // Allowed, or a governor I/O glitch: fail OPEN so a filesystem
             // hiccup can't brick the mesh — the 60s budget + GitHub's

--- a/crates/airc-lib/src/registry_refresh.rs
+++ b/crates/airc-lib/src/registry_refresh.rs
@@ -320,15 +320,29 @@ pub async fn run_loop<S>(
             // spam). `Notify` stores one permit if the nudge lands during
             // a tick, so the wakeup is never lost.
             _ = resync.notified() => {
-                if gated_tick(&gate, &airc, &store, &sink).await {
-                    route_wake.notify_one();
-                }
+                honor(gated_tick(&gate, &airc, &store, &sink).await, route_wake).await;
             }
             _ = ticker.tick() => {
-                if gated_tick(&gate, &airc, &store, &sink).await {
-                    route_wake.notify_one();
-                }
+                honor(gated_tick(&gate, &airc, &store, &sink).await, route_wake).await;
             }
+        }
+    }
+}
+
+/// Act on a tick's outcome: nudge route-refresh when something landed,
+/// and — the part that was missing — actually SLEEP OUT a governor denial.
+///
+/// The governor already computed "retry in N seconds" and the loop used to
+/// throw it away, coming back on its own cadence to be refused again. The
+/// account registry is how peers discover each other, so a permanently
+/// refused registry is a permanently blind node. Sleeping here is what
+/// turns the governor's advice into backpressure.
+async fn honor(outcome: TickOutcome, route_wake: &tokio::sync::Notify) {
+    match outcome {
+        TickOutcome::Imported => route_wake.notify_one(),
+        TickOutcome::NoChange => {}
+        TickOutcome::RateLimited { retry_after_secs } => {
+            tokio::time::sleep(Duration::from_secs(retry_after_secs)).await;
         }
     }
 }
@@ -344,12 +358,27 @@ pub async fn run_loop<S>(
 /// The loop uses that to nudge the route-refresh loop (#240 event-driven
 /// heal): a gate-skip or a failed import imported nothing, so there is
 /// nothing newly-dialable to wake for.
+/// What one gated tick did, for a caller that must react differently to
+/// "nothing changed" and "the door is shut for N seconds".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TickOutcome {
+    /// Publish+refresh ran and succeeded — fresh beacons/endpoints landed
+    /// in the trust store, so there is something newly dialable.
+    Imported,
+    /// Skipped or failed without a governor denial. Next tick on cadence.
+    NoChange,
+    /// The gh governor refused: its window is full. The caller MUST wait
+    /// this long before the next attempt — retrying sooner is what kept
+    /// the budget permanently exhausted and discovery permanently starved.
+    RateLimited { retry_after_secs: u64 },
+}
+
 async fn gated_tick<S>(
     gate: &RegistryRefreshGate,
     airc: &Airc,
     store: &S,
     sink: &StderrJsonDiagnosticSink,
-) -> bool
+) -> TickOutcome
 where
     S: AccountRegistryStore,
 {
@@ -363,9 +392,15 @@ where
             code,
             format!("account registry tick skipped: {block}"),
         ));
-        return false;
+        return TickOutcome::NoChange;
     }
-    run_tick(airc, store, sink).await.is_ok()
+    match run_tick(airc, store, sink).await {
+        Ok(_) => TickOutcome::Imported,
+        Err(crate::AircError::AccountRegistry(
+            crate::account_registry::AccountRegistryError::RateLimited { retry_after_secs },
+        )) => TickOutcome::RateLimited { retry_after_secs },
+        Err(_) => TickOutcome::NoChange,
+    }
 }
 
 #[cfg(test)]
@@ -784,5 +819,41 @@ exit 1
             .await
             .expect("loop must exit promptly on shutdown")
             .unwrap();
+    }
+
+    /// what this catches: the starvation half of the 2026-08-04 M5 ghost —
+    /// 4,951 governor denials in one daemon log while the account registry
+    /// (how peers FIND each other) stayed permanently refused. The governor
+    /// had already computed "retry in N seconds"; the loop threw it away and
+    /// came back on its own cadence to be refused again. Advisory backoff is
+    /// not backoff. `honor` must actually SLEEP the requested window.
+    #[tokio::test(start_paused = true)]
+    async fn a_rate_limited_tick_actually_waits_out_the_governors_window() {
+        let wake = tokio::sync::Notify::new();
+        let start = tokio::time::Instant::now();
+        honor(
+            TickOutcome::RateLimited {
+                retry_after_secs: 60,
+            },
+            &wake,
+        )
+        .await;
+        assert_eq!(
+            start.elapsed(),
+            Duration::from_secs(60),
+            "a governor denial must be waited out, not logged and retried"
+        );
+    }
+
+    /// what this catches: the backoff must not become a stall. A tick that
+    /// imported (or simply changed nothing) returns immediately — only a
+    /// denial costs wall-clock.
+    #[tokio::test(start_paused = true)]
+    async fn a_normal_tick_costs_no_wall_clock() {
+        let wake = tokio::sync::Notify::new();
+        let start = tokio::time::Instant::now();
+        honor(TickOutcome::Imported, &wake).await;
+        honor(TickOutcome::NoChange, &wake).await;
+        assert_eq!(start.elapsed(), Duration::from_secs(0));
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -855,7 +855,28 @@ _install_airc_binary() {
       cp -f "$built" "$tmp"
       chmod +x "$tmp"
       mv -f "$tmp" "$BIN_DIR/airc"
-      ok "Installed airc: $BIN_DIR/airc"
+      # VERIFY THE DEPLOY. "Installed" is a claim about a file existing;
+      # it is not evidence the binary RUNS. On macOS an invalidly-signed
+      # executable is SIGKILLed before `main` — exit 137, no output, no
+      # error — so `airc --version`, `airc status`, `airc join` and the
+      # daemon all silently do nothing and the operator sees "airc is
+      # broken" with nothing to read. Lived it 2026-08-04: twenty minutes
+      # of a dead mesh that looked like a transport bug.
+      #
+      # Cause-agnostic on purpose: this catches a bad signature, a missing
+      # dylib, a wrong-arch build, anything. If the thing we just put on
+      # PATH cannot state its own version, we do NOT report success.
+      if ! "$BIN_DIR/airc" --version >/dev/null 2>&1; then
+        local rc=$?
+        if [ "$(uname -s 2>/dev/null)" = "Darwin" ] && command -v codesign >/dev/null 2>&1; then
+          codesign -s - -f "$BIN_DIR/airc" >/dev/null 2>&1 || true
+        fi
+        "$BIN_DIR/airc" --version >/dev/null 2>&1 || fail \
+          "airc was installed to $BIN_DIR/airc but will not run (exit $rc; 137 = killed by the OS, \
+typically an invalid code signature on macOS). Refusing to report success on a binary that \
+cannot execute — a silently-dead airc looks exactly like a broken mesh."
+      fi
+      ok "Installed airc: $BIN_DIR/airc ($("$BIN_DIR/airc" --version 2>/dev/null))"
       ;;
   esac
 


### PR DESCRIPTION
Two low-risk, tested fixes split off PR #1316 so they can land without waiting on the identity work (which is unproven and CI-red). Nothing here touches identity, transport, or the wire.

## 1. The ghost — measured live on the M5, 2026-08-04

One daemon log:

```
44,704  relay self-elections
 4,951  "gh request budget exceeded for Registry (30/30 of 30 in 60s)"
    52  enrolled peers, ZERO reachable
  ~4.5s refresh re-entry against a 60s REFRESH_INTERVAL
```

`set_disconnect_observer` nudges `route_wake` on every session drop (#240, so a real reconnect doesn't wait out 60s). A refresh **dials every stored peer**. On a node whose registry is mostly dead peers, those dials drop, each drop nudges again, and the next refresh starts ~4.5s later — the dial sweep's length. Nothing bounded it.

The damage isn't CPU, it's starvation: every pass spends GitHub requests until the governor cuts the node off at 30/60s, and the account registry is *how peers find each other*. The loop eats the budget discovery needs, then hammers the closed door 44,704 times. It can't climb out, which is why a restart clears it for a minute and it returns a few times a day.

`MIN_REFRESH_SPACING` (15s) floors re-entry **on the wake path only**. The nudge is kept — a genuine reconnect still beats the 60s interval by 4× — it just can't re-enter faster than the floor, bounding the cycle at 4/min. The timer path is untouched.

Test pins the storm directly: 600 nudges across 60 virtual seconds must yield at most `1 + 60/MIN_REFRESH_SPACING + 1` refreshes. Unfloored it counts hundreds.

**Not yet proven:** that this ends the disconnects. Early post-deploy counters look right but the window was ~20s, which is not evidence. Needs a real observation window.

## 2. Verify the deploy

A locally-built airc landed on PATH and was SIGKILLed by macOS on every invocation — exit 137, zero output. `--version`, `status`, `join`, and the daemon each silently did nothing. Twenty minutes of a completely dead mesh that read exactly like a transport bug. One `codesign -s -` and it ran.

(The corrupt signature came from a hand-run `cp` over the installed path, not from install.sh, which already does cp-to-temp + atomic mv. The gap closed here is different: the script printed "Installed airc" without ever executing what it installed.)

"Installed" is now a claim about a binary that answered `--version`, and the success line carries the version it printed. Cause-agnostic — bad signature, missing dylib, wrong-arch build all fail identically and all get caught. On macOS it attempts one ad-hoc re-sign and re-verifies before giving up.

A silently-dead airc is indistinguishable from a broken mesh, which sends you hunting the network for a defect that is a signature bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo