### PR TITLE
feat(wall): room-scoped wall read (wall_posts_in) — the standing question needs a room

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1110,7 +1110,40 @@ impl Airc {
         &self,
         category_filter: Option<&str>,
     ) -> Result<Vec<airc_core::doctrine::WallPostPublished>, AircError> {
-        let events = self.page_recent(500).await?;
+        self.wall_posts_in(&self.current_room().await?, category_filter)
+            .await
+    }
+
+    /// The wall of a room the caller RESOLVED for itself.
+    ///
+    /// [`Self::wall_posts`] answers "the wall of whatever room I happen to
+    /// point at"; this answers "the wall of THIS room". Same split, and the
+    /// same reason, as [`Self::work_board`] vs `work_board_in`: a caller that
+    /// means a specific room must be able to say so, because the silent
+    /// default returns a plausible wall for the wrong room and nothing in the
+    /// result says which one it read.
+    ///
+    /// Continuum needs this to ask "is room X concluded?" about a room its
+    /// handle is not currently attached to — a persona reacts to traffic from
+    /// any subscribed room, not just its default one, so a current-room-only
+    /// read would answer about the wrong room precisely when the two differ.
+    ///
+    /// Reads through [`Self::room_transcripts_since`], the same room-scoped,
+    /// daemon-aware event path the work board projects from — wall and board
+    /// are two projections of one transcript and must never disagree about
+    /// which events they can see.
+    pub async fn wall_posts_in(
+        &self,
+        room: &crate::Room,
+        category_filter: Option<&str>,
+    ) -> Result<Vec<airc_core::doctrine::WallPostPublished>, AircError> {
+        let events = self
+            .room_transcripts_since(
+                room,
+                &crate::work_board_cache::zero_transcript_cursor(),
+                WALL_PROJECTION_PAGE_SIZE,
+            )
+            .await?;
         // Discriminate on each event's self-describing body, NOT its
         // transcript `kind` — see [`wall_post_from_event`] for why the
         // kind is unreliable on the daemon-attached read path.
@@ -2173,6 +2206,14 @@ fn warn_subscription_rebinds(rebinds: &[subscriptions::SubscriptionRebind]) {
         );
     }
 }
