### PR TITLE
fix(work): the board says which room it read, and can be told which room to read (continuum #345)

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -750,13 +750,14 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 work_commands::run_cleanup(&home, dry_run, force).await
             }
             WorkAction::Board {
+                room,
                 limit,
                 available,
                 mine,
                 others,
             } => {
                 let filter = work_commands::BoardFilter::from_flags(available, mine, others);
-                work_commands::run_board(&home, limit, filter).await
+                work_commands::run_board(&home, room, limit, filter).await
             }
             WorkAction::Next {
                 repo,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -157,12 +157,22 @@ pub enum WorkAction {
         #[arg(long)]
         force: bool,
     },
-    /// Print the current room's projected work board.
+    /// Print a room's projected work board (the current room by default).
     ///
     /// `--available`, `--mine`, `--others` are mutually exclusive filters
     /// over the projection so peers can see their slice fast (kink
     /// b408698c). When none are passed, the full board is shown.
+    ///
+    /// The output always names the room it read, with or without `--room`
+    /// (continuum #345) — a board for the wrong room looks exactly like a
+    /// board for the right one, so the reader needs the scope in the answer,
+    /// not only in the question.
     Board {
+        /// Read this room's board instead of the current room. Accepts a
+        /// channel name or a channel id, and must already be subscribed
+        /// (this never auto-joins).
+        #[arg(long)]
+        room: Option<String>,
         /// Maximum card rows to display (newest kept). The projection
         /// itself is always complete — continuum #154: the old
         /// recent-window read lost durable cards to chat traffic.

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1973,16 +1973,36 @@ fn format_lease(expires_at_ms: Option<u64>, now_ms: u64) -> String {
     }
 }
 
+/// Print a room's work board.
+///
+/// `room` is the caller's explicit scope — a channel name or id — and `None`
+/// means "the current room". Continuum #345: whichever way the room is chosen,
+/// the output SAYS which room it read. The flag is the convenience; the label is
+/// the fix. A board read against the wrong room is not an error and does not look
+/// like one — it is a plausible list of somebody else's cards, and the only thing
+/// that distinguishes it from the right answer is a line naming the scope. (I hit
+/// this myself and nearly reported a card released while another peer still held
+/// it, having filed this very bug an hour earlier — knowing about a silent default
+/// does not protect you from it.)
 pub async fn run_board(
     home: &Path,
+    room: Option<String>,
     limit: usize,
     filter: BoardFilter,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = crate::commands::attached_airc(home).await?;
+    let room = match room {
+        Some(ref requested) => {
+            airc.room_by_name_or_channel(requested, "read the work board of")
+                .await?
+        }
+        None => airc.current_room().await?,
+    };
     // Continuum #154: the board is always the COMPLETE projection —
     // the old recent-window read lost every durable card to chat
     // traffic in busy rooms. `limit` now caps displayed rows only.
-    let board = airc.work_board().await?;
+    let board = airc.work_board_in(&room).await?;
+    println!("work board — #{} [{}]", room.name, room.channel);
     let me = airc.peer_id();
 
     // Pre-fetch published aliases for every distinct non-self owner on

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1938,8 +1938,14 @@ impl BoardFilter {
         match self {
             Self::All => true,
             Self::Available => {
-                use airc_work::model::CardState;
-                if matches!(card.state, CardState::Closed | CardState::Merged) {
+                // Ask the SAME predicate the claim gate enforces. This filter
+                // used to spell its own exclusion list (`Closed | Merged`) and
+                // fell behind when `Review` was added to the gate on
+                // 2026-07-24 — so the board advertised settled cards as
+                // available and the claim then refused them. "Available" has
+                // to mean "the claim will accept this", or it is a promise the
+                // substrate breaks at the moment someone acts on it.
+                if card.state.is_settled() {
                     return false;
                 }
                 match (card.claim_id, card.claim_expires_at_ms) {
@@ -3452,6 +3458,57 @@ mod tests {
         // Closed terminal → never available (even with no claim)
         let card = make_card(CardState::Closed, None, None, None);
         assert!(!BoardFilter::Available.matches(&card, me, 1_000));
+
+        // Review with a LAPSED claim → NOT available. This is the case that
+        // was live-wrong (continuum #345 follow-up, measured 2026-08-07): the
+        // lapsed lease made it look reclaimable, the claim gate refuses it as
+        // settled work, and one real board advertised 12 of 12 available with
+        // 4 of them in this exact state.
+        let card = make_card(CardState::Review, Some(other), Some(claim), Some(500));
+        assert!(!BoardFilter::Available.matches(&card, me, 1_000));
+    }
+
+    /// what this catches: the two-surface drift itself, not just one state.
+    /// `--available` is a PROMISE that the claim gate will accept the card, so
+    /// it must agree with `CardState::is_settled` for EVERY variant — including
+    /// ones added later. The original filter spelled its own exclusion list and
+    /// silently fell behind when `Review` joined the gate; enumerating every
+    /// state here means the next variant added to the enum cannot repeat it
+    /// without turning this red.
+    #[test]
+    fn available_never_advertises_a_state_the_claim_gate_refuses() {
+        let me = PeerId::from_u128(10);
+        let other = PeerId::from_u128(20);
+        let claim = ClaimId::from_u128(30);
+
+        for state in [
+            CardState::Open,
+            CardState::Claimed,
+            CardState::InProgress,
+            CardState::Blocked,
+            CardState::Review,
+            CardState::Merged,
+            CardState::Closed,
+        ] {
+            // A lapsed claim is the ONLY interesting case: it is what makes a
+            // card look takeable, so it is where an over-advertising filter
+            // shows up.
+            let card = make_card(state, Some(other), Some(claim), Some(500));
+            let advertised = BoardFilter::Available.matches(&card, me, 1_000);
+            assert!(
+                !(advertised && state.is_settled()),
+                "BUG: --available advertises {state:?}, which the claim gate refuses as settled \
+                 work — the board is promising work the substrate will not hand over"
+            );
+        }
+
+        // Positive control: without this, a filter that returned `false` for
+        // everything would pass the assertion above vacuously.
+        let live = make_card(CardState::Claimed, Some(other), Some(claim), Some(500));
+        assert!(
+            BoardFilter::Available.matches(&live, me, 1_000),
+            "a lapsed claim on unsettled work must still read as available"
+        );
     }
 
     #[test]

--- a/crates/airc-daemon/tests/list_rooms_probe.rs
+++ b/crates/airc-daemon/tests/list_rooms_probe.rs
@@ -4,8 +4,8 @@
 //! Before this op, an attached client (continuum's nav, a TUI room
 //! list) could only learn rooms by watching traffic — a rebooted
 //! interface showed ONE room until each of the others happened to
-//! speak (live-found 2026-07-31: Joel's interface down to just
-//! k3-serving). These tests pin the membership read: every subscribed
+//! speak (live-found 2026-07-31: Joel's interface down to a
+//! single room). These tests pin the membership read: every subscribed
 //! room is returned with its name and default flag, parted rooms are
 //! excluded, and an empty registry is an empty list — never an error.
 //!
@@ -111,7 +111,7 @@ async fn list_rooms_serves_the_registry_and_excludes_parted() {
     coordinator
         .replace_subscriptions(vec![
             sub("general", 0x1, true, false),
-            sub("k3-serving", 0x2, false, false),
+            sub("project-x", 0x2, false, false),
             sub("old-experiment", 0x3, false, true), // explicitly left
         ])
         .await
@@ -127,7 +127,7 @@ async fn list_rooms_serves_the_registry_and_excludes_parted() {
     assert_eq!(rooms[0].name, "general");
     assert_eq!(rooms[0].room_id, RoomId::from_u128(0x1));
     assert!(rooms[0].is_default, "default flag survives the wire");
-    assert_eq!(rooms[1].name, "k3-serving");
+    assert_eq!(rooms[1].name, "project-x");
     assert!(!rooms[1].is_default);
     assert!(
         !rooms.iter().any(|r| r.name == "old-experiment"),

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -146,7 +146,7 @@ pub struct RoomsResponse {
 
 /// One subscribed room, straight from the coordinator store's
 /// subscriptions table. `name` is the human channel name (`general`,
-/// `k3-serving`); `room_id` is the converged UUID clients address
+/// `project-x`); `room_id` is the converged UUID clients address
 /// events with.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IpcRoomInfo {

--- a/crates/airc-lib/src/publish.rs
+++ b/crates/airc-lib/src/publish.rs
@@ -108,21 +108,57 @@ impl Airc {
         match target {
             PublishTarget::CurrentRoom => self.current_room().await,
             PublishTarget::RoomByName(name) => {
-                let set = subscriptions::load_or_init(self.event_store()).await?;
-                let channel_name = subscriptions::ChannelName::new(name).map_err(|error| {
-                    AircError::Route(format!("publish target channel name {name:?}: {error}"))
-                })?;
-                set.subscribed
-                    .get(&channel_name)
-                    .map(|subscription| subscription.as_room())
-                    .ok_or_else(|| {
-                        AircError::Route(format!(
-                            "refusing to publish to {name:?}: this scope is not subscribed to that \
-                             channel. join the room first (publish does not auto-join)."
-                        ))
-                    })
+                self.room_by_name_or_channel(name, "publish to").await
             }
         }
+    }
+
+    /// Resolve a room the caller NAMED — by channel name, or by the channel id
+    /// it already holds — against this scope's subscription set.
+    ///
+    /// One resolver, every "this room or that one" surface. `publish` had this
+    /// logic privately; the work board needs exactly the same question answered
+    /// (continuum #345), and a second copy would be the kind of duplication that
+    /// drifts — the two would disagree about whether an id is acceptable, or about
+    /// what the refusal says.
+    ///
+    /// Accepts a channel ID as well as a name because callers legitimately hold
+    /// either: a human types `#general`, while an agent reading a board or a
+    /// receipt has the raw channel uuid and nothing else. Refusing the id would
+    /// force every such caller to invent its own id→name lookup.
+    ///
+    /// NEVER auto-joins. A room outside the subscription set is a loud refusal
+    /// naming the room and the remedy, because reading or publishing must not
+    /// silently change what this scope is part of.
+    pub async fn room_by_name_or_channel(
+        &self,
+        name_or_channel: &str,
+        verb: &str,
+    ) -> Result<crate::Room, AircError> {
+        // Id first: a uuid is unambiguous, and a channel name can never parse as one.
+        if let Ok(uuid) = uuid::Uuid::parse_str(name_or_channel) {
+            let channel = RoomId::from_uuid(uuid);
+            if let Some(room) = self.room_by_channel(channel).await? {
+                return Ok(room);
+            }
+            return Err(AircError::Route(format!(
+                "refusing to {verb} {name_or_channel:?}: this scope is not subscribed to that \
+                 channel id. join the room first (this does not auto-join)."
+            )));
+        }
+        let set = subscriptions::load_or_init(self.event_store()).await?;
+        let channel_name = subscriptions::ChannelName::new(name_or_channel).map_err(|error| {
+            AircError::Route(format!("channel name {name_or_channel:?}: {error}"))
+        })?;
+        set.subscribed
+            .get(&channel_name)
+            .map(|subscription| subscription.as_room())
+            .ok_or_else(|| {
+                AircError::Route(format!(
+                    "refusing to {verb} {name_or_channel:?}: this scope is not subscribed to that \
+                     channel. join the room first (this does not auto-join)."
+                ))
+            })
     }
 }
 

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -5,7 +5,7 @@ use crate::work_board_cache::{
     cursor_strictly_before, zero_transcript_cursor, WorkBoardCache, WorkBoardCacheSource,
     WORK_BOARD_CACHE_FORMAT_VERSION,
 };
-use crate::{Airc, AircError};
+use crate::{Airc, AircError, Room};
 use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
@@ -826,7 +826,22 @@ impl Airc {
     /// projection the scheduling/mutation paths use (cheap since card
     /// 1291173d: snapshot + incremental resume).
     pub async fn work_board(&self) -> Result<WorkBoardProjection, AircError> {
-        self.work_board_complete(WORK_BOARD_PROJECTION_PAGE_SIZE)
+        self.work_board_in(&self.current_room().await?).await
+    }
+
+    /// The complete work board of a room the caller RESOLVED for itself.
+    ///
+    /// [`Self::work_board`] answers "the board of whatever room I happen to
+    /// point at"; this answers "the board of THIS room". Continuum #345: a
+    /// caller that means a specific room must be able to say so, because the
+    /// silent default produces a plausible board for the wrong room and nothing
+    /// in the result says which one it read.
+    ///
+    /// Same page size as `work_board` — the default lives in exactly one place,
+    /// so the two can never disagree about how much history a "complete" board
+    /// folds in.
+    pub async fn work_board_in(&self, room: &Room) -> Result<WorkBoardProjection, AircError> {
+        self.project_room_work_board(room, WORK_BOARD_PROJECTION_PAGE_SIZE)
             .await
     }
 

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -1187,12 +1187,9 @@ impl Airc {
         // personas kept re-claiming already-completed cards because this guard
         // only checked lease expiry — the board read as open work forever.
         // Reopening is an explicit `airc work state` transition, never a claim.
-        if matches!(
-            card.state,
-            airc_work::CardState::Review
-                | airc_work::CardState::Merged
-                | airc_work::CardState::Closed
-        ) {
+        // The predicate lives on CardState so the surfaces that ADVERTISE
+        // claimability answer with the same rule this gate enforces.
+        if card.state.is_settled() {
             return Err(AircError::WorkCardNotClaimable {
                 card_id,
                 state: card.state,

--- a/crates/airc-lib/tests/work_board_room_scoped.rs
+++ b/crates/airc-lib/tests/work_board_room_scoped.rs
@@ -1,0 +1,127 @@
+//! Continuum #345: a work board must be readable for a NAMED room, and the
+//! answer must be that room's cards — never the current room's.
+//!
+//! `airc work board` had no room parameter at all: it read whatever room the
+//! scope's default pointer happened to reference. That is not a missing
+//! convenience, it is a correctness hazard, because the failure produces a
+//! *plausible* board rather than an error — a real board, fully populated, for
+//! the wrong room. The operator who filed this card was fooled by it within the
+//! hour, and nearly reported a card released while another peer still held it.
+//!
+//! What this catches: a regression where the scoped read falls back to
+//! `current_room()` (the exact bug), or where the resolver auto-joins /
+//! silently substitutes a room instead of refusing. The two rooms below each
+//! hold a card the other does not, so a fallback cannot pass by coincidence.
+
+mod common;
+
+use airc_lib::{Airc, CreateWorkCard, Priority, RepoId};
+use common::Machine;
+
+async fn create_card(airc: &Airc, title: &str) {
+    airc.create_work_card(CreateWorkCard {
+        repo: RepoId::new("test-org/test-repo").unwrap(),
+        title: title.to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        reviews: None,
+    })
+    .await
+    .expect("create work card");
+}
+
+fn titles(board: &airc_lib::WorkBoardProjection) -> Vec<String> {
+    let mut titles: Vec<String> = board
+        .snapshot()
+        .cards
+        .into_iter()
+        .map(|card| card.title)
+        .collect();
+    titles.sort();
+    titles
+}
+
+#[tokio::test]
+async fn a_board_read_for_a_named_room_returns_that_rooms_cards_not_the_current_rooms() {
+    let machine = Machine::boot().await;
+    let alice = machine.attach("alice").await;
+
+    // Two rooms, one distinct card each. Cards land in whatever room is
+    // current at creation time, so create-then-switch.
+    let other = alice
+        .join("other-room")
+        .await
+        .expect("alice joins other-room");
+    create_card(&alice, "OTHER-ROOM CARD").await;
+    let home = alice
+        .join("home-room")
+        .await
+        .expect("alice joins home-room");
+    create_card(&alice, "HOME-ROOM CARD").await;
+
+    // Precondition: the default read answers for home-room. If this ever
+    // fails the rest of the test proves nothing, so assert it explicitly.
+    assert_eq!(
+        titles(&alice.work_board().await.expect("default board")),
+        vec!["HOME-ROOM CARD".to_string()],
+        "test precondition: the unscoped board reads the current (home) room"
+    );
+
+    // By name.
+    let resolved = alice
+        .room_by_name_or_channel(&other.name, "read the work board of")
+        .await
+        .expect("resolve other-room by name");
+    assert_eq!(resolved.channel, other.channel);
+    assert_eq!(
+        titles(&alice.work_board_in(&resolved).await.expect("scoped board")),
+        vec!["OTHER-ROOM CARD".to_string()],
+        "BUG: a board read scoped to other-room returned the CURRENT room's cards \
+         — the silent-default failure #345 exists to make impossible"
+    );
+
+    // By channel id — an agent reading a receipt or a board row holds the
+    // uuid and nothing else, and must not have to invent an id→name lookup.
+    let by_id = alice
+        .room_by_name_or_channel(&other.channel.to_string(), "read the work board of")
+        .await
+        .expect("resolve other-room by channel id");
+    assert_eq!(by_id.channel, other.channel, "id resolution finds the room");
+
+    // Reading another room's board must not move the pointer — same
+    // invariant `publish_to_room_does_not_mutate_default` pins for sends.
+    let current = alice.current_room().await.expect("read current room after");
+    assert_eq!(
+        current.channel, home.channel,
+        "BUG: a scoped board read mutated the default-room pointer"
+    );
+}
+
+#[tokio::test]
+async fn resolving_an_unsubscribed_room_refuses_loudly_instead_of_falling_back() {
+    let machine = Machine::boot().await;
+    let alice = machine.attach("alice").await;
+    alice
+        .join("home-room")
+        .await
+        .expect("alice joins home-room");
+
+    // What this catches: a "helpful" fallback to the current room. A board for
+    // a room you are not in must be an error the caller can see, because the
+    // alternative — a valid-looking board for a different room — is exactly the
+    // answer that fooled a careful reader.
+    let error = alice
+        .room_by_name_or_channel("a-room-alice-never-joined", "read the work board of")
+        .await
+        .expect_err("unsubscribed room must refuse, never fall back");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("a-room-alice-never-joined"),
+        "refusal must name the room the caller asked for, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("join"),
+        "refusal must name the remedy, got: {rendered}"
+    );
+}

--- a/crates/airc-work/src/model.rs
+++ b/crates/airc-work/src/model.rs
@@ -28,6 +28,30 @@ pub enum CardState {
     Closed,
 }
 
+impl CardState {
+    /// Is this card SETTLED — past claiming regardless of lease status?
+    ///
+    /// The single authority for "can this state be claimed at all". The claim
+    /// guard (`airc-lib::work`) and every surface that ADVERTISES claimability
+    /// must ask this one function, or they drift — and when they drift, the
+    /// board offers work that the claim path then refuses, which reads to the
+    /// person picking a card as a broken substrate.
+    ///
+    /// That drift was live, measured on 2026-08-07: the claim guard was taught
+    /// on 2026-07-24 that `Review` is history, not backlog (personas kept
+    /// re-claiming completed cards), but the board's `--available` filter was
+    /// never told. It excluded only `Merged | Closed`, so on one real board it
+    /// advertised 12 of 12 cards as available while 4 of them bounced with
+    /// "settled work is not claimable". The operator reading that board — me —
+    /// reported the inflated number as fact.
+    ///
+    /// `Blocked` is deliberately NOT settled: a blocked card is live work
+    /// waiting on something, and someone taking it over is exactly the move.
+    pub fn is_settled(self) -> bool {
+        matches!(self, Self::Review | Self::Merged | Self::Closed)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LaneState {


### PR DESCRIPTION
Closes the continuum-side card #345.

## The bug

`airc work board` had no room parameter. It read whatever room the scope's default pointer happened to reference, and said nothing about which one that was.

That is not a missing convenience — it is a correctness hazard, because the failure produces a **plausible** board rather than an error: a real, fully-populated board for the wrong room.

I hit it myself within an hour of filing the card. `airc room k3-serving` in one turn, `airc work board | grep <card>` in a later turn; the pointer had not persisted, the read landed on #general, the card was absent, and I was one sentence from reporting that a citizen had released a card she was still holding (`lease=22m12s`). Knowing about a silent default does not protect you from it — the failure mode is the *absence* of a signal, and you cannot notice an absence by intending to.

## The fix — the label, not just the flag

- **Every** board read prints `work board — #<name> [<channel>]` first, with or without `--room`. The scope is in the answer, not only in the question.
- `--room <name-or-channel-id>` reads a named room. Ids are accepted because agents legitimately hold one and nothing else (a receipt, a board row).
- An unsubscribed room **refuses**, naming the room and the remedy. Never auto-joins, never falls back.
- The pointer never moves — the same invariant `publish_to_room_does_not_mutate_default` pins for one-shot sends.

## Compression

`publish`'s private target resolver is generalized to `Airc::room_by_name_or_channel(name_or_channel, verb)` and shared, not copied — two copies would drift on whether an id is acceptable and on what the refusal says. `work_board()` is now `work_board_in(current_room())`, so the complete-board page size lives in one place.

## Verification

**Tests** (`crates/airc-lib/tests/work_board_room_scoped.rs`, real daemon fixture): two rooms each holding a card the other lacks, so a current-room fallback cannot pass by coincidence; plus the loud-refusal case.

**Mutation-verified** — with `work_board_in` reverted to `current_room()`:
```
left: ["HOME-ROOM CARD"] / right: ["OTHER-ROOM CARD"]
```

**Live against the running daemon** (current room `k3-serving`):

| read | result |
|---|---|
| no flag | `work board — #k3-serving [effe5955…]`, 12 cards |
| `--room k3-serving` | identical |
| `--room cb2e21a1-…` (id) | `work board — #cambriantech [cb2e21a1…]`, 19 cards — a genuinely different board |
| `airc room` after both | unchanged |
| `--room no-such-room-here` | `refusing to read the work board of "no-such-room-here": … join the room first (this does not auto-join).` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo