### PR TITLE
update reports the CHECKOUT, so a replaced binary reads as a no-op — and install.sh refuses your own branch

### DIFF
--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -1113,18 +1113,27 @@ mod tests {
         // Source advanced but the binary was already built from the new tip —
         // distinct from a no-op for anyone debugging a stale node.
         let caught_up = update_summary(Some("a08f3d38145c"), "35d40b1", "a08f3d3", "canary");
-        assert!(caught_up.contains("source 35d40b1 -> a08f3d3"), "{caught_up}");
+        assert!(
+            caught_up.contains("source 35d40b1 -> a08f3d3"),
+            "{caught_up}"
+        );
 
         // Unreportable previous build is UNKNOWN, never "unchanged" — an old
         // binary with no `build:` banner is exactly the one needing an update.
         let unknown = update_summary(None, "35d40b1", "a08f3d3", "canary");
-        assert!(!unknown.contains("Already at"), "unknown != no-op: {unknown}");
+        assert!(
+            !unknown.contains("Already at"),
+            "unknown != no-op: {unknown}"
+        );
         assert!(unknown.contains("previous build unknown"), "{unknown}");
 
         // Short-vs-long SHA forms must still compare equal (same tolerance the
         // smoke test uses), or every update would report itself as a change.
         let mixed = update_summary(Some("a08f3d38145c"), "a08f3d3", "a08f3d3", "canary");
-        assert!(mixed.starts_with("Already at"), "prefix match holds: {mixed}");
+        assert!(
+            mixed.starts_with("Already at"),
+            "prefix match holds: {mixed}"
+        );
     }
 
     // what this catches: the SHA match tolerates the differing short-SHA

--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -68,6 +68,13 @@ pub fn run_update(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std::error
     if daemon_was_running {
         stop_daemon(&airc_exe, home, &socket)?;
     }
+    // What the OPERATOR is holding, read before we replace it. `before`/`after`
+    // above describe the git checkout; this describes the tool. They are
+    // independent, and the summary at the end has to speak about this one.
+    // (Canary's #1332 moved `prepare_build_source` before the no-op gate;
+    // this read only has to precede `run_installer`, which is what replaces
+    // the binary.)
+    let binary_before = installed_binary_sha(&airc_exe);
 
     run_installer(&build_dir)?;
 
@@ -111,11 +118,30 @@ pub fn run_update(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std::error
         .into());
     }
 
