### PR TITLE
feat(version): auto-incrementing build number + built-at, on the health surface

### DIFF
--- a/crates/airc-cli/build.rs
+++ b/crates/airc-cli/build.rs
@@ -28,10 +28,33 @@ fn main() {
         git(["rev-parse", "--short=12", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
     let branch =
         git(["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
-
     println!("cargo:rustc-env=AIRC_BUILD_COMMIT={commit}");
     println!("cargo:rustc-env=AIRC_BUILD_COMMIT_SHORT={commit_short}");
     println!("cargo:rustc-env=AIRC_BUILD_BRANCH={branch}");
+    // Joel's ruling 2026-08-08: versions must ALWAYS auto-increment and display
+    // with the sha, in EVERY repo, on every connection/health/query surface —
+    // stale binaries have repeatedly poisoned testing. A sha NAMES a build but
+    // does not ORDER it, so "am I newer than that peer?" was unanswerable
+    // without a git checkout to compare against. The commit count does order
+    // it: squash-merge keeps canary linear, so deploys totally order, and an
+    // equal number with a different sha is a loud divergence rather than a
+    // quiet one.
+    let build_number = git(["rev-list", "--count", "HEAD"]).unwrap_or_else(|| "0".to_string());
+    println!("cargo:rustc-env=AIRC_BUILD_NUMBER={build_number}");
+    // Third leg: WHEN this binary was compiled. Number orders the source, sha
+    // names the source, built-at catches what both miss — a binary rebuilt from
+    // OLD source after a fix landed, where number and sha both look plausible
+    // and only the timestamp says the binary predates the fix.
+    //
+    // Computed from `SystemTime`, deliberately NOT by shelling out to `date`.
+    // `date -u +FORMAT` is coreutils; on Windows `date` is a cmd builtin with
+    // different semantics entirely, and a spawn only finds a compatible one if
+    // Git-for-Windows' `usr\bin` happens to be on PATH. Where it is not, the
+    // timestamp silently degrades to "unknown" — losing the third leg on the
+    // platform where stale binaries have bitten hardest, and losing it QUIETLY,
+    // which is the whole failure mode this trio exists to end. No process, no
+    // PATH assumption, identical on every platform.
+    println!("cargo:rustc-env=AIRC_BUILD_AT={}", built_at_utc());
     // Re-run when HEAD moves; tells cargo not to rerun on every
     // source change.
     println!("cargo:rerun-if-changed=.git/HEAD");
@@ -40,6 +63,38 @@ fn main() {
     // commit. Watch both so a commit on the current branch also
     // triggers a rebuild.
     println!("cargo:rerun-if-changed=.git/refs/heads/");
+}
+
+/// Current UTC time as `YYYY-MM-DDTHH:MM:SSZ`, computed from the system clock
+/// with no external process.
+///
+/// The civil-date conversion is Howard Hinnant's `civil_from_days`, the same
+/// algorithm every date library uses: shift the epoch to 0000-03-01 so leap day
+/// lands at the end of the cycle, then do exact integer arithmetic over the
+/// 400-year Gregorian cycle. Correct for any date this program will ever see,
+/// and it cannot fail — which is the point, since a timestamp that can silently
+/// become "unknown" defeats the staleness check it exists for.
+fn built_at_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let (days, rem) = (secs.div_euclid(86_400), secs.rem_euclid(86_400));
+    let (hh, mm, ss) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+
+    // days since 1970-01-01 → civil date
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097); // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11], March-based
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
 }
 
 fn git<I, S>(args: I) -> Option<String>

--- a/crates/airc-cli/src/build_info.rs
+++ b/crates/airc-cli/src/build_info.rs
@@ -11,6 +11,32 @@ pub const COMMIT: &str = env!("AIRC_BUILD_COMMIT");
 pub const COMMIT_SHORT: &str = env!("AIRC_BUILD_COMMIT_SHORT");
 /// Git branch at compile time, or `unknown`.
 pub const BRANCH: &str = env!("AIRC_BUILD_BRANCH");
+/// Auto-incrementing build number — `git rev-list --count HEAD` at compile
+/// time, or `0` when git was unavailable.
+///
+/// A sha NAMES a build; it does not ORDER one. Without this, "is that peer
+/// newer than me?" needed a git checkout to answer, so nobody asked and stale
+/// binaries kept poisoning tests. Canary is squash-merged and therefore linear,
+/// so these totally order — and an equal number with a DIFFERENT sha is a loud
+/// divergence rather than a quiet one.
+pub const BUILD_NUMBER: &str = env!("AIRC_BUILD_NUMBER");
+/// UTC compile timestamp, `YYYY-MM-DDTHH:MM:SSZ`.
+///
+/// Catches what number and sha both miss: a binary rebuilt from OLD source
+/// after a fix landed, where both look plausible and only the timestamp says
+/// the binary predates the fix.
+pub const BUILT_AT: &str = env!("AIRC_BUILD_AT");
+
+/// One-line version identity for any surface that reports what it is running:
+/// `#1234 a1b2c3d4e5f6 (canary) built 2026-08-08T13:00:00Z`.
+///
+/// ONE formatter, so connection banners, health output and version queries
+/// cannot drift into describing the same binary three different ways — which is
+/// exactly how a stale node reads as current on one surface and stale on
+/// another.
+pub fn version_line() -> String {
+    format!("#{BUILD_NUMBER} {COMMIT_SHORT} ({BRANCH}) built {BUILT_AT}")
+}
 /// Cargo package version (semver).
 pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -2198,6 +2198,16 @@ pub async fn run_status(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std:
     if let Some(executable) = status.executable.as_deref() {
         println!("executable:     {executable}");
     }
+    // Joel's ruling 2026-08-08: the version must be visible on every
+    // health/query surface, in every repo, because stale binaries have
+    // repeatedly poisoned testing. `build:` above reports what the DAEMON says
+    // it is; this reports what the CLI asking the question is. Printing both is
+    // the point — when they disagree, the operator is talking to a daemon built
+    // from different source than the tool they are holding, which is precisely
+    // the confusion the #354 incident produced ("Already at 1e2f424" one line
+    // above `airc --version` saying three commits behind, both true, describing
+    // different objects).
+    println!("cli_version:    {}", crate::build_info::version_line());
     Ok(())
 }
 


### PR DESCRIPTION
Joel's ruling 2026-08-08: **versions must always auto-increment and display with the sha, in every repo, visible on connection/health/query** — stale binaries have repeatedly poisoned our testing. Continuum shipped its side in CambrianTech/continuum#2185; this is airc's.

## What was missing

airc already baked the sha and branch. What it lacked was **order**. A sha *names* a build but does not rank it, so *"is that peer newer than me?"* required a git checkout to answer — and therefore mostly went unasked.

```
AIRC_BUILD_NUMBER   git rev-list --count HEAD
AIRC_BUILD_AT       UTC compile timestamp
```

Canary is squash-merged and therefore linear, so build numbers **totally order** deploys — and an equal number with a *different* sha is a loud divergence instead of a quiet one. Built-at catches what number and sha both miss: a binary rebuilt from **old** source after a fix landed, where both look plausible and only the timestamp says the binary predates the fix.

## Surfaced where the question gets asked

`airc status` now prints `cli_version` beside the daemon's `build:`. Printing **both** is deliberate — when they disagree, the operator is talking to a daemon built from different source than the tool in their hand. That is exactly the #354 confusion, where `Already at 1e2f424` sat one line above `airc --version` reporting *3 commits behind*: both true, describing different objects.

`version_line()` is the single formatter, so no surface can drift into describing the same binary a different way.

## The timestamp does not shell out to `date`

Continuum's version uses `Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])`. That is coreutils. On Windows `date` is a cmd builtin with unrelated semantics, and a spawn only finds a compatible one when Git-for-Windows' `usr\bin` happens to be on PATH — true on my box, **not guaranteed for a repo user**. Where it is not, the timestamp degrades to `"unknown"`: the third leg lost on the platform where stale binaries have bitten hardest, and lost *quietly*, which is the failure mode this trio exists to end.

Computed from `SystemTime` instead, with Hinnant's `civil_from_days` — exact integer arithmetic, no dependency, no PATH assumption, identical on every platform. Flagged to M5 for the continuum side.

## Verified

Real build, not asserted:

```
cli_version:    #916 e910008fe57a (feat/version-trio) built 2026-08-08T15:57:25Z
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
