### PR TITLE
Room-parameterized board read + room_by_channel (continuum #345)

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1957,6 +1957,31 @@ impl Airc {
             .map(|subscription| subscription.as_room()))
     }
 
+    /// Resolve a subscribed room by its channel id.
+    ///
+    /// The companion to [`Self::project_room_work_board`] for callers that carry
+    /// a room ID rather than a room: a consumer bound to one room (continuum's
+    /// persona board gate binds `RoomId`) can name the room it means instead of
+    /// falling through to [`Self::current_room`], which answers "whatever my
+    /// default subscription happens to be".
+    ///
+    /// `Ok(None)` is the honest answer for a channel this scope is not
+    /// subscribed to — the caller decides whether that is a degradation to
+    /// tolerate or a bug to shout about. Deliberately NOT falling back to the
+    /// default room: silently substituting a different room's board is the exact
+    /// failure this exists to make impossible.
+    pub async fn room_by_channel(
+        &self,
+        channel: airc_core::RoomId,
+    ) -> Result<Option<Room>, AircError> {
+        let set = self.subscription_set().await?;
+        let found = set
+            .all()
+            .map(|subscription| subscription.as_room())
+            .find(|room| room.channel == channel);
+        Ok(found)
+    }
+
     pub(crate) fn event_store(&self) -> &dyn EventStore {
         self.inner.store.as_ref()
     }

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -857,7 +857,19 @@ impl Airc {
     /// source mismatch, a cursor the log no longer agrees with) is
     /// logged loudly and recovered by a full from-scratch replay —
     /// the cache is an accelerator, never an authority.
-    async fn project_room_work_board(
+    ///
+    /// **Public because a caller that is already room-scoped must be able to say
+    /// WHICH room it means.** [`Self::work_board_complete`] resolves
+    /// `current_room()` — "whatever my default subscription happens to be" — which
+    /// is right for the CLI (the operator's current room IS the intent) and wrong
+    /// for any consumer that carries its own room. Continuum's persona gate binds
+    /// a room id and then checks it against a board this read never consulted; the
+    /// two agree only because both were seeded from the same `current_room()` at
+    /// bootstrap. Nothing prevented a gate that passed for room A while the read
+    /// returned room B, and no probe would have fired. Diagnosed 2026-08-07 while
+    /// tracing why a citizen's board and the operator's disagreed (they were two
+    /// different rooms, and neither surface named the one it read).
+    pub async fn project_room_work_board(
         &self,
         room: &crate::Room,
         page_size: usize,


### PR DESCRIPTION
A room-scoped caller must be able to name the room it means.

## The incident

A citizen's work board showed 58 claimable; the operator's showed 19, all Open. Both reads were correct — they were **different rooms** (`#general` vs `#cambriantech`) — and **neither surface named the room it had read**. Establishing that took three parallel investigations and most of a night.

## The hole

`work_board_complete()` resolves `current_room()` — "whatever my default subscription happens to be". Correct for the CLI, where the operator's current room *is* the intent. Wrong for any consumer carrying its own room.

Continuum's persona board gate binds a `RoomId` and checks it, then reads a board via `work_board_complete()` that never consults that id. They agree today only because both were seeded from the same call at bootstrap. Nothing in the types prevents a gate that passes for room A while the board comes from room B, and **no probe would fire**.

## The change

1. **`project_room_work_board` → `pub`.** The room-parameterized read already existed; it was just private, so callers fell back to the guess.
2. **`room_by_channel(RoomId) -> Option<Room>`.** `Room` carries name + wire + channel and cannot be synthesized from a bare uuid, so a caller holding an id needs a real subscription lookup. Returns `Ok(None)` for an unsubscribed channel and deliberately does **not** fall back to the default room — silently substituting a different room's board is exactly the failure being designed out.

No signature changes, no struct changes, no cache-format changes. `work_board_complete` stays for callers whose intent genuinely is "my current room".

## Verification

338 airc-lib tests green; fmt + clippy gate clean. Consumed by continuum `a60217ba2` (1023 persona tests green), where `RoomBoardReader::work_board` now takes the bound room and a miss raises `NotSubscribed` rather than sliding to the default.