+
+/// How much room history a wall projection folds in.
+///
+/// Generous because a busy room accumulates pinned posts over time, and a
+/// wall post that scrolls out of the window silently stops being true —
+/// which is worse than a slow read. Declared once so `wall_posts` and
+/// `wall_posts_in` can never disagree about what "the wall" means.
+pub const WALL_PROJECTION_PAGE_SIZE: usize = 500;
 
 fn wall_post_from_event(
     event: airc_core::TranscriptEvent,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -980,7 +980,7 @@ impl Airc {
     /// `cursor`, in transcript order — via the daemon when attached,
     /// the local store otherwise. Pass the zero cursor for the
     /// complete history.
-    async fn room_transcripts_since(
+    pub(crate) async fn room_transcripts_since(
         &self,
         room: &crate::Room,
         cursor: &airc_core::TranscriptCursor,

--- a/crates/airc-lib/tests/wall_posts_room_scoped.rs
+++ b/crates/airc-lib/tests/wall_posts_room_scoped.rs
@@ -1,0 +1,131 @@
+//! A wall must be readable for a NAMED room, and the answer must be that
+//! room's posts — never the current room's.
+//!
+//! Same correctness hazard as the room-scoped work board (Continuum #345), on
+//! the other projection of the same transcript: `wall_posts` read through
+//! `page_recent`, which is current-room-only, so a caller that meant a specific
+//! room got a *plausible* wall for the wrong one rather than an error.
+//!
+//! This matters because Continuum reads a room's STANDING off its wall — "is
+//! this activity concluded?" A persona reacts to traffic from any room it
+//! subscribes to, not only its default one, so the current-room read answers
+//! about the wrong room in exactly the case where the two differ, which is
+//! exactly when the question is being asked.
+//!
+//! What this catches: a regression where the scoped read falls back to
+//! `current_room()`, or where the two rooms' posts bleed together. Each room
+//! below holds a post the other does not, so a fallback cannot pass by
+//! coincidence.
+
+mod common;
+
+use airc_lib::Airc;
+use common::Machine;
+
+const CATEGORY: &str = "standing";
+
+async fn publish(airc: &Airc, body: &str) {
+    airc.publish_wall_post(CATEGORY.to_string(), body.to_string(), None)
+        .await
+        .expect("publish wall post");
+}
+
+async fn bodies(airc: &Airc, room: &airc_lib::Room) -> Vec<String> {
+    let mut bodies: Vec<String> = airc
+        .wall_posts_in(room, Some(CATEGORY))
+        .await
+        .expect("scoped wall read")
+        .into_iter()
+        .map(|post| post.body)
+        .collect();
+    bodies.sort();
+    bodies
+}
+
+#[tokio::test]
+async fn a_wall_read_for_a_named_room_returns_that_rooms_posts_not_the_current_rooms() {
+    let machine = Machine::boot().await;
+    let alice = machine.attach("alice").await;
+
+    // Two rooms, one distinct post each. Posts land in whatever room is
+    // current at publish time, so publish-then-switch.
+    let other = alice
+        .join("other-room")
+        .await
+        .expect("alice joins other-room");
+    publish(&alice, "OTHER-ROOM STANDING").await;
+    let home = alice
+        .join("home-room")
+        .await
+        .expect("alice joins home-room");
+    publish(&alice, "HOME-ROOM STANDING").await;
+
+    // Precondition: the default read answers for home-room. If this ever
+    // fails the rest of the test proves nothing, so assert it explicitly.
+    let default: Vec<String> = alice
+        .wall_posts(Some(CATEGORY))
+        .await
+        .expect("default wall")
+        .into_iter()
+        .map(|post| post.body)
+        .collect();
+    assert_eq!(
+        default,
+        vec!["HOME-ROOM STANDING".to_string()],
+        "test precondition: the unscoped wall reads the current (home) room"
+    );
+
+    // The actual contract: ask for the OTHER room while pointed at home, and
+    // get the other room's wall. A current-room fallback returns the home post
+    // here — a plausible answer, and the wrong one.
+    assert_eq!(
+        bodies(&alice, &other).await,
+        vec!["OTHER-ROOM STANDING".to_string()],
+        "a wall read for a named room must answer for THAT room"
+    );
+
+    // And naming the current room explicitly still works — the scoped path is
+    // the only implementation, so this pins that `wall_posts` delegating to it
+    // did not change what the default read means.
+    assert_eq!(
+        bodies(&alice, &home).await,
+        vec!["HOME-ROOM STANDING".to_string()],
+        "naming the current room reads the same wall the default read does"
+    );
+}
+
+/// what this catches: the category filter silently widening when the read went
+/// room-scoped. A standing read must not pick up a room's other pinned posts —
+/// if it did, "is this room concluded?" would parse an unrelated body and, per
+/// `current_standing`'s hard-error-on-unparseable rule, fail the whole turn.
+#[tokio::test]
+async fn a_scoped_wall_read_still_honors_the_category_filter() {
+    let machine = Machine::boot().await;
+    let alice = machine.attach("alice").await;
+
+    let room = alice.join("filtered-room").await.expect("alice joins");
+    publish(&alice, "STANDING POST").await;
+    alice
+        .publish_wall_post("doctrine".to_string(), "DOCTRINE POST".to_string(), None)
+        .await
+        .expect("publish doctrine post");
+
+    assert_eq!(
+        bodies(&alice, &room).await,
+        vec!["STANDING POST".to_string()],
+        "the standing category must not pick up a doctrine post"
+    );
+
+    let all: Vec<String> = alice
+        .wall_posts_in(&room, None)
+        .await
+        .expect("unfiltered scoped wall")
+        .into_iter()
+        .map(|post| post.body)
+        .collect();
+    assert_eq!(
+        all.len(),
+        2,
+        "unfiltered, the same scoped read sees both posts: {all:?}"
+    );
+}


### PR DESCRIPTION
## Why

`wall_posts` reads through `page_recent`, which is **current-room only**. A caller that means a specific room gets a plausible wall for the wrong one — not an error, a real answer about the wrong subject. Exactly the hazard PR #1322 fixed for the work board (#345), on the other projection of the same transcript.

## What Continuum needs it for

A room's **standing** — "is this activity concluded?" — lives on its wall. A persona reacts to traffic from any room it subscribes to, not just its default one, so a current-room read answers about the wrong room *precisely when the two differ*, which is exactly when the question is worth asking.

This is load-bearing for the continuum-side fix where a concluded activity stops recruiting ambient turns while staying fully readable forever.

## What changed

- `wall_posts_in(room, category)` — the scoped read.
- `wall_posts(category)` now delegates to it with `current_room()`. Same split as `work_board` / `work_board_in`.
- Reads through `room_transcripts_since` — the same room-scoped, daemon-aware event path the work board projects from. Wall and board are two views of one transcript and must never disagree about which events they can see.
- Page size lifted to `WALL_PROJECTION_PAGE_SIZE` (500, unchanged) so the two entry points cannot drift on what "the wall" means.
- `room_transcripts_since` widened `private` → `pub(crate)`.

## Tests

`crates/airc-lib/tests/wall_posts_room_scoped.rs`:

1. **Two rooms, one distinct post each.** Ask for the other room's wall while pointed at home. A current-room fallback returns the home post and fails — the strings are distinct so coincidence can't pass it. The precondition (unscoped read answers for the current room) is asserted explicitly; without it the rest proves nothing.
2. **Category filter survives the scoped read.** A standing read that picked up a doctrine post would hard-error the caller's turn, per `current_standing`'s parse rule.

Full `airc-lib` suite: 33 test binaries, zero failures. All 15 pre-existing wall tests green — worth noting because this changed what `wall_posts` reads *through*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo