### PR TITLE
fix(auto-update): self-update could only fire on a DISCONNECTED node — gate on outstanding frames, not connection count (#288/#272)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1475,20 +1475,41 @@ pub async fn run_daemon(
     // peers that can't speak the current protocol). The dangerous half (fetch +
     // smoke-test + rollback-safe `airc update --auto`, spawned detached) lives
     // in `airc_daemon::auto_update`; the daemon supplies only the MESH-IDLE
-    // predicate so an update never restarts mid-work. Idle = zero live LAN peer
-    // connections: with no connection there is definitionally no in-flight mesh
-    // work to drop, and control-plane reconnect after a restart is cheap +
-    // self-healing. (Refinement TODO: once stream-plane sessions are tracked in
-    // daemon connection-state, gate on "no active TRANSFER" so a connected-but-
-    // quiet node can still update.) Exits on the shared shutdown notifier.
+    // predicate so an update never restarts mid-work.
+    //
+    // Idle = NO HEALTHY PEER HAS FRAMES OUTSTANDING (`mesh_is_quiet` over the
+    // delivery-truth stats, #280). This replaced `connected_lan_peers == 0`,
+    // which was inverted: a node connected to the mesh — i.e. one doing its job
+    // — was never "idle", so it could never self-update, and only an already-
+    // isolated node ever did. That is why two healthy nodes sat on a stale build
+    // for a day (2026-08-05) with a merged transport fix available, until a human
+    // ran the update by hand on both. Connection COUNT is not work.
+    //
+    // Note the resolved TODO this carries: a connected-but-quiet node CAN now
+    // update, which is the whole point. Exits on the shared shutdown notifier.
     let auto_update_task = {
         let daemon_state = state.clone();
         tokio::spawn(async move {
             airc_daemon::auto_update::run(&daemon_state.shutdown, || {
-                daemon_state
-                    .connected_lan_peers
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                    == 0
+                // try_read, NOT blocking_read: this predicate is called from
+                // inside the async tick, and tokio's RwLock::blocking_read
+                // panics in an async context — it would have taken the daemon
+                // down on the first tick.
+                match daemon_state.delivery_stats.try_read() {
+                    Ok(stats) => airc_daemon::auto_update::mesh_is_quiet(
+                        stats.iter().map(|s| (s.attempts_since_ack, s.suspect)),
+                    ),
+                    Err(_) => {
+                        // Contended write (stats being refreshed). Skip THIS
+                        // tick and retry next interval — never guess "quiet"
+                        // from a lock we couldn't read. Loud, because a
+                        // permanently-contended lock would silently become a
+                        // node that never self-updates again, which is the
+                        // exact failure class this whole path exists to kill.
+                        eprintln!("airc auto-update: delivery stats busy — skipping this check");
+                        false
+                    }
+                }
             })
             .await;
         })

--- a/crates/airc-daemon/src/auto_update.rs
+++ b/crates/airc-daemon/src/auto_update.rs
@@ -18,11 +18,10 @@
 //!
 //! ## Safety gates (why this is OK to default-on)
 //! - **Idle-gated.** The caller supplies an `is_idle` predicate; we only fire
-//!   when there is no live work to drop. NOTE: the right signal is *active mesh
-//!   streams*, not IPC-client idle — wiring that predicate (+ this loop into the
-//!   daemon startup) is the coordinated final step, on top of reliable
-//!   restart/reconnect (the transport-reliability lane). Until then this loop is
-//!   constructed but not spawned.
+//!   when there is no live work to drop. The signal is [`mesh_is_quiet`] — no
+//!   healthy peer with frames outstanding — supplied by the daemon from its
+//!   delivery-truth stats. It is NOT connection count; see that function's docs
+//!   for the day that cost.
 //! - **Rollback.** `--auto` smoke-tests + rolls back, so a bad canary can't down
 //!   the node.
 //! - **No-op when current.** Restarts happen ONLY when canary actually moved, so
@@ -68,6 +67,40 @@ pub fn interval() -> Duration {
 /// testable apart from the I/O.
 pub fn should_fire(enabled: bool, is_idle: bool) -> bool {
     enabled && is_idle
+}
+
+/// Is the mesh QUIET — i.e. is there no in-flight delivery this node would drop
+/// by restarting? True when no healthy peer has frames outstanding.
+///
+/// ## Why this replaced "zero connected peers" (the bug this function exists for)
+///
+/// The original idle predicate was `connected_lan_peers == 0`. That is exactly
+/// inverted from the intent: a node doing its job — connected to the mesh,
+/// talking to its peer — is NEVER idle by that measure, so it could never
+/// self-update. Only an already-isolated node updated. Lived on 2026-08-05: two
+/// healthy, continuously-connected nodes both sat on a stale build for a full
+/// day while a merged transport fix was available, and the human had to run the
+/// update by hand on both — the precise outcome task #288 exists to abolish.
+/// Connection COUNT is not work; outstanding UNCONFIRMED FRAMES are.
+///
+/// `attempts_since_ack` is the delivery-truth counter (#280): frames flushed to
+/// a peer with no ack back yet. Zero across every peer means nothing is in
+/// flight, so a restart drops nothing — regardless of how many peers are
+/// connected.
+///
+/// **A `suspect` peer cannot veto.** A half-open connection's outstanding frames
+/// are never going to be acked (that is what `suspect` means — route refresh is
+/// about to drop and re-dial it). Counting those as live work would let one
+/// wedged pipe block self-update FOREVER: a strictly worse version of the bug
+/// being fixed here, and one that would present identically — a node that just
+/// never updates.
+///
+/// Vacuously true when there are no peers at all, which subsumes the old
+/// zero-connections case rather than dropping it.
+pub fn mesh_is_quiet(peers: impl IntoIterator<Item = (u32, bool)>) -> bool {
+    peers
+        .into_iter()
+        .all(|(attempts_since_ack, suspect)| suspect || attempts_since_ack == 0)
 }
 
 /// Spawn a DETACHED `airc update --auto` — its own process group so it survives
@@ -131,6 +164,52 @@ mod tests {
         assert!(!should_fire(true, false), "busy node must not auto-restart");
         assert!(!should_fire(false, true), "opt-out must be honored");
         assert!(!should_fire(false, false));
+    }
+
+    // what this catches (THE #288/#272 regression): a CONNECTED but quiet node
+    // must still be eligible to self-update. The predicate this replaced was
+    // `connected_lan_peers == 0`, under which a healthy peered node could never
+    // update — two live nodes sat on a stale build for a day on 2026-08-05 and a
+    // human had to run the fix by hand on both. Quiet is about outstanding
+    // frames, not about having peers.
+    #[test]
+    fn a_connected_but_quiet_node_is_still_eligible_to_update() {
+        // Three peers, all connected, none with unacked frames → quiet.
+        assert!(mesh_is_quiet([(0, false), (0, false), (0, false)]));
+        // No peers at all → vacuously quiet (subsumes the old zero-conn case).
+        assert!(mesh_is_quiet([]));
+    }
+
+    // what this catches: the other direction — a node with real in-flight
+    // delivery must NOT restart out from under it. One unacked peer vetoes.
+    #[test]
+    fn outstanding_frames_veto_the_update() {
+        assert!(!mesh_is_quiet([(3, false)]));
+        assert!(
+            !mesh_is_quiet([(0, false), (1, false)]),
+            "one busy peer among idle ones still vetoes"
+        );
+    }
+
+    // what this catches: a wedged half-open pipe must not block self-update
+    // FOREVER. A suspect peer's outstanding frames will never be acked (route
+    // refresh is about to drop and re-dial it), so counting them as live work
+    // would be a strictly worse version of the bug above — a node that simply
+    // never updates again, presenting identically.
+    #[test]
+    fn a_suspect_peer_cannot_veto_forever() {
+        assert!(
+            mesh_is_quiet([(9999, true)]),
+            "suspect peer is not live work"
+        );
+        assert!(
+            mesh_is_quiet([(0, false), (42, true)]),
+            "healthy-idle + suspect-stuck is still quiet"
+        );
+        assert!(
+            !mesh_is_quiet([(42, true), (1, false)]),
+            "but a HEALTHY peer's outstanding frames still veto"
+        );
     }
 
     // what this catches: the interval floor — an override can't drive the check


### PR DESCRIPTION
## The bug

The daemon's self-update loop is wired, default-on, smoke-tested and rollback-safe. It still never ran on either of our nodes, because its idle predicate was inverted:

```rust
is_idle = connected_lan_peers == 0
```

A node doing its job — connected to the mesh, talking to its peer — is **never** "idle" by that measure. So the only nodes eligible to self-update were the ones already isolated, and every healthy node stayed on whatever build it happened to install.

## Why it matters

Lived out today: two continuously-connected nodes both sat on a stale build for a full day while a merged transport fix (#1318) was available on canary, until a human ran the update by hand on both. That is precisely the outcome #288 exists to abolish — *"no human ever runs the fix"* — and it explains why the instruction had to be repeated ~20 times. The automation was structurally incapable of firing on the only nodes that mattered. Repetition was never going to fix it.

## The fix

Connection COUNT is not work. Outstanding UNCONFIRMED FRAMES are.

`mesh_is_quiet` reads the delivery-truth stats (#280): quiet ⟺ no healthy peer has `attempts_since_ack > 0`.

- A **connected-but-quiet** node can now update — the case that was failing.
- A node with **real in-flight delivery** still refuses to restart out from under it.
- **Empty peer set is vacuously quiet**, so the old zero-connection case is subsumed, not dropped.
- Resolves the TODO the call site was already carrying.

### A `suspect` peer cannot veto

Its outstanding frames are never going to be acked — that is what `suspect` *means* (route refresh is about to drop and re-dial it). Counting them as live work would let one wedged pipe block self-update **forever**: a strictly worse version of this same bug, presenting identically as a node that just never updates.

### `try_read`, not `blocking_read`

The predicate runs inside the async tick, and tokio's `RwLock::blocking_read` **panics** in an async context — it would have taken the daemon down on the first tick. A contended read skips that tick *loudly* and retries, rather than guessing "quiet" from a lock it could not read.

## Tests

Three, one per failure direction:

| test | catches |
|---|---|
| `a_connected_but_quiet_node_is_still_eligible_to_update` | the regression in this PR |
| `outstanding_frames_veto_the_update` | restarting mid-transfer |
| `a_suspect_peer_cannot_veto_forever` | a wedged pipe permanently blocking updates |

`cargo test -p airc-daemon --lib auto_update` → 6 passed. clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo