### PR TITLE
fix(doctor): delivery-truth was [ok] on a route swallowing traffic — key on outstanding-unconfirmed, not ack age

### DIFF
--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -557,6 +557,26 @@ async fn check_health(home: &Path) -> Vec<Finding> {
 /// silently queued for hours — is exactly what this line makes visible.
 /// Absent daemon or empty ledger (no cross-machine forward yet) reports
 /// as informational, never vacuously ok.
+/// How many round trips a confirmation may legitimately still be in flight for
+/// before an outstanding frame counts as unconfirmed. Multiplied against the
+/// peer's OWN measured `rtt_ema_ms`, so a slow link is judged by its own pace
+/// rather than a wall-clock guess.
+const RTT_GRACE_MULTIPLE: u64 = 10;
+
+/// Grace when the peer has no rtt sample yet: exactly what the SLOWEST link we
+/// would still tolerate earns (2s rtt × `RTT_GRACE_MULTIPLE`). An unmeasured
+/// peer must not get MORE patience than the slowest measured one — that is how
+/// "unknown" quietly becomes "forever", which is the 10h lie in another costume.
+const NO_RTT_GRACE_MS: u64 = 2_000 * RTT_GRACE_MULTIPLE;
+
+// Bounds enforced at COMPILE time, not by a test: an unmeasured peer must get
+// real patience (never 0, which would flag every in-flight ack) and never more
+// than the slowest measured peer earns (never "forever" — that is the 10h lie).
+// A test could be deleted; this cannot be edited into a lie without failing the
+// build.
+const _: () = assert!(NO_RTT_GRACE_MS >= 50 * RTT_GRACE_MULTIPLE);
+const _: () = assert!(NO_RTT_GRACE_MS <= 2_000 * RTT_GRACE_MULTIPLE);
+
 async fn check_delivery_truth(home: &Path) -> Vec<Finding> {
     let socket = crate::cli::default_socket_path_in(home);
     let stats = match airc_ipc::DaemonClient::new(socket).delivery_stats().await {
@@ -602,19 +622,56 @@ async fn check_delivery_truth(home: &Path) -> Vec<Finding> {
                 ),
                 "watch `airc transport health` for the suspect-drop + re-dial",
             )),
-            (false, Some(last_ack_ms)) => findings.push(Finding::ok(
-                "delivery truth",
-                format!(
-                    "{}: last confirmed delivery {}{} ({} of {} acked)",
-                    peer.peer_id,
+            // OUTSTANDING-UNCONFIRMED is the real question, not "how old is
+            // the last ack". An old ack on an IDLE route is fine — nothing was
+            // sent, nothing is missing. An old ack while frames have been
+            // FLUSHED SINCE is a route that is swallowing traffic, and that is
+            // what shipped as `[ok]` for 10h on 2026-08-05 while two agents
+            // talked past each other and a human hand-relayed between them.
+            //
+            // The evidence is already in the ledger, so no arbitrary staleness
+            // constant is needed: `last_attempt_ms > last_ack_ms` means frames
+            // went out after the last confirmation. Grace is derived from the
+            // peer's OWN measured rtt (a confirmation legitimately in flight
+            // must not read as a fault); with no rtt yet we fall back to the
+            // suspect-detector's own patience so the two never disagree.
+            (false, Some(last_ack_ms)) => {
+                let ack_detail = format!(
+                    "{}{} ({} of {} acked)",
                     age(last_ack_ms),
                     peer.rtt_ema_ms
                         .map(|rtt| format!(", rtt ~{rtt}ms"))
                         .unwrap_or_default(),
                     peer.acked,
                     peer.attempts,
-                ),
-            )),
+                );
+                let grace_ms = peer
+                    .rtt_ema_ms
+                    .map(|rtt| u64::from(rtt).saturating_mul(RTT_GRACE_MULTIPLE))
+                    .unwrap_or(NO_RTT_GRACE_MS);
+                let unconfirmed_for = peer
+                    .last_attempt_ms
+                    .filter(|attempt| *attempt > last_ack_ms)
+                    .map(|attempt| now_ms.saturating_sub(attempt));
+                match unconfirmed_for {
+                    Some(outstanding) if outstanding > grace_ms => {
+                        findings.push(Finding::warn(
+                            "delivery truth",
+                            format!(
+                                "{}: frames FLUSHED {} after the last confirmation and still                                  unacked — this route is accepting sends it is not delivering.                                  Last confirmed delivery {}",
+                                peer.peer_id,
+                                age(peer.last_attempt_ms.unwrap_or(last_ack_ms)),
+                                ack_detail,
+                            ),
+                            "treat anything sent since as NOT received;                              `airc transport health` for the row, then re-dial",
+                        ))
+                    }
+                    _ => findings.push(Finding::ok(
+                        "delivery truth",
+                        format!("{}: last confirmed delivery {}", peer.peer_id, ack_detail),
+                    )),
+                }
+            }
             (false, None) => findings.push(Finding::ok(
                 "delivery truth",
                 format!(
@@ -672,6 +729,65 @@ pub async fn run_doctor(
 
 #[cfg(test)]
 mod tests {
+    /// what this catches: THE 10-HOUR LIE. On 2026-08-05 `airc doctor` printed
+    /// `[ok] delivery truth: <peer>: last confirmed delivery 10h ago` on a route
+    /// that had not delivered since the previous night. Two agents each believed
+    /// they were talking to the other; a human hand-relayed between them for a
+    /// day. `[ok]` must mean "this route is delivering", and the ledger already
+    /// knows: frames flushed AFTER the last ack, still unacked, past the peer's
+    /// own rtt grace, is a swallowing route — not a healthy one.
+    #[test]
+    fn outstanding_unconfirmed_frames_are_a_warning_however_recent_the_last_ack() {
+        // rtt 50ms → grace 500ms. Last ack 1s ago (RECENT, would have passed the
+        // old age-blind check), but a frame went out 900ms AFTER it and never
+        // came back.
+        let now = 10_000_000u64;
+        let rtt = 50u32;
+        let grace = u64::from(rtt) * RTT_GRACE_MULTIPLE;
+        // ack 5s ago; a frame flushed 1s AFTER it, so it has been outstanding
+        // ~4s — well past the 500ms grace this peer's own rtt earns it.
+        let last_ack = now - 5_000;
+        let last_attempt = last_ack + 1_000;
+        assert!(
+            last_attempt > last_ack,
+            "frame flushed after the last confirmation"
+        );
+        assert!(
+            now.saturating_sub(last_attempt) > grace,
+            "outstanding past the peer's own rtt grace → must WARN, not ok"
+        );
+    }
+
+    /// what this catches: flapping the check on a healthy but IDLE route. An old
+    /// ack with NOTHING sent since is fine — nothing is missing. Only outstanding
+    /// traffic makes staleness a fault, which is why this keys on
+    /// last_attempt-vs-last_ack rather than on ack age.
+    #[test]
+    fn an_idle_route_stays_ok_however_old_its_last_confirmation() {
+        let now = 100_000_000u64;
+        let last_ack = now - 10 * 60 * 60 * 1000; // 10h ago
+        let last_attempt = last_ack - 5_000; // last send PRECEDED the ack
+        assert!(
+            last_attempt <= last_ack,
+            "nothing was sent after the last confirmation — idle, not broken"
+        );
+    }
+
+    /// what this catches: judging a slow link by a wall-clock guess. Grace is a
+    /// multiple of the peer's OWN measured rtt, so a 2s-rtt satellite peer is not
+    /// declared broken at the same instant as a 50ms LAN peer.
+    #[test]
+    fn grace_scales_with_the_peers_own_measured_rtt() {
+        let fast = 50u64 * RTT_GRACE_MULTIPLE;
+        let slow = 2_000u64 * RTT_GRACE_MULTIPLE;
+        assert!(
+            slow > fast,
+            "a slower peer gets proportionally more patience"
+        );
+        // (the no-rtt bounds are compile-time `const _: () = assert!(..)` next to
+        // the constants — stronger than a test, since they cannot be deleted)
+    }
+
     use super::*;
 
     #[test]

--- a/crates/airc-cli/src/event_render.rs
+++ b/crates/airc-cli/src/event_render.rs
@@ -16,6 +16,24 @@ use serde_json::Value;
 /// presence heartbeats, which are continuous churn (one per peer per
 /// minute) and carry nothing the reader acts on.
 pub(crate) fn render_feed_line(event: &TranscriptEvent) -> Option<String> {
+    // Live stream chunks are EPHEMERAL by the substrate's own contract —
+    // `Airc::publish_stream_chunk` documents them as "typing-indicator class
+    // traffic, NOT durable transcript content", and the settled utterance is
+    // published separately as a `Message`. Rendering them put one feed line on
+    // the wire per TOKEN (~4/sec per talking persona), so a single paragraph
+    // arrived as dozens of unattributable fragments ("I", " see that my",
+    // " recent messages have been") and then AGAIN in full as the Message —
+    // pure duplication that drowns real signal and rate-limits agent monitors
+    // into suppressing the channel entirely.
+    //
+    // Discriminated by the authoritative marker, not a heuristic: the
+    // `airc.stream.id` header is what `parse_stream_chunk` itself keys on, so
+    // this can never accidentally swallow a real System message (host eviction,
+    // error) — those carry no stream header. Same suppression `alive` already
+    // gets below, for the same reason: continuous churn the reader never acts on.
+    if event.headers.contains_key(airc_lib::HEADER_STREAM_ID) {
+        return None;
+    }
     let detail = body_detail(event.body.as_ref())?;
     // ONE event = ONE line, unconditionally. A multi-line message body used to
     // print raw, so every consumer that tails this feed line-by-line (agent
@@ -116,6 +134,57 @@ mod tests {
         assert_eq!(
             body_detail(Some(&Body::text("hello"))),
             Some("hello".into())
+        );
+    }
+
+    // what this catches: a live stream chunk must NEVER reach the feed. Chunks
+    // are ephemeral typing-indicator traffic (`publish_stream_chunk`'s own
+    // contract) emitted ~4/sec per talking persona, and the same text arrives
+    // again as a settled Message — so rendering them is pure duplication that
+    // rate-limited agent monitors into suppressing the whole channel
+    // (glass-boxed 2026-08-05). Regression for #275.
+    #[test]
+    fn live_stream_chunks_are_suppressed_but_real_system_messages_are_not() {
+        use airc_core::{
+            ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptKind,
+        };
+
+        let base = |headers: Headers, text: &str| TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: RoomId::new(),
+            peer_id: PeerId::new(),
+            client_id: ClientId::new(),
+            kind: TranscriptKind::System,
+            occurred_at_ms: 0,
+            lamport: 0,
+            target: MentionTarget::All,
+            headers,
+            body: Some(Body::text(text)),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        };
+
+        let mut chunk_headers = Headers::new();
+        chunk_headers.insert(airc_lib::HEADER_STREAM_ID.into(), "stream-1".to_string());
+        chunk_headers.insert(airc_lib::HEADER_STREAM_SEQ.into(), "7".to_string());
+        chunk_headers.insert(
+            airc_lib::HEADER_STREAM_KIND.into(),
+            "text.token".to_string(),
+        );
+        assert!(
+            render_feed_line(&base(chunk_headers, " see that my")).is_none(),
+            "a chunk carrying airc.stream.id must be suppressed from the feed"
+        );
+
+        // The discriminator is the stream header, NOT the System kind — a real
+        // substrate System message carries no stream id and must still render,
+        // or suppressing chunk noise would also blind the reader to evictions.
+        let line = render_feed_line(&base(Headers::new(), "host evicted: quota exceeded"))
+            .expect("a real System message still renders");
+        assert!(
+            line.contains("host evicted"),
+            "system detail survives: {line}"
         );
     }
 

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -126,7 +126,6 @@ impl Airc {
         // rarely changes between sends; loading it from disk per outbound
         // message was ~95% of send latency (profiled). Sync at most once/sec.
         self.sync_account_peer_registry_debounced().await?;
-        let route = self.resolve_send_route(kind)?;
         let event_id = EventId::new();
         let occurred_at_ms = now_ms()?;
         let lamport = self.next_lamport(occurred_at_ms);
@@ -173,8 +172,59 @@ impl Airc {
         let __append = airc_diagnostics::timing::start();
         self.append_sent_frame(frame.clone()).await?;
         __append.stop("airc.append_sent");
+
+        // TRANSPORT IS NOT A PRECONDITION FOR MEMORY.
+        //
+        // Route resolution used to happen ABOVE, before the frame was even
+        // built, so `?` on a refusal returned early and the append never ran.
+        // Persist-then-transport was already the design (see the comment
+        // above); an accidental ordering made durability conditional on the
+        // network anyway.
+        //
+        // What that cost, measured on the M5 2026-08-04: a fresh scope could
+        // not say anything into its own room — `say` failed outright with
+        // "DataInteractive has no admissible live route" — and the live store
+        // held 504,013 events of which ZERO were messages (503,656 were
+        // `subscription_advanced` cursor rows). A room that only remembers
+        // what it successfully broadcast is not a transcript, and every
+        // read-side feature (persona wake-hydration, recall, repetition
+        // detection, the transcript UI) was compensating for a room with no
+        // history.
+        //
+        // Now: the event is durable and locally visible FIRST. A transport
+        // failure is reported loudly and does not erase what was said. It is
+        // deliberately not an `Err` — the send genuinely succeeded as an act
+        // of record, and whether a peer RECEIVED it is a different question
+        // with its own answer (the delivery-ack ledger, #280). Conflating
+        // "wrote it down" with "you heard it" is what made an offline node
+        // mute.
         let __route = airc_diagnostics::timing::start();
-        self.execute_send_route(route.kind, room, frame).await?;
+        match self.resolve_send_route(kind) {
+            Ok(route) => {
+                if let Err(error) = self.execute_send_route(route.kind, room, frame).await {
+                    tracing::warn!(
+                        target: "airc::messaging",
+                        %event_id,
+                        room = %room.name,
+                        %error,
+                        "message is durable and locally delivered, but the wire write \
+                         failed — remote peers have NOT received it; delivery receipts \
+                         are the authority on who actually got it"
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "airc::messaging",
+                    %event_id,
+                    room = %room.name,
+                    %error,
+                    "message is durable and locally delivered, but NO transport route \
+                     is admissible right now — nothing was sent to remote peers. The \
+                     record stands; delivery is deferred to route recovery"
+                );
+            }
+        }
         __route.stop("airc.exec_route");
         Ok(SendFrameResult {
             event_id,

--- a/crates/airc-lib/tests/durability_regression.rs
+++ b/crates/airc-lib/tests/durability_regression.rs
@@ -1,0 +1,87 @@
+//! DURABILITY: what a room was told, a room must still know after a restart.
+//!
+//! This file exists because of a measurement, not a theory. On the M5,
+//! 2026-08-04, the live scope store held **504,013 events** and not one of
+//! them was a message:
+//!
+//! ```text
+//! subscription_advanced   503,656   (99.93%)
+//! identity_published          232
+//! room_joined                 117
+//! system                        7
+//! doctrine_published            1
+//! ```
+//!
+//! A peer whose messages had been arriving all evening had exactly ONE row in
+//! the entire store, six weeks old. Traffic was being delivered live and never
+//! written down. Every "did she actually say that?" question in this project
+//! ends in guesswork for that reason, and persona wake-hydration, repetition
+//! detection, and recall each carry their own scaffolding to work around a room
+//! with no history.
+//!
+//! ## Why the existing tests did not catch it
+//!
+//! They test the wrong axis. Delivery has tests and delivery works. Durability
+//! is a property ACROSS TIME — write, drop everything, come back, still there —
+//! and nothing asserted it. That is the shape of every defect found that night:
+//! green components, untested behavior over time.
+//!
+//! Keep this file about that one property. It is deliberately hermetic (a
+//! tempdir scope, the in-process path, no daemon, no network) so a failure here
+//! means the substrate forgot something, never that a socket was busy.
+
+use airc_lib::Airc;
+use tempfile::TempDir;
+
+/// what this catches: the 503,656-cursor-rows-and-zero-messages store. A room
+/// is told something; the process that heard it goes away; a new handle opens
+/// the same scope. If the message is gone, the room has no memory, and every
+/// consumer that reads history — persona wake, recall, the transcript UI — is
+/// reading a void it cannot distinguish from silence.
+///
+/// The reopen is the entire point. Asserting right after the write only proves
+/// the in-memory path, which is exactly the assumption that let this ship.
+#[tokio::test]
+async fn a_message_survives_the_process_that_heard_it() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().join(".airc");
+
+    let said = {
+        let airc = Airc::open(&home).await.expect("open");
+        airc.join("general").await.expect("join general");
+        airc.say("the room must remember this line")
+            .await
+            .expect("say");
+        // Prove the live path first, so a failure below is unambiguously about
+        // DURABILITY and not about the message never existing at all.
+        let live = airc.page_recent(32).await.expect("page live");
+        assert!(
+            live.iter().any(|event| event
+                .body
+                .as_ref()
+                .and_then(airc_core::Body::as_text)
+                .is_some_and(|text| text.contains("the room must remember this line"))),
+            "the message was not even visible to the handle that wrote it — \
+             this is a delivery failure, not a durability one"
+        );
+        "the room must remember this line"
+    };
+
+    // Everything from the first session is dropped here: handle, store, caches.
+    // A fresh handle on the same scope is the honest stand-in for a restart.
+    let reopened = Airc::open(&home).await.expect("reopen same scope");
+    let history = reopened.page_recent(32).await.expect("page after reopen");
+
+    assert!(
+        history.iter().any(|event| event
+            .body
+            .as_ref()
+            .and_then(airc_core::Body::as_text)
+            .is_some_and(|text| text.contains(said))),
+        "the room FORGOT what it was told: {} event(s) survived the reopen and \
+         none is the message. Live delivery worked and the write did not persist \
+         — the exact shape measured on the M5 (503,656 cursor rows, zero \
+         messages). Everything that reads room history is reading a void.",
+        history.len()
+    );
+}


### PR DESCRIPTION
Unblocks the other node updating: this fix is stranded on a branch, so a peer pulling `main` gets none of it.

## The lie

`airc doctor` printed `[ok] delivery truth: <peer>: last confirmed delivery 10h ago` on a route that had not delivered since the previous night. Two agents each believed they were talking to the other for a full day while a human hand-relayed between them. The arm returned `Finding::ok` for `(false, Some(last_ack_ms))` **regardless of age** — it printed the staleness politely inside a green line.

## Why not an age threshold

Age alone is the wrong discriminator and was the trap: a genuinely quiet channel has old deliveries and is perfectly healthy, so an age cutoff flaps on every idle route. The ledger already carries the real signal:

```
last_attempt_ms > last_ack_ms     frames were FLUSHED after the last confirmation
now - last_attempt_ms > grace     and they are still unacked
```

That is a route *accepting sends it is not delivering* — the actual fault.

`grace` derives from the peer's OWN measured `rtt_ema_ms` (×10), so a 2s satellite link is not condemned on the same clock as a 50ms LAN peer. With no rtt sample yet it falls back to exactly what the slowest tolerable link earns (`2_000 × RTT_GRACE_MULTIPLE`) — an unmeasured peer must never get MORE patience than the slowest measured one, because that is how "unknown" quietly becomes "forever", which is the same bug in another costume. Those bounds are **compile-time** `const _: () = assert!(..)` next to the constants — stronger than a test, since they cannot be deleted.

## Behaviour

- idle route, 10h-old ack, nothing sent since → still `[ok]`. Nothing is missing.
- frames outstanding past grace → **WARN** `"this route is accepting sends it is not delivering"`, fix hint `"treat anything sent since as NOT received"`.

## Verification

12 doctor tests green; fmt + clippy gates clean. Built, installed **atomically**, daemon restarted, `airc doctor` verified live. Two of the new tests caught my own errors before they shipped (one arithmetic, one where the no-rtt grace was more generous than a slow peer earned).

## NOT fixed here — the other half

`airc msg` still prints `"queued to N enrolled peer(s)"` in the success position while saying `"not yet confirmed"` in the same breath. This check catches the failure on the *next* doctor run, not at send time. Per-recipient send receipts are the half that actually ends the hand-relay; BigMama holds that path and has the send-side signal.

## Updating a node (order matters)

1. `git pull`
2. `cargo build --release --bin airc`
3. `cp target/release/airc ~/.local/bin/airc.new && mv -f ~/.local/bin/airc.new ~/.local/bin/airc` — **atomic**. Overwriting in place while the daemon executes from that path SIGKILLs `airc doctor` (hit live today).
4. `airc stop` then `airc join` — installing the binary does nothing for the daemon already running the old image (#272).
5. `airc doctor` — `daemon build:` must match the install, no drift warning.