-    if before == after {
-        println!("Already at {after} on channel {channel}.");
-    } else {
-        println!("Updated ({channel}): {before} -> {after}");
-    }
+    // Report the BINARY's transition, not the checkout's (#354 follow-up).
+    //
+    // #354 made the update VERIFY the binary but left the summary branching on
+    // `before == after` — two git refs. Those describe the checkout, and the
+    // checkout can already be current while the binary is stale, so the two
+    // most different outcomes printed the SAME line:
+    //
+    //   nothing happened                     -> "Already at a08f3d3 on channel canary."
+    //   your binary was just replaced        -> "Already at a08f3d3 on channel canary."
+    //
+    // Measured on BigMama 2026-08-07, immediately after #354 landed: source was
+    // already at a08f3d3 (a manual pull had moved it), the installed binary was
+    // still 35d40b1, `airc update` rebuilt and installed a08f3d3 — and printed
+    // "Already at". The verification worked; the sentence describing it did not.
+    // An operator reading "Already at" reasonably concludes no work was done and
+    // does not restart anything that embeds the binary.
+    //
+    // Same defect as #354, one layer down: #354 fixed which object we CHECK,
+    // this fixes which object we TALK ABOUT. Both halves have to point at the
+    // tool the operator is holding.
+    println!(
+        "{}",
+        update_summary(binary_before.as_deref(), &before, &after, &channel)
+    );
     if daemon_was_running {
         restart_daemon(&airc_exe, home, &socket)?;
         wait_daemon_ready(&airc_exe, home, &socket)?;
@@ -422,6 +448,54 @@ fn smoke_test_new_binary(airc_exe: &Path, expected_short: &str) -> bool {
     match parse_build_sha(&stdout) {
         Some(sha) => smoke_sha_matches(&sha, expected_short),
         None => false,
+    }
+}
+
+/// The SHA the CURRENTLY INSTALLED binary reports, read by running it. `None`
+/// when it won't run or predates the `build:` banner — an old binary being
+/// exactly the case where an update matters most, so callers must treat `None`
+/// as "unknown", never as "unchanged".
+fn installed_binary_sha(airc_exe: &Path) -> Option<String> {
+    let output = Command::new(airc_exe).arg("version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_build_sha(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// The one line the operator reads. Speaks about the BINARY; mentions the
+/// checkout only when it is the thing that did not move.
+///
+/// `binary_before` is `None` when the old binary could not report its SHA. That
+/// is NOT "unchanged" — an unreportable binary is precisely the stale one — so
+/// it renders as an installed-at statement rather than an "Already at" that
+/// would claim a no-op we cannot substantiate.
+///
+/// Pure — unit-tested.
+fn update_summary(
+    binary_before: Option<&str>,
+    source_before: &str,
+    after: &str,
+    channel: &str,
+) -> String {
+    match binary_before {
+        Some(b) if smoke_sha_matches(b, after) => {
+            // Binary already correct. Say whether the checkout moved under it,
+            // because "nothing to do" and "the source advanced but the binary
+            // was already built from it" are different facts to an operator
+            // debugging a stale node.
+            if source_before == after {
+                format!("Already at {after} on channel {channel} (binary and source current).")
+            } else {
+                format!(
+                    "Already at {after} on channel {channel} (binary current; source {source_before} -> {after})."
+                )
+            }
+        }
+        Some(b) => format!("Updated ({channel}): binary {b} -> {after}"),
+        None => format!(
+            "Installed ({channel}): binary now {after} (previous build unknown — it could not report one)"
+        ),
     }
 }
 
@@ -1012,6 +1086,45 @@ mod tests {
             "  airc 0.1.0\n  install: /home/u/.local/bin/airc\n  build:   9cc678fc0203 on canary\n";
         assert_eq!(parse_build_sha(out).as_deref(), Some("9cc678fc0203"));
         assert_eq!(parse_build_sha("no build line here"), None);
+    }
+
+    // what this catches: the summary must describe the BINARY, because the two
+    // most different outcomes used to print the identical line. Regression for
+    // the live BigMama case on 2026-08-07, immediately after #354: the checkout
+    // was ALREADY at a08f3d3 (a manual pull had moved it) while the installed
+    // binary was still 35d40b1, so `before == after` held, the binary was
+    // genuinely replaced, and update printed "Already at" — which an operator
+    // reads as "no work done" and acts on by not restarting anything.
+    #[test]
+    fn summary_reports_the_binary_transition_not_the_checkouts() {
+        // THE live case: source already current, binary stale → an UPDATE.
+        let s = update_summary(Some("35d40b1468ee"), "a08f3d3", "a08f3d3", "canary");
+        assert!(
+            s.starts_with("Updated (canary): binary 35d40b1468ee -> a08f3d3"),
+            "a replaced binary must not read as a no-op: {s}"
+        );
+        assert!(!s.contains("Already at"), "the old wording is the bug: {s}");
+
+        // Genuine no-op: binary already the pulled SHA and source did not move.
+        let noop = update_summary(Some("a08f3d38145c"), "a08f3d3", "a08f3d3", "canary");
+        assert!(noop.starts_with("Already at a08f3d3"), "{noop}");
+        assert!(noop.contains("binary and source current"), "{noop}");
+
+        // Source advanced but the binary was already built from the new tip —
+        // distinct from a no-op for anyone debugging a stale node.
+        let caught_up = update_summary(Some("a08f3d38145c"), "35d40b1", "a08f3d3", "canary");
+        assert!(caught_up.contains("source 35d40b1 -> a08f3d3"), "{caught_up}");
+
+        // Unreportable previous build is UNKNOWN, never "unchanged" — an old
+        // binary with no `build:` banner is exactly the one needing an update.
+        let unknown = update_summary(None, "35d40b1", "a08f3d3", "canary");
+        assert!(!unknown.contains("Already at"), "unknown != no-op: {unknown}");
+        assert!(unknown.contains("previous build unknown"), "{unknown}");
+
+        // Short-vs-long SHA forms must still compare equal (same tolerance the
+        // smoke test uses), or every update would report itself as a change.
+        let mixed = update_summary(Some("a08f3d38145c"), "a08f3d3", "a08f3d3", "canary");
+        assert!(mixed.starts_with("Already at"), "prefix match holds: {mixed}");
     }
 
     // what this catches: the SHA match tolerates the differing short-SHA

--- a/install.sh
+++ b/install.sh
@@ -566,6 +566,28 @@ EOF
     exit 1
   fi
   info "Channel = current branch '$CURRENT_BRANCH'"
+  # A LOCAL-ONLY branch is not an error — it is the most common thing a
+  # contributor does. "Fast-forward whatever branch is checked out" has nothing
+  # to fast-forward when the branch exists only here, so build the tree as-is
+  # rather than failing.
+  #
+  # Measured 2026-08-07: `./install.sh` from a dev checkout on an unpushed
+  # feature branch died with "fatal: couldn't find remote ref <branch>" +
+  # "Network? gh auth?" — a message that sends you to check your token when
+  # your token is fine. The one action this script exists for, installing the
+  # build you just made, was the action it refused. The documented recovery
+  # ("git checkout canary && ./install.sh") works only because it throws your
+  # branch away, which is the opposite of what you asked for.
+  #
+  # This preserves the design intent above — git stays the state manager and we
+  # still never silently switch branches — while removing the footgun for the
+  # case that intent implies should work: testing your own commits. Same shape
+  # as the Rust updater's #288 fix (a channel must not be whatever branch the
+  # checkout happens to sit on); that one was fixed in update_commands.rs and
+  # this path kept the original behaviour.
+  if ! git -C "$CLONE_DIR" ls-remote --exit-code --heads origin "$CURRENT_BRANCH" >/dev/null 2>&1; then
+    info "Branch '$CURRENT_BRANCH' has no remote counterpart — installing this tree as-is (nothing to pull)"
+  else
   git -C "$CLONE_DIR" fetch --quiet origin "$CURRENT_BRANCH" || {
     echo "ERROR: Couldn't fetch origin/$CURRENT_BRANCH. Network? gh auth?" >&2
     exit 1
@@ -584,6 +606,7 @@ Recover with:
 EOF
     exit 1
   fi
+  fi  # local-only-branch guard
   fi  # AIRC_INSTALL_NO_PULL guard
 else
   # First install. The channel is just a git branch — git is the state


### PR DESCRIPTION
Two fixes found by testing #354 on the box where the original incident happened. #354 works — it caught nothing here only because the thing it checks was already right. What it exposed is that the *other half* of the same seam was never fixed.

## 1. The summary describes the checkout, not the binary

#354 made the manual path VERIFY the binary, but left the summary branching on `before == after` — two **git refs**. Those describe the checkout, and the checkout can already be current while the installed binary is stale. So the two most different outcomes printed the identical line:

```
nothing happened               -> "Already at a08f3d3 on channel canary."
your binary was just replaced  -> "Already at a08f3d3 on channel canary."
```

**Measured on BigMama 2026-08-07, immediately after #354 landed.** Source was already at `a08f3d3` (an earlier manual pull had moved it); the installed binary was still `35d40b1`. `airc update` rebuilt, installed `a08f3d3`, verified it via `smoke_test_new_binary` — and printed **"Already at"**. The verification worked exactly as intended; the sentence reporting it did not. An operator reading "Already at" concludes no work was done, and does not restart anything embedding the binary.

Same defect as #354, one layer down: **#354 fixed which object we CHECK; this fixes which object we TALK ABOUT.** Both halves have to point at the tool the operator is holding, and it took #354 landing to reveal that only one did.

Reads the installed binary's SHA *before* the installer runs and reports that transition. Four outcomes, four distinct sentences:

| situation | output |
|---|---|
| binary changed | `Updated (canary): binary 35d40b1 -> a08f3d3` |
| binary + source current | `Already at a08f3d3 … (binary and source current).` |
| binary current, source moved | `Already at a08f3d3 … (binary current; source X -> a08f3d3).` |
| previous build unreportable | `Installed (canary): binary now a08f3d3 (previous build unknown…)` |

That last case is deliberately **not** "Already at": a binary too old to print a `build:` banner is precisely the one an update matters for, so unknown must never render as unchanged.

`update_summary` is pure and unit-tested, matching the file's existing style. The regression test pins the live case by name.

## 2. `install.sh` refuses a local-only branch

```
fatal: couldn't find remote ref fix/update-reports-the-binary-not-the-checkout
ERROR: Couldn't fetch origin/<branch>. Network? gh auth?
```

Both lines mislead — network and token were fine. The branch just didn't exist on the remote yet, which is the normal state of a branch you're still working on. **So the one action this script exists for, installing the build you just made, was the action it refused.** The documented recovery (`git checkout canary && ./install.sh`) works only by throwing your branch away.

The design intent in that block is right and is preserved: git stays the state manager, the checked-out branch is the channel, and we still never silently switch branches. "Fast-forward whatever branch is checked out" simply has nothing to fast-forward when the branch is local-only — so build the tree as-is and say so.

Same shape as the Rust updater's #288 fix (a channel must not be whatever branch a checkout happens to sit on). That was fixed in `update_commands.rs`; this path kept the original behaviour, so the two disagreed about the same situation.

## Verification — live, end to end, on the box where it failed

```
$ ./install.sh
-> Branch 'fix/...' has no remote counterpart — installing this tree as-is (nothing to pull)
install rc=0        # was rc=1

$ airc update
Updated (canary): binary 9efa81137346 -> a08f3d3     # was "Already at a08f3d3"
$ airc version
build:   a08f3d38145c on canary
```

Self-cleaning: the run that demonstrates the fix also restores the node to canary. 14 tests pass in `update_commands`; `bash -n install.sh` clean; `cargo fmt` applied.

Fix 2 is what made fix 1 testable — without it there is no way to run your own build of airc at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
