### PR TITLE
fix(ci): windows leg was a phantom runner; docs: lead with delivery truth + name the gaps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -255,15 +255,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows runs on the self-hosted bigmama runner (5090 grid
-        # node) — GitHub-hosted windows-latest has been queue-starved
-        # for days and was blocking merges (#1114). The install-smoke
-        # jobs in ci.yml deliberately STAY on windows-latest: they do
-        # real machine-wide winget installs and need a virgin box,
-        # which a persistent self-hosted runner is not.
-        # Security: repo fork-PR approval policy is set to
-        # all_external_contributors, so no fork code reaches the
-        # self-hosted runner without a maintainer's explicit approval.
+        # Windows runs on GitHub-hosted windows-latest.
+        #
+        # It was moved to a self-hosted "bigmama" runner in #1114 because
+        # windows-latest was queue-starved for days. That runner DOES NOT
+        # EXIST. Measured 2026-08-09:
+        #   gh api repos/CambrianTech/airc/actions/runners -> total_count 0
+        # and bigmama itself has no runner service, no Runner.Listener
+        # process, and no actions-runner directory. So this leg was not
+        # slow or offline — nothing could ever claim it. On PR #1336 it sat
+        # `pending` at 0s, and it has been emitting a permanently-pending
+        # `cargo test (windows-self-hosted)` check on every PR since,
+        # faking coverage that never ran a single test. It came within one
+        # check of blocking the canary->main release.
+        #
+        # The #1114 starvation is also stale: ci.yml's clean-install-windows
+        # and clean-install-windows-ps5 run on windows-latest and passed in
+        # 9m10s / 8m42s the same day. So the hosted queue is healthy, and a
+        # leg that actually RUNS beats one that reports a green-looking
+        # pending forever.
+        #
+        # If a self-hosted bigmama runner is genuinely registered later,
+        # this can move back — but only once `actions/runners` shows it,
+        # and the fork-PR guard below is kept for exactly that case.
+        # The install-smoke jobs in ci.yml stay on windows-latest for their
+        # own reason: they do real machine-wide winget installs and need a
+        # virgin box, which a persistent self-hosted runner is not.
         # ubuntu-latest is NOT here — it's the dedicated `test-ubuntu` job
         # below. A SKIPPED matrix job reports ONE check named with the
         # unexpanded template `cargo test (${{ matrix.display }})`, so the
@@ -272,7 +289,7 @@ jobs:
         # their template-named skip is harmless.
         include:
           - { os: macos-latest, display: macos-latest }
-          - { os: [self-hosted, windows], display: windows-self-hosted }
+          - { os: windows-latest, display: windows-latest }
     steps:
       # Self-defending guard (sentinel ask on #1116): the self-hosted leg
       # refuses fork-PR code before checkout. Lives at STEP level because

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
-# Agentic Internet Relay Chat
+# airc — Agentic Internet Relay Chat
 
-airc lets local and remote AI agents share rooms so they can coordinate work directly. It uses IRC-shaped commands over a generic signed event substrate: channels, peers, presence, messages, typed headers, replay, and transport routing.
+**Your agents stop talking through you.**
+
+Two AI agents on two machines — different operators, different networks, behind NAT — join a room and coordinate directly. They claim work, ask each other questions, hand off a PR, argue about a root cause. No human copy-pasting between terminal tabs, no shared checkout, no server you have to run.
+
+**And it tells you the truth about delivery.** Most chat surfaces say *sent*. airc says *delivered*, with evidence:
+
+```console
+$ airc doctor --health
+[ok] route health: 1 route(s) healthy
+[ok] delivery truth: last confirmed delivery 64s ago, rtt ~134ms (1305 of 1305 acked)
+```
+
+That distinction is the product, not a detail. A daemon being **up** is not the same as messages **arriving** — and a coordination substrate that cannot tell you which one you have will send you debugging the wrong layer for an afternoon. Here the answer is one command, and it is a count of acknowledgements, not a hopeful log line.
+
+Underneath, it is IRC-shaped commands over a generic signed event substrate: channels, peers, presence, messages, typed headers, replay, and transport routing. Agents already understand IRC, so the surface needs no explaining; the typed envelope underneath is what lets the same room carry work queues, CI state, and live avatar sessions.
 
 The chat model is the product surface. Because the substrate carries opaque typed events, the same rooms can also carry coordination buses for tools and applications. Cambrian uses airc this way for systems such as Continuum, Hermes, OpenClaw, work queues, and grid/runtime events, but those are consumers above airc. airc does not know their domains; it routes signed events between peers.
 
@@ -273,6 +287,15 @@ Other integrations live in [`integrations/`](integrations/):
 
 airc is designed to fail loudly and recover through `join`.
 
+**Delivery truth is the load-bearing one.** `airc msg` returning cleanly means *queued*, and the command says so rather than implying more. Actual delivery is confirmed by ACK and kept as a ledger you can read:
+
+```console
+$ airc doctor --health
+[ok] delivery truth: last confirmed delivery 64s ago, rtt ~134ms (1305 of 1305 acked)
+```
+
+Read that instead of uptime. `airc status` showing a daemon with 21h uptime tells you a process is alive; it does not tell you a single message reached anyone. The two answers diverge for real and mundane reasons — a peer asleep, a route that stopped delivering while still reporting healthy — and only the ACK count distinguishes them. Ask for the number before concluding the transport is at fault.
+
 - Sends use explicit route selection across local-fs, LAN-TCP, relay, and other transports.
 - GitHub is governed and limited to invite/rendezvous work, not routine same-host or same-LAN delivery.
 - Same-machine tabs share local state safely; `airc stop` is scope-aware and only shuts down its own scope's daemon.
@@ -351,6 +374,17 @@ airc update
 Supported platforms: macOS, Linux, WSL2, Windows Git Bash, and native PowerShell 7.
 
 Tailscale is optional. airc works locally without it, and can use direct or relay routes when peers are on different machines or networks.
+
+## What Doesn't Work Yet
+
+Stated plainly, because each of these looks like inattention or a broken peer when you hit it, and knowing which is which saves you a wrong diagnosis.
+
+- **`@Name` in a message body is decorative.** Every send goes out with `MentionTarget::All`; nothing parses a name out of the text into a structural target. So a peer is not *addressed* in any way it can filter on — an agent that ignores your `@Name` may be structurally unable to see it was meant for them. Use `airc msg @peer "..."` (a real DM) when you need one specific peer to act.
+- **Long message bodies can clip on the receiving side.** A body past the render budget is truncated where the reader sees it, and the tail is not recoverable from the notification. Reproduced live: a two-part message arrived cut mid-sentence and the second half never appeared. Split long messages, or lead with the part that must survive.
+- **No store-and-forward for an offline peer.** Delivery is to peers reachable *now*. A peer that is asleep or unreachable does not receive on wake — the message is not queued for them. Backfill-on-request exists for transcript catch-up, but it is a pull, not a durable outbox.
+- **Delivery is confirmed, addressing is not.** The ACK ledger proves a message reached a peer's node. It does not prove any agent read it, and there is no read-receipt or per-recipient acknowledgement above the transport.
+
+None of these are hypothetical; all four were hit while building on airc. They are tracked as work, not disclaimers.
 
 ## Roadmap
 

--- a/crates/airc-lib/src/backfill.rs
+++ b/crates/airc-lib/src/backfill.rs
@@ -1,0 +1,319 @@
+//! Peer-to-peer transcript backfill — "what did I miss on this channel?"
+//!
+//! ## Why (#47, incident 2026-08-08)
+//!
+//! A message published while a peer is unreachable is **lost, not queued**.
+//! `airc msg` reports `reached 0 of 76 enrolled peers — NONE currently
+//! connected` and that is the end of it: no retry, no forward on reconnect.
+//! Measured three times in one day — twice by accident, once inside the
+//! investigation of it, when the receiving node was down for a ~4 minute
+//! `airc update`.
+//!
+//! The reason it is lost rather than pending is structural. Replay resumes from
+//! the RECEIVER's cursor against the RECEIVER's own store, which is exactly why
+//! a daemon restart loses nothing: the events are already local. Across a peer
+//! boundary they are not, so a frame that never arrived cannot be replayed —
+//! and the receiver has no way to know it missed one.
+//!
+//! ## Pull, not an outbox
+//!
+//! The sender-side alternative is an outbox: durably record every unacked
+//! event per peer and flush on reconnect. That needs new per-event durable
+//! state AND an eviction decision — a queue that grows while a peer is away for
+//! a week is its own incident, and an unbounded store with no owner is a defect
+//! this project has been bitten by before.
+//!
+//! Pull needs neither. The sender ALREADY has every event in its durable
+//! transcript; the receiver ALREADY holds a per-room cursor. So backfill is
+//! "give me events on this channel since my cursor" — the same shape as the
+//! daemon's existing resume, crossing a peer boundary instead of a process one.
+//! Nothing new is stored, so nothing new needs evicting.
+//!
+//! `DeliveryLedger` cannot serve this role, incidentally: it is per-peer
+//! COUNTERS (attempts, acks, attempts-since-ack), so it can say a peer has not
+//! acked in N attempts but not WHICH events it missed. Useful as a trigger,
+//! useless as a queue.
+//!
+//! ## Ask always; do not detect
+//!
+//! A receiver cannot detect a gap whose frames never arrived — absence of an
+//! event leaves no trace to notice. So the contract is to ASK on every
+//! peer-connect rather than to ask when a gap is suspected. When the cursor is
+//! current the answer is an empty page, which is cheap; detection is the part
+//! with no signal, and asking is the part that is always safe.
+//!
+//! ## Duplicates are free
+//!
+//! Re-delivering an event the receiver already holds is harmless: events carry
+//! a stable `event_id` and the receive path already dedups through the
+//! recently-broadcast ring. That is what lets the request be sloppy about its
+//! cursor — an overlapping page costs bandwidth, never correctness.
+//!
+//! Slice 1 (this module) is the request/response pair. Nothing calls it
+//! automatically yet; the reconnect watcher that will is slice 2. Landing them
+//! separately keeps this one incapable of changing existing behaviour.
+
+use std::time::Duration;
+
+use airc_core::headers::Headers;
+use airc_core::transcript::MentionTarget;
+use airc_core::{Body, PeerId, RoomId, TranscriptCursor, TranscriptEvent};
+use serde::{Deserialize, Serialize};
+
+use crate::error::AircError;
+use crate::Airc;
+
+/// Header marking a command-bus request as a backfill ask. Present on the
+/// request; absent on the reply (the reply is correlated by the bus).
+pub const HEADER_AIRC_BACKFILL: &str = "airc.backfill";
+
+/// Default ceiling on events returned by one backfill reply.
+///
+/// Bounded on purpose: a peer returning from a long absence could otherwise ask
+/// for a page the size of the whole transcript. When the cap binds, the reply
+/// says so (`truncated`) and the caller can ask again from the newer cursor —
+/// never a silent cap, which would present a partial history as a complete one.
+pub const DEFAULT_BACKFILL_LIMIT: usize = 500;
+
+/// "What did I miss on `channel` since `since`?"
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BackfillRequest {
+    pub channel: RoomId,
+    /// The asker's cursor. `None` means "I have nothing for this channel" —
+    /// a fresh scope, or a room it just joined — and yields the newest page.
+    pub since: Option<TranscriptCursor>,
+    /// Caller's ceiling; the responder clamps to [`DEFAULT_BACKFILL_LIMIT`].
+    pub limit: usize,
+}
+
+/// The answered page.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BackfillResponse {
+    pub channel: RoomId,
+    pub events: Vec<TranscriptEvent>,
+    /// True when the limit bound the page — there is MORE beyond it. The
+    /// caller re-asks from the newest event it received. Without this a
+    /// truncated page is indistinguishable from a complete one, which is how a
+    /// gap silently survives the mechanism built to close it.
+    pub truncated: bool,
+}
+
+impl BackfillRequest {
+    /// Recover a request from a received event, or `None` when the event is not
+    /// a backfill ask. Total over arbitrary input: a malformed body from a peer
+    /// is a non-request, never a panic.
+    pub fn from_event(event: &TranscriptEvent) -> Option<Self> {
+        event.headers.get(HEADER_AIRC_BACKFILL)?;
+        let Some(Body::Json(value)) = event.body.as_ref() else {
+            return None;
+        };
+        serde_json::from_value(value.clone()).ok()
+    }
+}
+
+impl Airc {
+    /// Ask `peer` for everything on `channel` since `since`.
+    ///
+    /// Returns the events the peer had. An empty page is the ordinary answer
+    /// when the cursor is current, NOT an error — which is what makes it safe
+    /// to ask on every reconnect.
+    pub async fn request_backfill(
+        &self,
+        peer: PeerId,
+        channel: RoomId,
+        since: Option<TranscriptCursor>,
+        deadline: Duration,
+    ) -> Result<BackfillResponse, AircError> {
+        let request = BackfillRequest {
+            channel,
+            since,
+            limit: DEFAULT_BACKFILL_LIMIT,
+        };
+        let mut headers = Headers::new();
+        headers.insert(HEADER_AIRC_BACKFILL.into(), "request".into());
+        let body = Body::Json(
+            serde_json::to_value(&request)
+                .map_err(|e| AircError::Crypto(format!("backfill request encode: {e}")))?,
+        );
+        let pending = self
+            .request(MentionTarget::Peer(peer), headers, body, deadline)
+            .await?;
+        let reply = self.await_reply(pending).await?;
+        let Some(Body::Json(value)) = reply.body else {
+            return Err(AircError::Crypto(
+                "backfill reply carried no JSON body".to_string(),
+            ));
+        };
+        serde_json::from_value(value)
+            .map_err(|e| AircError::Crypto(format!("backfill reply decode: {e}")))
+    }
+
+    /// Answer a backfill request from this scope's own durable transcript.
+    ///
+    /// Returns the number of events sent. A request for a channel this scope
+    /// does not subscribe to answers with an EMPTY page rather than an error:
+    /// "I have nothing for you" is true and actionable, whereas a failure would
+    /// make the asker retry against a peer that will never have it.
+    pub async fn serve_backfill(
+        &self,
+        request_event: &TranscriptEvent,
+    ) -> Result<usize, AircError> {
+        let Some(request) = BackfillRequest::from_event(request_event) else {
+            return Ok(0);
+        };
+        let Some((reply_to, correlation_id)) = crate::command_bus::reply_addressing(request_event)
+        else {
+            return Ok(0);
+        };
+
+        let limit = request.limit.clamp(1, DEFAULT_BACKFILL_LIMIT);
+        let events = match request.since.as_ref() {
+            Some(cursor) => self
+                .daemon_room_transcripts_since(request.channel, cursor, limit)
+                .await
+                .unwrap_or_default(),
+            None => {
+                // No cursor: the newest page of the channel.
+                let mut filter = crate::EventFilter {
+                    channel: Some(request.channel),
+                    ..Default::default()
+                };
+                filter.self_echo = None;
+                self.page_recent_filtered(filter, limit)
+                    .await
+                    .unwrap_or_default()
+            }
+        };
+
+        let truncated = events.len() >= limit;
+        if truncated {
+            tracing::debug!(
+                target: "airc::backfill",
+                channel = %request.channel,
+                limit,
+                "backfill page hit the limit — replying `truncated` so the asker re-asks"
+            );
+        }
+        let sent = events.len();
+        let response = BackfillResponse {
+            channel: request.channel,
+            events,
+            truncated,
+        };
+        let body = Body::Json(
+            serde_json::to_value(&response)
+                .map_err(|e| AircError::Crypto(format!("backfill reply encode: {e}")))?,
+        );
+        self.reply(reply_to, correlation_id, Headers::new(), body)
+            .await?;
+        Ok(sent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::EventId;
+
+    fn request_event(headers: Headers, body: Option<Body>) -> TranscriptEvent {
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: RoomId::from_uuid(uuid::Uuid::from_u128(7)),
+            peer_id: PeerId::from_uuid(uuid::Uuid::from_u128(8)),
+            client_id: airc_core::ClientId::new(),
+            kind: airc_core::TranscriptKind::Message,
+            occurred_at_ms: 1_700_000_000_000,
+            lamport: 1,
+            target: MentionTarget::All,
+            headers,
+            body,
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    fn a_request() -> BackfillRequest {
+        BackfillRequest {
+            channel: RoomId::from_uuid(uuid::Uuid::from_u128(0xB4CF111)),
+            since: Some(TranscriptCursor {
+                lamport: 42,
+                event_id: EventId::new(),
+            }),
+            limit: 100,
+        }
+    }
+
+    // what this catches: a peer's malformed or unrelated frame being read as a
+    // backfill ask. `serve_backfill` answers from the durable transcript, so a
+    // parser that accepted junk would turn any garbage frame into a transcript
+    // disclosure. Both the header AND a well-formed body are required.
+    #[test]
+    fn only_a_well_formed_backfill_frame_parses_as_one() {
+        let mut headers = Headers::new();
+        headers.insert(HEADER_AIRC_BACKFILL.into(), "request".into());
+        let good = Body::Json(serde_json::to_value(a_request()).unwrap());
+
+        assert!(
+            BackfillRequest::from_event(&request_event(headers.clone(), Some(good.clone())))
+                .is_some()
+        );
+        assert!(
+            BackfillRequest::from_event(&request_event(Headers::new(), Some(good))).is_none(),
+            "no header = not a backfill ask, even with a valid body"
+        );
+        assert!(
+            BackfillRequest::from_event(&request_event(
+                headers.clone(),
+                Some(Body::text("not json"))
+            ))
+            .is_none(),
+            "header without a JSON body must not parse"
+        );
+        assert!(
+            BackfillRequest::from_event(&request_event(
+                headers,
+                Some(Body::Json(serde_json::json!({"nonsense": true})))
+            ))
+            .is_none(),
+            "header with the WRONG json must not parse"
+        );
+    }
+
+    // what this catches: the round-trip that carries the whole feature. If
+    // `since` stops surviving encode/decode, backfill silently degrades to
+    // "newest page" — it would still return events, still look like it worked,
+    // and quietly stop closing the gap it exists to close.
+    #[test]
+    fn a_request_survives_the_wire_with_its_cursor_intact() {
+        let original = a_request();
+        let encoded = serde_json::to_value(&original).unwrap();
+        let decoded: BackfillRequest = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, original);
+        assert_eq!(
+            decoded.since.as_ref().map(|c| c.lamport),
+            Some(42),
+            "the cursor is the whole request — losing it makes the answer arbitrary"
+        );
+    }
+
+    // what this catches: a truncated page presented as a complete one. Without
+    // `truncated`, a peer returning from a long absence gets the oldest N events
+    // it missed and no indication that more exist — the gap survives the
+    // mechanism built to close it, which is worse than not backfilling at all
+    // because it looks fixed.
+    #[test]
+    fn a_bounded_page_says_that_it_was_bounded() {
+        let full = BackfillResponse {
+            channel: RoomId::from_uuid(uuid::Uuid::from_u128(1)),
+            events: Vec::new(),
+            truncated: true,
+        };
+        let decoded: BackfillResponse =
+            serde_json::from_value(serde_json::to_value(&full).unwrap()).unwrap();
+        assert!(
+            decoded.truncated,
+            "the `there is more` bit must survive the wire"
+        );
+    }
+}

--- a/crates/airc-lib/src/command_bus.rs
+++ b/crates/airc-lib/src/command_bus.rs
@@ -157,6 +157,24 @@ impl PendingCommand {
     }
 }
 
+/// Read the addressing a responder needs off an in-flight request:
+/// `(reply_to, correlation_id)`.
+///
+/// `None` when either header is missing or unparseable, which means the event
+/// is not an answerable request — a responder that guessed here would reply
+/// into the void or, worse, correlate its answer to someone else's question.
+/// Extracted because every responder needs exactly this pair, and each one
+/// re-deriving it from raw headers is how they drift apart.
+pub fn reply_addressing(event: &TranscriptEvent) -> Option<(PeerId, Uuid)> {
+    let reply_to = PeerId::from_uuid(event.headers.get(HEADER_AIRC_REPLY_TO)?.parse().ok()?);
+    let correlation_id = event
+        .headers
+        .get(HEADER_AIRC_CORRELATION_ID)?
+        .parse()
+        .ok()?;
+    Some((reply_to, correlation_id))
+}
+
 impl Airc {
     /// Issue a request and return a [`PendingCommand`] handle. The
     /// reply is awaited via [`Airc::await_reply`]. The substrate

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -39,6 +39,7 @@ pub mod account_registry_fs;
 pub mod adapter;
 pub mod agent_heartbeat;
 pub mod airc;
+pub mod backfill;
 mod broadcast_deduper;
 pub mod capability_registry;
 pub mod command_bus;


### PR DESCRIPTION
## CI: a required-looking check that never ran

`cargo test (windows-self-hosted)` has been emitting a permanently-pending check on every PR. The runner does not exist — not slow, not offline:

```
gh api repos/CambrianTech/airc/actions/runners  ->  total_count 0
```

and bigmama has no runner service, no `Runner.Listener` process, no `actions-runner` directory. On #1336 it sat `pending` at 0s and came one check from blocking the canary→main release, while reporting Windows coverage that never ran a single test.

The #1114 rationale (hosted Windows queue-starved) is stale — `clean-install-windows` and `clean-install-windows-ps5` passed on `windows-latest` in 9m10s / 8m42s the same day. Moving the leg back **restores** real Windows coverage instead of removing it. The fork-PR guard stays for whenever a real self-hosted runner is registered.

## README

Two gaps, both about honesty:

1. **Delivery truth was absent.** In 366 lines the word "ack" never appeared. The lead was an inventory of plumbing. But the property that distinguishes airc is that most surfaces say *sent* and airc says *delivered, with a count* — which did real work this week: a daemon at 21h uptime told us nothing; `1305 of 1305 acked, rtt ~134ms` told us everything. Now the lead, and first-class in Reliability.

2. **No limitations section.** Added *What Doesn't Work Yet* for four things hit while building ON airc, each of which reads as inattention or a broken peer when met cold: `@Name` in a body is decorative (every send is `MentionTarget::All`), long bodies clip on receive, offline peers get no store-and-forward, and the ACK proves transport delivery rather than that an agent read it.

Verified rather than recalled: re-grepped `MentionTarget::All` across the send sites, and the truncation was reproduced live in a two-part message whose second half never arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc