### PR TITLE
fix(status): disclose the daemon it just started, so `airc status` stops reading as a liveness probe

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -2180,9 +2180,41 @@ pub async fn run_ping(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>>
 /// `ensure_daemon_running` before the probe gives every recipe that
 /// says "run `airc status` first" a working contract again.
 pub async fn run_status(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    // `ensure_daemon_running` may SPAWN a daemon (see card 2bdae532 above), which
+    // makes this command unable to report "down" — asking creates the answer.
+    // That is fine as convenience and fatal as a measurement, so establish
+    // whether one was already answering BEFORE we ensure, and say so.
+    //
+    // Incident 2026-08-08: a grid blackout drill measured a 0.0s outage across
+    // an `airc update` because its probe was `airc status`. The positive control
+    // failed — status reported UP one second after `airc stop` — and the number
+    // was retracted. An instrument that changes what it measures reads as
+    // healthy precisely when the thing it watches is broken.
+    //
+    // Worse than a bad number: anything polling `status` DURING an update
+    // respawns a daemon from the OLD binary mid-swap, which is a candidate cause
+    // of the stale-process class `update_commands.rs` already guards against
+    // ("a stale process that survived `stop_daemon` answers IPC perfectly").
+    //
+    // The spawn is NOT removed — 2bdae532 added it so a fresh onboard has a
+    // working contract, and breaking onboarding to fix an honesty bug trades one
+    // defect for another. It is now DISCLOSED instead, and `airc ping` remains
+    // the non-spawning probe for anyone who needs to observe rather than ensure.
+    let was_already_up = DaemonClient::new(socket.clone())
+        .status_with_timeout(Duration::from_millis(250))
+        .await
+        .is_ok();
+
     ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
     let client = DaemonClient::new(socket);
     let status = client.status().await?;
+    if !was_already_up {
+        println!(
+            "note: no daemon was answering — this command STARTED one. \
+             It was not running until you asked. Use `airc ping` to observe \
+             liveness without starting anything."
+        );
+    }
     println!("peer_id:        {}", status.peer_id);
     println!("uptime_seconds: {}", status.uptime_seconds);
     if let Some(version) = status.ipc_protocol_version {


### PR DESCRIPTION
## `airc status` cannot report "down" — asking creates the answer

`run_status` calls `ensure_daemon_running` **before** it probes, and that helper spawns a daemon when nothing answers. It is not a stale read; it is an instrument that changes what it measures.

**How it surfaced:** a grid blackout drill measured a **0.0s** outage across an `airc update`. The positive control failed — status reported UP one second after `airc stop` — and the number was retracted. Confirmed live from the other node afterwards: **one `airc status` call resurrected a stopped daemon.**

## Why this is worse than a wrong number

**The fleet is instructed to trust it.** The `/join` operating doc names `airc status` as local-only ground truth, to be believed over other signals. It is what an agent reaches for to answer *"is the node up"* — and the one command structurally incapable of saying no.

**Polling it during an update resurrects the old binary.** `airc update` stops the daemon, builds, restarts. Anything checking the node in that window — a monitor, a hook, another agent — spawns a daemon from the **pre-update** binary, mid-swap. `update_commands.rs` already guards against the symptom (*"a stale process that survived `stop_daemon` answers IPC perfectly"*); this is a live candidate for how that process gets there. **The blackout window and the auto-spawn are the same window** (see #1332).

## The change

The spawn is **not** removed. Card 2bdae532 added it deliberately so a fresh onboard (*"run `airc status` first"*) has a working contract, and breaking onboarding to fix an honesty bug trades one defect for another.

Status now checks whether anything was **already** answering before it ensures, and says so when it wasn't:

```
note: no daemon was answering — this command STARTED one. It was not running
until you asked. Use `airc ping` to observe liveness without starting anything.
```

`airc ping` (`run_ping`) goes straight to `DaemonClient` with no ensure — the honest non-spawning probe already existed and simply wasn't the one being reached for. The drill now uses it, and its two-sided control passes: exit 0 live, non-zero on a real stop. M5 has corrected the `/join` doc accordingly: ping is the liveness probe, status is configuration display plus a deliberate onboarding spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
