### PR TITLE
feat(lib): current_room_landing_in — caller-chosen fresh-scope landing room (canary re-land of #1328)

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1949,13 +1949,29 @@ impl Airc {
     /// `#general` through the subscription set, using the resolved
     /// mesh identity so the `RoomId` is stable per Git/GitHub user.
     pub async fn current_room(&self) -> Result<Room, AircError> {
+        self.current_room_landing_in("general").await
+    }
+
+    /// [`current_room`](Self::current_room) with a caller-chosen
+    /// fresh-scope landing room.
+    ///
+    /// An established scope returns its durable default subscription
+    /// unchanged — `landing` only decides where a FRESH scope's first
+    /// subscription lands. airc's own lobby stays `#general`
+    /// (`current_room` delegates here with that), but a hosting
+    /// substrate whose commons is a different room (continuum's
+    /// citizens land in `#academy`, card daa01102) names it instead of
+    /// inheriting airc's lobby and then migrating — the lazy subscribe
+    /// is a real attach point (presence + identity card), so landing
+    /// in the wrong room first is visible noise, not a free move.
+    pub async fn current_room_landing_in(&self, landing: &str) -> Result<Room, AircError> {
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         if let Some(subscription) = set.default_subscription() {
             return Ok(subscription.as_room());
         }
 
         let identity = self.mesh_identity().await?;
-        let channel = ChannelName::new("general")?;
+        let channel = ChannelName::new(landing)?;
         let subscription =
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;

--- a/crates/airc-lib/tests/fresh_scope_landing_room.rs
+++ b/crates/airc-lib/tests/fresh_scope_landing_room.rs
@@ -1,0 +1,94 @@
+//! `Airc::current_room_landing_in` — a hosting substrate chooses where a
+//! FRESH scope's first subscription lands, instead of inheriting airc's
+//! `#general` lobby and migrating afterwards (the lazy subscribe is a real
+//! attach point — presence + identity card — so a wrong first landing is
+//! visible noise, not a free move). Continuum's citizens land in
+//! `#academy` (card daa01102); airc's own `current_room` keeps `#general`.
+//!
+//! Pins three invariants:
+//! 1. A fresh scope lands in the CALLER-CHOSEN room, durably (a reopened
+//!    handle sees the same default).
+//! 2. An ESTABLISHED scope ignores `landing` — the durable default wins.
+//! 3. `current_room()` still lands fresh scopes in `#general` (no drift
+//!    for every existing caller).
+
+use airc_lib::Airc;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn fresh_scope_lands_in_caller_chosen_room_durably() {
+    let dir = tempdir().unwrap();
+    let machine = dir.path().join("machine/.airc");
+    let wire = dir.path().join("wire");
+
+    let airc = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("open fresh scope");
+
+    let room = airc
+        .current_room_landing_in("academy")
+        .await
+        .expect("land fresh scope");
+    assert_eq!(
+        room.name, "academy",
+        "fresh scope must land in the caller-chosen room, not #general"
+    );
+
+    // Durable: a new handle on the same home resolves the same default
+    // WITHOUT being told a landing room (current_room's #general landing
+    // must not fire — the scope is established now).
+    drop(airc);
+    let reopened = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("reopen same home");
+    let default = reopened.current_room().await.expect("read default room");
+    assert_eq!(
+        default.name, "academy",
+        "the chosen landing room must persist as the durable default"
+    );
+}
+
+#[tokio::test]
+async fn established_scope_ignores_landing_param() {
+    let dir = tempdir().unwrap();
+    let machine = dir.path().join("machine/.airc");
+    let wire = dir.path().join("wire");
+
+    let airc = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("open fresh scope");
+
+    airc.current_room_landing_in("academy")
+        .await
+        .expect("land fresh scope");
+
+    // A later caller naming a DIFFERENT landing room must get the
+    // established default back — `landing` only decides the first
+    // subscription, never a migration.
+    let room = airc
+        .current_room_landing_in("somewhere-else")
+        .await
+        .expect("read established scope");
+    assert_eq!(
+        room.name, "academy",
+        "landing param must be inert on an established scope"
+    );
+}
+
+#[tokio::test]
+async fn current_room_still_lands_fresh_scopes_in_general() {
+    let dir = tempdir().unwrap();
+    let machine = dir.path().join("machine/.airc");
+    let wire = dir.path().join("wire");
+
+    let airc = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("open fresh scope");
+
+    let room = airc.current_room().await.expect("default room");
+    assert_eq!(
+        room.name, "general",
+        "current_room's fresh-scope landing must stay #general — \
+         every existing caller depends on it"
+    );
+}


### PR DESCRIPTION
Re-lands #1328 onto canary — the branch continuum's workspace pins actually track (my #1328 went to main by mistake; `require-canary-or-hotfix` correctly flagged it, but auto-merge completed because the check isn't required — worth making it required).

A hosting substrate whose commons is not airc's lobby could only inherit the hardcoded `#general` first-subscribe and migrate afterwards — and the lazy default-room subscribe is a real attach point (presence beacon + identity card), so a wrong first landing is visible room noise. Continuum's citizens land in `#academy` (room-consolidation master card daa01102, Joel's positron gate).

- `current_room()` delegates to `current_room_landing_in("general")` — identical behavior for every existing caller, pinned by test.
- `landing` only decides a FRESH scope's first subscription; an established scope's durable default always wins, pinned.
- 3 integration tests in `fresh_scope_landing_room.rs`, green on canary base.

Consumer follow-up in continuum: bump the airc pins to the canary rev and pass `CITIZEN_COMMONS_ROOM` at persona bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo