### PR TITLE
docs(acp): pin the airc-as-ACP-client design against the real SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol 2.0.0",
  "agent-client-protocol-tokio",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+dependencies = [
+ "agent-client-protocol-derive 0.11.1",
+ "agent-client-protocol-schema 0.12.0",
+ "anyhow",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
+dependencies = [
+ "agent-client-protocol-derive 2.0.0",
+ "agent-client-protocol-schema 1.5.0",
+ "async-io",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "rustc-hash",
+ "rustix",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
+dependencies = [
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
+name = "agent-client-protocol-tokio"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1572b219f22c4b3be0f20f934c8b6f1d1457126ce72923c4f6608f96153b65"
+dependencies = [
+ "agent-client-protocol 0.11.1",
+ "futures",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,9 +162,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-acp"
+version = "0.1.0"
+dependencies = [
+ "agent-client-protocol 2.0.0",
+ "agent-client-protocol-tokio",
+ "tokio",
+]
+
+[[package]]
 name = "airc-acp-bridge"
 version = "0.1.0"
 dependencies = [
+ "airc-acp",
  "airc-core",
  "airc-lib",
  "futures",
@@ -525,7 +650,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -537,7 +662,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -549,7 +674,84 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -571,8 +773,14 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -582,7 +790,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -681,6 +889,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,7 +936,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -869,7 +1099,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -910,6 +1140,15 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1019,7 +1258,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1028,8 +1267,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1042,7 +1291,20 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1051,9 +1313,20 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1075,6 +1348,37 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "der"
@@ -1140,10 +1444,11 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1167,7 +1472,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1175,6 +1480,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1298,6 +1609,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1645,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flume"
@@ -1399,6 +1726,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1773,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,7 +1793,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1562,7 +1915,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1579,6 +1932,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1634,6 +1993,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1908,6 +2273,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1926,7 +2302,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1958,6 +2334,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +2396,16 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2140,7 +2579,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2316,7 +2755,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2373,6 +2812,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2865,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2895,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs1"
@@ -2475,6 +2951,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2985,21 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2528,7 +3033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2559,7 +3064,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2579,7 +3084,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -2601,7 +3106,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2781,6 +3286,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,7 +3415,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -2908,7 +3433,42 @@ checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3055,7 +3615,7 @@ checksum = "b39d78fc2ae7d5e99881d6604a972e99d97d839e5b3d0668018f82f0faa9bfb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3311,6 +3871,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62751faa8bc286982334a082fe125184a29fc89d17775766e4f891b7d726980"
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,7 +3924,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3352,7 +3950,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.18",
  "time",
  "tracing",
@@ -3387,7 +3985,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3436,11 +4034,11 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -3466,7 +4064,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3516,7 +4114,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3525,6 +4134,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3542,6 +4152,39 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3580,6 +4223,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3698,7 +4347,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -3727,7 +4376,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3750,7 +4399,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -3897,6 +4546,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "substring"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3923,6 +4593,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,7 +4620,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3990,7 +4671,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4001,7 +4682,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4071,13 +4752,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -4093,7 +4775,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4126,6 +4808,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4143,7 +4826,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_write",
  "winnow",
@@ -4220,7 +4903,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4306,6 +4989,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -4466,7 +5155,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4496,7 +5185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4509,7 +5198,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4618,7 +5307,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4629,7 +5318,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4847,9 +5536,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4865,7 +5554,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4878,7 +5567,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4897,7 +5586,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4995,7 +5684,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5016,7 +5705,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5036,7 +5725,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5057,7 +5746,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5090,7 +5779,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/airc-daemon",
     "crates/airc-lib",
     "crates/airc-cli",
+    "crates/airc-acp",
     "crates/examples/embedded_consumer_smoke",
     "crates/examples/consumer_shapes",
     "crates/examples/persona_spawn_smoke",

--- a/crates/airc-acp/Cargo.toml
+++ b/crates/airc-acp/Cargo.toml
@@ -15,7 +15,27 @@ publish = false
 # way means the security-relevant rule is unit-tested before a subprocess exists,
 # rather than being an `if` buried in an async callback.
 
+[features]
+# Test fixtures. Per CLAUDE.md's test discipline, fixtures live behind a cargo
+# feature so a production build physically cannot link them.
+test-fixtures = []
+
+# A real ACP agent over real stdio, so the SUBPROCESS path (spawn + JSON-RPC
+# framing) is covered by a deterministic test rather than only by a live run.
+# That path is where Windows historically fails silently — a child that never
+# starts looks exactly like an agent with nothing to say.
+[[bin]]
+name = "acp-echo-agent"
+path = "src/bin/acp_echo_agent.rs"
+required-features = ["test-fixtures"]
+
 [lints]
 workspace = true
 
 [dependencies]
+agent-client-protocol = "2"
+agent-client-protocol-tokio = "0.11"
+tokio = { version = "1.53.1", features = ["process", "rt", "macros", "io-util"] }
+
+[dev-dependencies]
+tokio = { version = "1.53.1", features = ["rt", "macros", "rt-multi-thread"] }

--- a/crates/airc-acp/Cargo.toml
+++ b/crates/airc-acp/Cargo.toml
@@ -35,6 +35,10 @@ workspace = true
 [dependencies]
 agent-client-protocol = "2"
 agent-client-protocol-tokio = "0.11"
+# The ToolKind → toolsAllow key is derived from the type's serde repr (see
+# `kind_key` in transport.rs) rather than a `_`-wildcard match the non-exhaustive
+# enum forces and the no-silent-fallback clippy gate forbids. Already in the lock.
+serde_json = "1"
 tokio = { version = "1.53.1", features = ["process", "rt", "macros", "io-util"] }
 
 [dev-dependencies]

--- a/crates/airc-acp/Cargo.toml
+++ b/crates/airc-acp/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "airc-acp"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+# airc as an ACP CLIENT — one bridge, every agent that speaks the Agent Client
+# Protocol. See docs/architecture/ACP-CLIENT-BRIDGE.md.
+#
+# This slice owns the DECISIONS (who may prompt, which tools may run, how a
+# refusal reaches the room) as pure, testable logic with no I/O. The transport —
+# spawning the agent and driving Initialize/NewSession/Prompt over
+# `agent-client-protocol` — lands next, against this contract. Splitting it this
+# way means the security-relevant rule is unit-tested before a subprocess exists,
+# rather than being an `if` buried in an async callback.
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/airc-acp/src/bin/acp_echo_agent.rs
+++ b/crates/airc-acp/src/bin/acp_echo_agent.rs
@@ -1,0 +1,154 @@
+//! A real ACP agent, over real stdio — the fixture that proves the SUBPROCESS
+//! path.
+//!
+//! The in-process round-trip tests in `transport.rs` cover the protocol logic,
+//! but they never fork anything. Spawning a child and speaking JSON-RPC over its
+//! stdin/stdout is a separate risk surface, and on Windows it is the one that
+//! historically breaks quietly: a child that fails to start, or a stdout that
+//! isn't clean UTF-8, presents as an agent that simply never answers.
+//!
+//! So this binary exists to be spawned. It is deliberately tiny and has no
+//! model, no network, and no configuration — if a test using it fails, the
+//! failure is in spawn/framing, not in someone's inference backend.
+//!
+//! Gated behind the `test-fixtures` feature so a production build physically
+//! cannot link it.
+//!
+//! ## Behaviour
+//!
+//! - Any prompt → replies `echo: <prompt>`.
+//! - A prompt starting with `tool:<kind>` → first asks the client for permission
+//!   to run a tool of that kind, then reports the verdict it got back. This is
+//!   what lets a test assert that a REFUSAL crossed a process boundary.
+//! - A prompt of exactly `die` → exits the process mid-turn, so the "a killed
+//!   agent is visible, not silent" case can be tested rather than asserted.
+//!
+//! ## stdout is the protocol
+//!
+//! ACP agents reserve stdout for JSON-RPC framing. Anything this binary prints
+//! for humans MUST go to stderr — a stray `println!` here would corrupt the
+//! stream and produce exactly the confusing "agent went quiet" symptom this
+//! fixture is meant to catch.
+
+use agent_client_protocol::schema::v1::{
+    AgentCapabilities, ContentBlock, ContentChunk, InitializeRequest, InitializeResponse,
+    NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionId,
+    PermissionOptionKind, PromptRequest, PromptResponse, RequestPermissionRequest, SessionId,
+    SessionNotification, SessionUpdate, StopReason, TextContent, ToolCallId, ToolCallUpdate,
+    ToolCallUpdateFields, ToolKind,
+};
+use agent_client_protocol::{Agent, Client, ConnectionTo, Responder, Stdio};
+
+fn tool_kind(name: &str) -> ToolKind {
+    match name {
+        "read" => ToolKind::Read,
+        "edit" => ToolKind::Edit,
+        "delete" => ToolKind::Delete,
+        "move" => ToolKind::Move,
+        "search" => ToolKind::Search,
+        "execute" => ToolKind::Execute,
+        "think" => ToolKind::Think,
+        "fetch" => ToolKind::Fetch,
+        _ => ToolKind::Other,
+    }
+}
+
+fn option(id: &str, kind: PermissionOptionKind) -> PermissionOption {
+    PermissionOption::new(
+        PermissionOptionId::from(id.to_string()),
+        id.to_string(),
+        kind,
+    )
+}
+
+/// Pull the text out of a prompt request's content blocks.
+fn prompt_text(request: &PromptRequest) -> String {
+    request
+        .prompt
+        .iter()
+        .filter_map(|b| match b {
+            ContentBlock::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[tokio::main]
+async fn main() -> agent_client_protocol::Result<()> {
+    Agent
+        .builder()
+        .name("acp-echo-agent")
+        .on_receive_request(
+            async move |req: InitializeRequest,
+                        responder: Responder<InitializeResponse>,
+                        _cx: ConnectionTo<Client>| {
+                responder.respond(
+                    InitializeResponse::new(req.protocol_version)
+                        .agent_capabilities(AgentCapabilities::new()),
+                )
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |_req: NewSessionRequest,
+                        responder: Responder<NewSessionResponse>,
+                        _cx: ConnectionTo<Client>| {
+                responder.respond(NewSessionResponse::new(SessionId::new("echo-session")))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            move |req: PromptRequest,
+                  responder: Responder<PromptResponse>,
+                  cx: ConnectionTo<Client>| {
+                let cx2 = cx.clone();
+                // Spawned, not inline: an `on_receive_request` callback holds the
+                // dispatch loop, so awaiting the permission reply inline would
+                // deadlock waiting on the loop it is holding. (The SDK documents
+                // this under "Deadlock Risk".)
+                let turn = async move {
+                    let asked = prompt_text(&req);
+
+                    if asked.trim() == "die" {
+                        // Vanish mid-turn on purpose. The client must surface this
+                        // as a failure rather than an empty reply.
+                        eprintln!("acp-echo-agent: exiting mid-turn by request");
+                        std::process::exit(9);
+                    }
+
+                    let mut text = format!("echo: {asked}");
+
+                    if let Some(kind) = asked.trim().strip_prefix("tool:") {
+                        let fields = ToolCallUpdateFields::new()
+                            .kind(tool_kind(kind.trim()))
+                            .title(format!("fixture tool ({})", kind.trim()));
+                        let verdict = cx2
+                            .send_request(RequestPermissionRequest::new(
+                                req.session_id.clone(),
+                                ToolCallUpdate::new(ToolCallId::new("fixture-call"), fields),
+                                vec![
+                                    option("once", PermissionOptionKind::AllowOnce),
+                                    option("rej-once", PermissionOptionKind::RejectOnce),
+                                ],
+                            ))
+                            .block_task()
+                            .await?;
+                        text = format!("verdict: {:?}", verdict.outcome);
+                    }
+
+                    cx2.send_notification(SessionNotification::new(
+                        req.session_id,
+                        SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                            TextContent::new(text),
+                        ))),
+                    ))?;
+                    responder.respond(PromptResponse::new(StopReason::EndTurn))
+                };
+                async move { cx.spawn(turn) }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .connect_to(Stdio::new())
+        .await
+}

--- a/crates/airc-acp/src/lib.rs
+++ b/crates/airc-acp/src/lib.rs
@@ -1,0 +1,223 @@
+//! airc as an ACP **client** — one bridge, N agents.
+//!
+//! See `docs/architecture/ACP-CLIENT-BRIDGE.md` for why this shape rather than a
+//! per-agent plugin. Short version: Hermes already ships an
+//! `agent-client-protocol` adapter over JSON-RPC stdio, as do the other entries
+//! in the ACP registry. Writing a Hermes-specific plugin would buy one agent and
+//! couple us to their internals; speaking the standard instead makes every ACP
+//! agent a room citizen with zero upstream patches.
+//!
+//! ## Shape
+//!
+//! ```text
+//!   room message  ──▶  PromptRequest         ──▶  agent subprocess (stdio JSON-RPC)
+//!   room message  ◀──  SessionNotification   ◀──
+//!                      RequestPermissionRequest ─▶ ToolPolicy (deny by default)
+//! ```
+//!
+//! The agent is a child process the bridge owns. `AcpAgent::from_str("hermes-acp")`
+//! spawns it and serves as the transport.
+
+pub mod policy;
+
+pub use policy::{PeerPolicy, PermissionDecision, ToolPolicy};
+
+use std::fmt;
+
+/// How to launch one ACP agent, and what it is allowed to do once running.
+///
+/// The command is a plain string (`"hermes-acp"`, `"uvx hermes-agent[acp]"`,
+/// `"python my_agent.py"`) because that is what the ACP registry publishes and
+/// what the SDK's `AcpAgent::from_str` consumes. Keeping it a string means a new
+/// agent is a config line, not a code change — which is the entire point of
+/// speaking the standard.
+#[derive(Debug, Clone)]
+pub struct AgentSpec {
+    /// Command line that launches the agent in ACP mode.
+    pub command: String,
+    /// Which tools it may run on behalf of the room. Defaults to nothing.
+    pub tools: ToolPolicy,
+    /// Which peers may prompt it. Defaults to anyone in the room.
+    pub peers: PeerPolicy,
+}
+
+impl AgentSpec {
+    /// A spec that can think but cannot act: it will answer prompts from anyone
+    /// in the room and refuse every tool.
+    ///
+    /// This is the honest default for an agent nobody has configured yet. It is
+    /// useful immediately (chat works) and cannot be turned into a foothold by a
+    /// peer, which is the property that matters when the prompter is arbitrary.
+    pub fn talk_only(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            tools: ToolPolicy::deny_all(),
+            peers: PeerPolicy::any(),
+        }
+    }
+
+    pub fn with_tools(mut self, tools: ToolPolicy) -> Self {
+        self.tools = tools;
+        self
+    }
+
+    pub fn with_peers(mut self, peers: PeerPolicy) -> Self {
+        self.peers = peers;
+        self
+    }
+}
+
+/// Why a bridge attempt failed, in terms an operator can act on.
+///
+/// Deliberately NOT a catch-all string: "the agent did not answer" and "the
+/// agent refused the peer" lead to different fixes, and a bridge that collapses
+/// them sends the reader to the wrong layer — the failure mode this whole
+/// session kept running into.
+#[derive(Debug)]
+pub enum BridgeError {
+    /// The peer is not permitted to prompt this agent.
+    PeerRefused { peer_id: String },
+    /// The agent process could not be spawned or did not speak ACP.
+    AgentUnavailable { command: String, detail: String },
+    /// The agent was reached but the exchange failed.
+    Exchange { detail: String },
+}
+
+impl fmt::Display for BridgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BridgeError::PeerRefused { peer_id } => write!(
+                f,
+                "peer {peer_id} is not in this agent's allowFrom list — it may read the room but not prompt this agent"
+            ),
+            BridgeError::AgentUnavailable { command, detail } => write!(
+                f,
+                "could not start ACP agent `{command}`: {detail} — check it is installed and supports ACP (e.g. `uvx hermes-agent[acp]`)"
+            ),
+            BridgeError::Exchange { detail } => {
+                write!(f, "ACP exchange failed: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BridgeError {}
+
+/// One turn's worth of result, ready to publish back into the room.
+#[derive(Debug, Clone, Default)]
+pub struct AgentTurn {
+    /// The agent's reply text, assembled from its streamed updates.
+    pub text: String,
+    /// Every permission decision made during the turn, in order.
+    ///
+    /// Carried out of the turn rather than logged and forgotten: a refusal that
+    /// only reaches a log file is invisible to the room, and the room is where
+    /// the person wondering why the agent stopped short is looking.
+    pub decisions: Vec<PermissionDecision>,
+}
+
+impl AgentTurn {
+    /// Did anything get refused this turn?
+    pub fn had_refusal(&self) -> bool {
+        self.decisions.iter().any(|d| !d.is_allowed())
+    }
+
+    /// The lines to publish into the room alongside the reply, or empty when the
+    /// turn needed no permissions. Refusals are surfaced; approvals are not —
+    /// announcing every permitted tool would flood the room and train readers to
+    /// ignore the line that matters.
+    pub fn refusal_lines(&self) -> Vec<String> {
+        self.decisions
+            .iter()
+            .filter(|d| !d.is_allowed())
+            .map(|d| d.to_room_line())
+            .collect()
+    }
+}
+
+/// Decide whether `peer_id` may prompt `spec`, before any process is spawned.
+///
+/// Split out and pure so the gate is testable without an agent, and so the
+/// refusal happens BEFORE we pay for a subprocess — a peer who cannot prompt
+/// should not be able to make us fork one.
+pub fn admit_prompt(spec: &AgentSpec, peer_id: &str) -> Result<(), BridgeError> {
+    if spec.peers.may_prompt(peer_id) {
+        Ok(())
+    } else {
+        Err(BridgeError::PeerRefused {
+            peer_id: peer_id.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// what this catches: a default that can act. An unconfigured agent must be
+    /// able to CHAT (that is the point of the bridge) while refusing every tool —
+    /// in a room the prompter is an arbitrary peer.
+    #[test]
+    fn the_default_spec_can_think_but_not_act() {
+        let spec = AgentSpec::talk_only("hermes-acp");
+        assert!(
+            spec.peers.may_prompt("peer-anyone"),
+            "chat must work by default"
+        );
+        assert!(!spec.tools.decide("shell").is_allowed(), "tools must not");
+    }
+
+    /// what this catches: spawning a subprocess for a peer we were going to
+    /// refuse anyway. The gate must be decidable before any process exists.
+    #[test]
+    fn a_refused_peer_is_rejected_before_any_spawn() {
+        let spec = AgentSpec::talk_only("hermes-acp").with_peers(PeerPolicy::only(["peer-a"]));
+        let err = admit_prompt(&spec, "peer-b").unwrap_err();
+        assert!(matches!(err, BridgeError::PeerRefused { .. }));
+        // The message must name the distinction, or the operator reads it as "the
+        // agent is broken" rather than "the agent is configured".
+        assert!(err.to_string().contains("allowFrom"), "{err}");
+        assert!(admit_prompt(&spec, "peer-a").is_ok());
+    }
+
+    /// what this catches: refusals dying in a log. The room is where someone is
+    /// wondering why the agent stopped short, so the turn must carry them out.
+    #[test]
+    fn refusals_travel_with_the_turn_and_approvals_stay_quiet() {
+        let turn = AgentTurn {
+            text: "I could not write that file.".into(),
+            decisions: vec![
+                PermissionDecision::Allow {
+                    tool: "read_file".into(),
+                },
+                PermissionDecision::Deny {
+                    tool: "write_file".into(),
+                    reason: "not allow-listed".into(),
+                },
+            ],
+        };
+        assert!(turn.had_refusal());
+        let lines = turn.refusal_lines();
+        assert_eq!(lines.len(), 1, "only refusals surface: {lines:?}");
+        assert!(lines[0].contains("write_file"));
+    }
+
+    /// what this catches: an error type that collapses "cannot start" into
+    /// "exchange failed". They point at different fixes — install the agent vs
+    /// debug the protocol — and today's whole session was one long lesson in
+    /// what a mislabelled cause costs.
+    #[test]
+    fn unavailable_and_exchange_failures_stay_distinguishable() {
+        let unavailable = BridgeError::AgentUnavailable {
+            command: "hermes-acp".into(),
+            detail: "no such file".into(),
+        };
+        assert!(unavailable.to_string().contains("could not start"));
+        assert!(unavailable.to_string().contains("uvx hermes-agent[acp]"));
+
+        let exchange = BridgeError::Exchange {
+            detail: "timeout".into(),
+        };
+        assert!(!exchange.to_string().contains("could not start"));
+    }
+}

--- a/crates/airc-acp/src/lib.rs
+++ b/crates/airc-acp/src/lib.rs
@@ -19,10 +19,13 @@
 //! spawns it and serves as the transport.
 
 pub mod policy;
+pub mod transport;
 
-pub use policy::{PeerPolicy, PermissionDecision, ToolPolicy};
+pub use policy::{PeerPolicy, PermissionDecision, ToolIdentity, ToolPolicy};
+pub use transport::AcpBridge;
 
 use std::fmt;
+use std::path::PathBuf;
 
 /// How to launch one ACP agent, and what it is allowed to do once running.
 ///
@@ -39,6 +42,13 @@ pub struct AgentSpec {
     pub tools: ToolPolicy,
     /// Which peers may prompt it. Defaults to anyone in the room.
     pub peers: PeerPolicy,
+    /// The directory the agent treats as its workspace.
+    ///
+    /// `None` means the bridge process's current directory. Named explicitly
+    /// rather than always-implicit because the bridge may run as a daemon whose
+    /// cwd is unrelated to any project — an agent silently rooted at `/` is a
+    /// confusing way to find out.
+    pub workspace: Option<PathBuf>,
 }
 
 impl AgentSpec {
@@ -53,6 +63,7 @@ impl AgentSpec {
             command: command.into(),
             tools: ToolPolicy::deny_all(),
             peers: PeerPolicy::any(),
+            workspace: None,
         }
     }
 
@@ -63,6 +74,11 @@ impl AgentSpec {
 
     pub fn with_peers(mut self, peers: PeerPolicy) -> Self {
         self.peers = peers;
+        self
+    }
+
+    pub fn with_workspace(mut self, workspace: impl Into<PathBuf>) -> Self {
+        self.workspace = Some(workspace.into());
         self
     }
 }
@@ -164,7 +180,11 @@ mod tests {
             spec.peers.may_prompt("peer-anyone"),
             "chat must work by default"
         );
-        assert!(!spec.tools.decide("shell").is_allowed(), "tools must not");
+        let execute = ToolIdentity {
+            kind: Some("execute".into()),
+            title: Some("run a shell command".into()),
+        };
+        assert!(!spec.tools.decide(&execute).is_allowed(), "tools must not");
     }
 
     /// what this catches: spawning a subprocess for a peer we were going to
@@ -188,10 +208,11 @@ mod tests {
             text: "I could not write that file.".into(),
             decisions: vec![
                 PermissionDecision::Allow {
-                    tool: "read_file".into(),
+                    label: "read src/main.rs (read)".into(),
+                    caveat: None,
                 },
                 PermissionDecision::Deny {
-                    tool: "write_file".into(),
+                    label: "write src/main.rs (edit)".into(),
                     reason: "not allow-listed".into(),
                 },
             ],
@@ -199,7 +220,7 @@ mod tests {
         assert!(turn.had_refusal());
         let lines = turn.refusal_lines();
         assert_eq!(lines.len(), 1, "only refusals surface: {lines:?}");
-        assert!(lines[0].contains("write_file"));
+        assert!(lines[0].contains("write src/main.rs"));
     }
 
     /// what this catches: an error type that collapses "cannot start" into

--- a/crates/airc-acp/src/policy.rs
+++ b/crates/airc-acp/src/policy.rs
@@ -18,20 +18,80 @@
 //! the room rather than swallowed. A silent denial is its own bug: the agent
 //! stalls, the room sees nothing, and whoever debugs it spends an hour before
 //! discovering a permission gate declined without saying so.
+//!
+//! ## Why the allow-list is keyed on KIND, not on tool name
+//!
+//! ACP's stable permission request identifies a tool by `ToolCallUpdateFields`,
+//! whose `title` is a per-call human string ("Write file src/main.rs") and whose
+//! `kind` is a fixed enum (`Read`/`Edit`/`Execute`/…). The *programmatic* name is
+//! behind the `unstable_tool_call_name` feature.
+//!
+//! Allow-listing on `title` would therefore be matching free text that changes
+//! per invocation — a rule that silently stops matching the moment an agent
+//! rewords its own label. Allow-listing on `kind` is stable across agents and is
+//! the decision an operator actually wants to express: *this agent may read, but
+//! not execute*. So `kind` is the gate, and `title` is carried only for the human
+//! reading the room line.
+//!
+//! See [`ToolIdentity::kind_key`] for the one place the enum becomes a config
+//! string.
 
 use std::collections::BTreeSet;
+
+/// What the room knows about the tool an agent is asking to run.
+///
+/// Both fields are optional because *both are optional on the wire*. An agent
+/// may request permission without declaring what for. That is not a reason to
+/// assume it is harmless — see [`ToolPolicy::decide`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolIdentity {
+    /// Normalized ACP `ToolKind` ("read", "execute", …), when the agent declared
+    /// one. `None` means the agent did not say.
+    pub kind: Option<String>,
+    /// The agent's own human-readable label for this specific call. Display
+    /// only — never matched against, because it varies per invocation.
+    pub title: Option<String>,
+}
+
+impl ToolIdentity {
+    /// The gate key: the declared kind, or `None` when the agent didn't declare.
+    pub fn kind_key(&self) -> Option<&str> {
+        self.kind.as_deref()
+    }
+
+    /// How this tool call should read in a room line. Prefers the agent's own
+    /// wording, falls back to the kind, and finally admits it doesn't know —
+    /// rather than printing an empty string that reads like a bug.
+    pub fn label(&self) -> String {
+        match (self.title.as_deref(), self.kind.as_deref()) {
+            (Some(t), Some(k)) => format!("{t} ({k})"),
+            (Some(t), None) => t.to_string(),
+            (None, Some(k)) => k.to_string(),
+            (None, None) => "an undeclared tool".to_string(),
+        }
+    }
+}
 
 /// What the bridge decided about one tool-permission request, and why.
 ///
 /// The reason is carried, not just the verdict, because it is published into the
-/// room. "Denied" alone teaches the operator nothing; "denied: `write_file` is not
+/// room. "Denied" alone teaches the operator nothing; "denied: `execute` is not
 /// in this account's toolsAllow" tells them exactly which knob to turn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionDecision {
     /// The tool is explicitly allowed for this account.
-    Allow { tool: String },
+    ///
+    /// `caveat` is `Some` when the approval had to be granted on terms we would
+    /// not have chosen — currently only when the agent offered no once-only
+    /// option, so approving means it will remember. Carried rather than dropped
+    /// because "the agent will stop asking" is exactly the kind of fact that
+    /// must not be invisible.
+    Allow {
+        label: String,
+        caveat: Option<String>,
+    },
     /// Refused. `reason` is operator-facing and names the fix.
-    Deny { tool: String, reason: String },
+    Deny { label: String, reason: String },
 }
 
 impl PermissionDecision {
@@ -42,17 +102,26 @@ impl PermissionDecision {
     /// One line, safe to publish into a room.
     pub fn to_room_line(&self) -> String {
         match self {
-            PermissionDecision::Allow { tool } => {
-                format!("permitted tool `{tool}` (allow-listed)")
+            PermissionDecision::Allow {
+                label,
+                caveat: None,
+            } => {
+                format!("permitted {label} (allow-listed)")
             }
-            PermissionDecision::Deny { tool, reason } => {
-                format!("refused tool `{tool}`: {reason}")
+            PermissionDecision::Allow {
+                label,
+                caveat: Some(c),
+            } => {
+                format!("permitted {label} (allow-listed) — {c}")
+            }
+            PermissionDecision::Deny { label, reason } => {
+                format!("refused {label}: {reason}")
             }
         }
     }
 }
 
-/// Which tools an ACP agent may run on behalf of a room.
+/// Which classes of tool an ACP agent may run on behalf of a room.
 ///
 /// Empty means empty: an account that lists no tools gets no tools. This is
 /// deliberately NOT "unset means everything" — the permissive reading of an
@@ -70,14 +139,22 @@ impl ToolPolicy {
         Self::default()
     }
 
-    /// Permit exactly these tool names.
-    pub fn allow<I, S>(tools: I) -> Self
+    /// Permit exactly these tool kinds (`"read"`, `"search"`, `"execute"`, …).
+    ///
+    /// Names are normalized to lowercase so a config saying `"Read"` behaves as
+    /// the operator plainly intended — a case mismatch silently denying a tool
+    /// they explicitly allow-listed would be a wrong-shaped surprise.
+    pub fn allow<I, S>(kinds: I) -> Self
     where
         I: IntoIterator<Item = S>,
-        S: Into<String>,
+        S: AsRef<str>,
     {
         Self {
-            allowed: tools.into_iter().map(Into::into).collect(),
+            allowed: kinds
+                .into_iter()
+                .map(|k| k.as_ref().trim().to_ascii_lowercase())
+                .filter(|k| !k.is_empty())
+                .collect(),
         }
     }
 
@@ -88,25 +165,41 @@ impl ToolPolicy {
     /// Decide one request. Pure: no I/O, no logging, no side effects — so the
     /// rule is unit-testable without spawning an agent, and there is exactly one
     /// place the decision is made.
-    pub fn decide(&self, tool: &str) -> PermissionDecision {
-        if self.allowed.contains(tool) {
+    pub fn decide(&self, tool: &ToolIdentity) -> PermissionDecision {
+        let label = tool.label();
+
+        // An agent that does not say what it wants to run does not thereby get to
+        // run it. NOT-DECLARED and KNOWN-HARMLESS are different facts, and
+        // collapsing them is how a gate ends up approving the one call it had the
+        // least information about.
+        let Some(kind) = tool.kind_key() else {
+            return PermissionDecision::Deny {
+                label,
+                reason: "the agent did not declare a tool kind, so this cannot be matched against \
+                         toolsAllow — an undeclared tool is refused, not assumed safe"
+                    .to_string(),
+            };
+        };
+
+        if self.allowed.contains(kind) {
             return PermissionDecision::Allow {
-                tool: tool.to_string(),
+                label,
+                caveat: None,
             };
         }
+
         let reason = if self.allowed.is_empty() {
-            "this account allow-lists no tools at all — set `toolsAllow` to permit specific ones"
-                .to_string()
+            format!(
+                "this account allow-lists no tools at all — set `toolsAllow` to permit kinds like \
+                 `{kind}`"
+            )
         } else {
             format!(
-                "not in this account's toolsAllow ({})",
+                "kind `{kind}` is not in this account's toolsAllow ({})",
                 self.allowed.iter().cloned().collect::<Vec<_>>().join(", ")
             )
         };
-        PermissionDecision::Deny {
-            tool: tool.to_string(),
-            reason,
-        }
+        PermissionDecision::Deny { label, reason }
     }
 }
 
@@ -147,17 +240,39 @@ impl PeerPolicy {
 mod tests {
     use super::*;
 
+    fn tool(kind: &str) -> ToolIdentity {
+        ToolIdentity {
+            kind: Some(kind.to_string()),
+            title: None,
+        }
+    }
+
     /// what this catches: the SDK example's behaviour leaking into a room. An
     /// unconfigured lane must refuse tools, not inherit "allow everything" — in a
     /// room the prompter is an arbitrary peer.
     #[test]
     fn an_unconfigured_policy_permits_nothing() {
         let p = ToolPolicy::deny_all();
-        let d = p.decide("shell");
+        let d = p.decide(&tool("execute"));
         assert!(!d.is_allowed());
-        assert!(d.to_room_line().contains("refused tool `shell`"));
+        assert!(d.to_room_line().contains("refused execute"));
         // The refusal must name the fix, or the operator learns nothing from it.
         assert!(d.to_room_line().contains("toolsAllow"));
+    }
+
+    /// what this catches: treating "the agent didn't say" as "nothing to worry
+    /// about". An undeclared tool carries the LEAST information, so it is the
+    /// last one that should get the benefit of the doubt.
+    #[test]
+    fn an_undeclared_tool_kind_is_refused_even_when_tools_are_allowed() {
+        let permissive = ToolPolicy::allow(["read", "execute"]);
+        let undeclared = ToolIdentity {
+            kind: None,
+            title: Some("do the thing".into()),
+        };
+        let d = permissive.decide(&undeclared);
+        assert!(!d.is_allowed(), "undeclared must not inherit an allow");
+        assert!(d.to_room_line().contains("did not declare"), "{d:?}");
     }
 
     /// what this catches: a denial that says only "denied". The reason is
@@ -165,20 +280,30 @@ mod tests {
     /// cannot tell a typo from a policy choice.
     #[test]
     fn a_denial_names_what_was_allowed_instead() {
-        let p = ToolPolicy::allow(["read_file", "search"]);
-        let line = p.decide("write_file").to_room_line();
-        assert!(line.contains("read_file"), "{line}");
+        let p = ToolPolicy::allow(["read", "search"]);
+        let line = p.decide(&tool("execute")).to_room_line();
+        assert!(line.contains("read"), "{line}");
         assert!(line.contains("search"), "{line}");
     }
 
     #[test]
-    fn an_allow_listed_tool_is_permitted() {
-        let p = ToolPolicy::allow(["read_file"]);
-        assert!(p.decide("read_file").is_allowed());
+    fn an_allow_listed_kind_is_permitted() {
+        let p = ToolPolicy::allow(["read"]);
+        assert!(p.decide(&tool("read")).is_allowed());
         assert!(
-            !p.decide("read_file2").is_allowed(),
+            !p.decide(&tool("read_all")).is_allowed(),
             "prefix must not match"
         );
+    }
+
+    /// what this catches: a case-sensitivity trap. An operator writing "Read" in
+    /// their config means read; silently denying it would send them hunting
+    /// through the bridge for a bug that is really a lowercase letter.
+    #[test]
+    fn config_casing_does_not_change_the_verdict() {
+        let p = ToolPolicy::allow(["Read", "  EXECUTE  "]);
+        assert!(p.decide(&tool("read")).is_allowed());
+        assert!(p.decide(&tool("execute")).is_allowed());
     }
 
     /// what this catches: collapsing the two gates. Prompting is open by default
@@ -195,5 +320,18 @@ mod tests {
         let p = PeerPolicy::only(["peer-a"]);
         assert!(p.may_prompt("peer-a"));
         assert!(!p.may_prompt("peer-b"));
+    }
+
+    /// what this catches: an approval granted on terms we didn't choose going
+    /// out silently. If the agent will REMEMBER an approval, the room has to be
+    /// told, because from the next turn onward our policy stops being asked.
+    #[test]
+    fn an_approval_the_agent_will_remember_says_so_out_loud() {
+        let d = PermissionDecision::Allow {
+            label: "read (read)".into(),
+            caveat: Some("the agent offered no once-only option, so it will remember".into()),
+        };
+        assert!(d.is_allowed());
+        assert!(d.to_room_line().contains("will remember"), "{d:?}");
     }
 }

--- a/crates/airc-acp/src/policy.rs
+++ b/crates/airc-acp/src/policy.rs
@@ -1,0 +1,199 @@
+//! Tool-permission policy for an ACP agent answering in a ROOM.
+//!
+//! ## Why this is not the SDK's example
+//!
+//! The `agent-client-protocol` SDK ships a client example that auto-approves
+//! every permission request. It is honest about that — it is named
+//! `yolo_one_shot_client`, and for its use case it is right: a human typed the
+//! prompt into their own terminal and is watching the tool run.
+//!
+//! A room inverts the trust model. The prompt arrives from a PEER, and airc
+//! broadcasts carry no structural addressing (every send is `MentionTarget::All`,
+//! see the "What Doesn't Work Yet" section of the README), so *anyone* who can
+//! reach the room is a potential prompter. Auto-approving there would mean any
+//! peer can induce arbitrary tool execution — file writes, shell, network — on
+//! the machine hosting the agent, with no human in the loop.
+//!
+//! So the default here is DENY, and the denial is meant to be spoken aloud into
+//! the room rather than swallowed. A silent denial is its own bug: the agent
+//! stalls, the room sees nothing, and whoever debugs it spends an hour before
+//! discovering a permission gate declined without saying so.
+
+use std::collections::BTreeSet;
+
+/// What the bridge decided about one tool-permission request, and why.
+///
+/// The reason is carried, not just the verdict, because it is published into the
+/// room. "Denied" alone teaches the operator nothing; "denied: `write_file` is not
+/// in this account's toolsAllow" tells them exactly which knob to turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionDecision {
+    /// The tool is explicitly allowed for this account.
+    Allow { tool: String },
+    /// Refused. `reason` is operator-facing and names the fix.
+    Deny { tool: String, reason: String },
+}
+
+impl PermissionDecision {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, PermissionDecision::Allow { .. })
+    }
+
+    /// One line, safe to publish into a room.
+    pub fn to_room_line(&self) -> String {
+        match self {
+            PermissionDecision::Allow { tool } => {
+                format!("permitted tool `{tool}` (allow-listed)")
+            }
+            PermissionDecision::Deny { tool, reason } => {
+                format!("refused tool `{tool}`: {reason}")
+            }
+        }
+    }
+}
+
+/// Which tools an ACP agent may run on behalf of a room.
+///
+/// Empty means empty: an account that lists no tools gets no tools. This is
+/// deliberately NOT "unset means everything" — the permissive reading of an
+/// absent config is how a security default becomes an accident.
+#[derive(Debug, Clone, Default)]
+pub struct ToolPolicy {
+    allowed: BTreeSet<String>,
+}
+
+impl ToolPolicy {
+    /// A policy that permits nothing. The correct default for a lane that has
+    /// not been configured: it fails closed and says so, rather than deciding on
+    /// the operator's behalf that their unconfigured agent should have a shell.
+    pub fn deny_all() -> Self {
+        Self::default()
+    }
+
+    /// Permit exactly these tool names.
+    pub fn allow<I, S>(tools: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            allowed: tools.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.allowed.is_empty()
+    }
+
+    /// Decide one request. Pure: no I/O, no logging, no side effects — so the
+    /// rule is unit-testable without spawning an agent, and there is exactly one
+    /// place the decision is made.
+    pub fn decide(&self, tool: &str) -> PermissionDecision {
+        if self.allowed.contains(tool) {
+            return PermissionDecision::Allow {
+                tool: tool.to_string(),
+            };
+        }
+        let reason = if self.allowed.is_empty() {
+            "this account allow-lists no tools at all — set `toolsAllow` to permit specific ones"
+                .to_string()
+        } else {
+            format!(
+                "not in this account's toolsAllow ({})",
+                self.allowed.iter().cloned().collect::<Vec<_>>().join(", ")
+            )
+        };
+        PermissionDecision::Deny {
+            tool: tool.to_string(),
+            reason,
+        }
+    }
+}
+
+/// Who may prompt this agent at all.
+///
+/// Separate from [`ToolPolicy`] on purpose: "may this peer talk to the agent"
+/// and "may the agent run this tool" are different questions, and collapsing
+/// them produces a config where tightening one silently loosens the other.
+#[derive(Debug, Clone, Default)]
+pub struct PeerPolicy {
+    allowed: BTreeSet<String>,
+}
+
+impl PeerPolicy {
+    /// Accept any peer in the room. This IS the sane default for prompting —
+    /// unlike tools, a prompt runs no code; it only asks the agent to think. The
+    /// tool gate is where the teeth belong.
+    pub fn any() -> Self {
+        Self::default()
+    }
+
+    pub fn only<I, S>(peers: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            allowed: peers.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub fn may_prompt(&self, peer_id: &str) -> bool {
+        self.allowed.is_empty() || self.allowed.contains(peer_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// what this catches: the SDK example's behaviour leaking into a room. An
+    /// unconfigured lane must refuse tools, not inherit "allow everything" — in a
+    /// room the prompter is an arbitrary peer.
+    #[test]
+    fn an_unconfigured_policy_permits_nothing() {
+        let p = ToolPolicy::deny_all();
+        let d = p.decide("shell");
+        assert!(!d.is_allowed());
+        assert!(d.to_room_line().contains("refused tool `shell`"));
+        // The refusal must name the fix, or the operator learns nothing from it.
+        assert!(d.to_room_line().contains("toolsAllow"));
+    }
+
+    /// what this catches: a denial that says only "denied". The reason is
+    /// published into the room; without the allow-list contents the operator
+    /// cannot tell a typo from a policy choice.
+    #[test]
+    fn a_denial_names_what_was_allowed_instead() {
+        let p = ToolPolicy::allow(["read_file", "search"]);
+        let line = p.decide("write_file").to_room_line();
+        assert!(line.contains("read_file"), "{line}");
+        assert!(line.contains("search"), "{line}");
+    }
+
+    #[test]
+    fn an_allow_listed_tool_is_permitted() {
+        let p = ToolPolicy::allow(["read_file"]);
+        assert!(p.decide("read_file").is_allowed());
+        assert!(
+            !p.decide("read_file2").is_allowed(),
+            "prefix must not match"
+        );
+    }
+
+    /// what this catches: collapsing the two gates. Prompting is open by default
+    /// (a prompt runs no code); tools are closed by default. If a refactor ever
+    /// makes these share one set, this fails.
+    #[test]
+    fn prompting_is_open_by_default_while_tools_are_closed() {
+        assert!(PeerPolicy::any().may_prompt("peer-anyone"));
+        assert!(ToolPolicy::deny_all().is_empty());
+    }
+
+    #[test]
+    fn an_explicit_peer_list_excludes_everyone_else() {
+        let p = PeerPolicy::only(["peer-a"]);
+        assert!(p.may_prompt("peer-a"));
+        assert!(!p.may_prompt("peer-b"));
+    }
+}

--- a/crates/airc-acp/src/transport.rs
+++ b/crates/airc-acp/src/transport.rs
@@ -32,24 +32,22 @@ use crate::{admit_prompt, AgentSpec, AgentTurn, BridgeError};
 /// This is the ONE place the enum becomes config, so the vocabulary can't drift
 /// between the gate and the documentation.
 ///
-/// The catch-all matters: `ToolKind` is `#[non_exhaustive]`, so a kind added by
-/// a future SDK release lands here. It maps to `"other"` — the same bucket as
-/// ACP's own `Other` default — which is denied unless an operator has explicitly
-/// allow-listed unclassified tools. A new protocol capability therefore arrives
-/// closed, not open.
-fn kind_key(kind: &ToolKind) -> &'static str {
-    match kind {
-        ToolKind::Read => "read",
-        ToolKind::Edit => "edit",
-        ToolKind::Delete => "delete",
-        ToolKind::Move => "move",
-        ToolKind::Search => "search",
-        ToolKind::Execute => "execute",
-        ToolKind::Think => "think",
-        ToolKind::Fetch => "fetch",
-        ToolKind::SwitchMode => "switch_mode",
-        _ => "other",
-    }
+/// Derived from the `ToolKind` serde repr (`#[serde(rename_all = "snake_case")]`)
+/// rather than a `match`: `ToolKind` is `#[non_exhaustive]`, so any match needs a
+/// `_` arm — which the compiler FORCES and the production no-silent-fallback
+/// clippy gate (`-D clippy::wildcard_enum_match_arm`) forbids. No match can win.
+///
+/// The serde repr sidesteps the match: a future fieldless SDK variant yields its
+/// OWN snake_case name, stays absent from `toolsAllow`, and is still denied — a new
+/// protocol capability arrives CLOSED, not open, and the denial names the real
+/// kind instead of a blanket `"other"`. A future *data-carrying* variant can't
+/// render to a plain string and falls to `"other"` (still ACP's own default deny
+/// bucket) — fail-closed either way, with no wildcard.
+fn kind_key(kind: &ToolKind) -> String {
+    serde_json::to_value(kind)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_owned))
+        .unwrap_or_else(|| "other".to_owned())
 }
 
 /// Read the tool's identity off the wire request.
@@ -61,7 +59,7 @@ fn kind_key(kind: &ToolKind) -> &'static str {
 fn identity_of(request: &RequestPermissionRequest) -> ToolIdentity {
     let fields = &request.tool_call.fields;
     ToolIdentity {
-        kind: fields.kind.as_ref().map(|k| kind_key(k).to_string()),
+        kind: fields.kind.as_ref().map(kind_key),
         title: fields.title.clone(),
     }
 }

--- a/crates/airc-acp/src/transport.rs
+++ b/crates/airc-acp/src/transport.rs
@@ -1,0 +1,658 @@
+//! The transport: spawn an ACP agent, drive one turn, come back with something
+//! the room can read.
+//!
+//! Everything security-relevant is decided in [`crate::policy`] — this module's
+//! job is to be the honest plumbing between that decision and the wire. The two
+//! places where plumbing can quietly become policy are marked below, because
+//! both of them look like harmless defaults:
+//!
+//! 1. **Choosing which permission option to send back.** The SDK example picks
+//!    `options.first()`, which is fine when a human is watching and wrong here —
+//!    option order is the agent's choice, so "first" can mean "allow always".
+//!    See [`choose_outcome`].
+//! 2. **Answering `AllowAlways`.** That tells the agent to stop asking, which
+//!    silently retires our policy from every future turn. See [`choose_outcome`].
+
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol::schema::v1::{
+    InitializeRequest, PermissionOption, PermissionOptionKind, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, ToolKind,
+};
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::{AcpAgent, Client, ConnectionTo};
+
+use crate::policy::{PermissionDecision, ToolIdentity};
+use crate::{admit_prompt, AgentSpec, AgentTurn, BridgeError};
+
+/// Map an ACP `ToolKind` onto the string an operator writes in `toolsAllow`.
+///
+/// This is the ONE place the enum becomes config, so the vocabulary can't drift
+/// between the gate and the documentation.
+///
+/// The catch-all matters: `ToolKind` is `#[non_exhaustive]`, so a kind added by
+/// a future SDK release lands here. It maps to `"other"` — the same bucket as
+/// ACP's own `Other` default — which is denied unless an operator has explicitly
+/// allow-listed unclassified tools. A new protocol capability therefore arrives
+/// closed, not open.
+fn kind_key(kind: &ToolKind) -> &'static str {
+    match kind {
+        ToolKind::Read => "read",
+        ToolKind::Edit => "edit",
+        ToolKind::Delete => "delete",
+        ToolKind::Move => "move",
+        ToolKind::Search => "search",
+        ToolKind::Execute => "execute",
+        ToolKind::Think => "think",
+        ToolKind::Fetch => "fetch",
+        ToolKind::SwitchMode => "switch_mode",
+        _ => "other",
+    }
+}
+
+/// Read the tool's identity off the wire request.
+///
+/// Both fields are `Option` on the wire and stay `Option` here rather than being
+/// defaulted into something confident. `ToolPolicy::decide` is what turns "the
+/// agent didn't say" into a refusal; inventing a kind at this layer would hide
+/// that fact from the decision that needs it.
+fn identity_of(request: &RequestPermissionRequest) -> ToolIdentity {
+    let fields = &request.tool_call.fields;
+    ToolIdentity {
+        kind: fields.kind.as_ref().map(|k| kind_key(k).to_string()),
+        title: fields.title.clone(),
+    }
+}
+
+/// Turn a decision into the outcome to send back, given the options the agent
+/// offered.
+///
+/// Pure, and separated from the async handler so the selection rule is testable
+/// without a subprocess — this is the function that decides whether a "yes"
+/// means *this once* or *forever*.
+///
+/// Rules:
+/// - Prefer the ONCE-scoped option in both directions. An `AllowAlways` reply
+///   makes the agent cache the approval and stop sending permission requests,
+///   which would leave [`crate::policy::ToolPolicy`] wired up, passing its tests, and never
+///   consulted again. Answering `AllowOnce` keeps the policy in the loop on
+///   every single turn, which is the whole point of having one.
+/// - If the agent offers no once-scoped option, take the always-scoped one but
+///   return a caveat, so the room is told the agent will remember. Silently
+///   accepting a broader grant than we intended is the failure this avoids.
+/// - If the agent offers no option of the needed polarity at all, cancel.
+///   Cancelling is a refusal the protocol has a word for; guessing at an option
+///   of the wrong polarity is not.
+fn choose_outcome(
+    decision: &PermissionDecision,
+    options: &[PermissionOption],
+) -> (RequestPermissionOutcome, Option<String>) {
+    let (once, always) = if decision.is_allowed() {
+        (
+            PermissionOptionKind::AllowOnce,
+            PermissionOptionKind::AllowAlways,
+        )
+    } else {
+        (
+            PermissionOptionKind::RejectOnce,
+            PermissionOptionKind::RejectAlways,
+        )
+    };
+
+    let find = |want: &PermissionOptionKind| {
+        options
+            .iter()
+            .find(|o| &o.kind == want)
+            .map(|o| o.option_id.clone())
+    };
+
+    if let Some(id) = find(&once) {
+        return (
+            RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(id)),
+            None,
+        );
+    }
+
+    if let Some(id) = find(&always) {
+        let caveat = if decision.is_allowed() {
+            "the agent offered no once-only option, so it will remember this approval and may \
+             stop asking"
+        } else {
+            "the agent offered no once-only option, so it will remember this refusal"
+        };
+        return (
+            RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(id)),
+            Some(caveat.to_string()),
+        );
+    }
+
+    (RequestPermissionOutcome::Cancelled, None)
+}
+
+/// One ACP agent, reachable from a room.
+///
+/// ## Session lifetime (a known cost, not an oversight)
+///
+/// Each [`prompt`](Self::prompt) spawns the agent, runs one turn, and lets the
+/// process exit. That is correct-but-costly: it pays full startup per message and
+/// the agent remembers nothing between turns.
+///
+/// It is the honest first shape because the alternative — a long-lived session
+/// per room — has an unmeasured context-growth cost and a liveness story
+/// (what happens to a room whose agent died three hours ago) that deserves to be
+/// built deliberately rather than fallen into. The design doc lists session
+/// lifetime as an open question to settle by measurement; this is the version
+/// that is obviously correct while that measurement is outstanding.
+#[derive(Debug, Clone)]
+pub struct AcpBridge {
+    spec: AgentSpec,
+}
+
+impl AcpBridge {
+    pub fn new(spec: AgentSpec) -> Self {
+        Self { spec }
+    }
+
+    pub fn spec(&self) -> &AgentSpec {
+        &self.spec
+    }
+
+    /// Run one turn: `peer_id` said `text` in a room; get the agent's reply.
+    ///
+    /// Errors are typed by what an operator would DO about them — see
+    /// [`BridgeError`]. In particular an agent that dies mid-turn surfaces as
+    /// [`BridgeError::Exchange`] rather than an empty reply, so the room learns
+    /// the difference between "it had nothing to say" and "it stopped existing".
+    pub async fn prompt(&self, peer_id: &str, text: &str) -> Result<AgentTurn, BridgeError> {
+        // Before anything is spawned: a peer who may not prompt must not be able
+        // to make us fork a process.
+        admit_prompt(&self.spec, peer_id)?;
+
+        let agent =
+            AcpAgent::from_str(&self.spec.command).map_err(|e| BridgeError::AgentUnavailable {
+                command: self.spec.command.clone(),
+                detail: e.to_string(),
+            })?;
+
+        run_turn(agent, &self.spec, text).await
+    }
+}
+
+/// Drive one ACP turn over an already-constructed transport.
+///
+/// Split from [`AcpBridge::prompt`] so the protocol logic is substitutable:
+/// `prompt` supplies a spawned subprocess, while tests supply an in-process fake
+/// agent. Both drive THIS function, so what CI exercises is the same code the
+/// room runs — a test against a re-implementation of the turn would prove
+/// nothing about the turn.
+pub(crate) async fn run_turn(
+    transport: impl agent_client_protocol::ConnectTo<Client> + 'static,
+    spec: &AgentSpec,
+    text: &str,
+) -> Result<AgentTurn, BridgeError> {
+    {
+        let workspace = spec
+            .workspace
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+
+        // Decisions are collected out of the permission callback, which runs on
+        // the connection's task rather than ours. std::sync::Mutex is right here
+        // precisely because nothing awaits while it is held.
+        let decisions: Arc<Mutex<Vec<PermissionDecision>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let policy = spec.tools.clone();
+        let sink = Arc::clone(&decisions);
+        let prompt_text = text.to_string();
+
+        // Did the agent ever speak ACP at all?
+        //
+        // This is how "could not start" is told apart from "the exchange
+        // failed", and it is deliberately STRUCTURAL rather than a string match
+        // on the SDK's error text. `AcpAgent::from_str` only PARSES the command
+        // — a nonexistent program parses fine and fails later inside connect,
+        // where the SDK reports a generic internal error carrying
+        // "program not found". Matching that string would work until the SDK
+        // reworded it.
+        //
+        // Whereas: if we never got an initialize response, the agent never spoke,
+        // and that is precisely `AgentUnavailable` ("could not be spawned or did
+        // not speak ACP") no matter which of those it was. The distinction the
+        // operator needs — install something vs debug something — survives
+        // rewordings this way.
+        let spoke = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let spoke_inner = Arc::clone(&spoke);
+
+        let text_out = Client
+            .builder()
+            .on_receive_request(
+                async move |request: RequestPermissionRequest, responder, _connection| {
+                    let identity = identity_of(&request);
+                    let mut decision = policy.decide(&identity);
+                    let (outcome, caveat) = choose_outcome(&decision, &request.options);
+
+                    // A grant we had to make broader than intended is recorded as
+                    // such, so `refusal_lines()`/the room see the real terms.
+                    if let (PermissionDecision::Allow { caveat: slot, .. }, Some(c)) =
+                        (&mut decision, caveat)
+                    {
+                        *slot = Some(c);
+                    }
+
+                    if let Ok(mut guard) = sink.lock() {
+                        guard.push(decision);
+                    }
+
+                    responder.respond(RequestPermissionResponse::new(outcome))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .connect_with(transport, async move |cx: ConnectionTo<_>| {
+                // `run_until` sends session/new but NOT initialize — the SDK's
+                // working example initializes explicitly and so do we.
+                cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                spoke_inner.store(true, std::sync::atomic::Ordering::SeqCst);
+
+                cx.build_session(&workspace)
+                    .block_task()
+                    .run_until(async |mut session| {
+                        session.send_prompt(&prompt_text)?;
+                        // Buffers chunks to end-of-turn and returns once. A room
+                        // wants one message, not a token stream.
+                        session.read_to_string().await
+                    })
+                    .await
+            })
+            .await
+            .map_err(|e| {
+                if spoke.load(std::sync::atomic::Ordering::SeqCst) {
+                    BridgeError::Exchange {
+                        detail: e.to_string(),
+                    }
+                } else {
+                    BridgeError::AgentUnavailable {
+                        command: spec.command.clone(),
+                        detail: e.to_string(),
+                    }
+                }
+            })?;
+
+        let decisions = Arc::try_unwrap(decisions)
+            .map(|m| m.into_inner().unwrap_or_default())
+            .unwrap_or_else(|shared| shared.lock().map(|g| g.clone()).unwrap_or_default());
+
+        Ok(AgentTurn {
+            text: text_out,
+            decisions,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::v1::PermissionOptionId;
+
+    fn opt(id: &str, kind: PermissionOptionKind) -> PermissionOption {
+        PermissionOption::new(
+            PermissionOptionId::from(id.to_string()),
+            id.to_string(),
+            kind,
+        )
+    }
+
+    fn allow() -> PermissionDecision {
+        PermissionDecision::Allow {
+            label: "read".into(),
+            caveat: None,
+        }
+    }
+
+    fn deny() -> PermissionDecision {
+        PermissionDecision::Deny {
+            label: "execute".into(),
+            reason: "not allow-listed".into(),
+        }
+    }
+
+    fn selected_id(outcome: &RequestPermissionOutcome) -> Option<String> {
+        match outcome {
+            RequestPermissionOutcome::Selected(s) => Some(s.option_id.to_string()),
+            _ => None,
+        }
+    }
+
+    /// what this catches: the SDK example's `options.first()`. Option ORDER is
+    /// the agent's choice, so an agent that lists "allow always" first would get
+    /// a permanent grant out of a one-time decision. We select by KIND.
+    #[test]
+    fn selection_is_by_kind_not_by_position() {
+        let options = vec![
+            opt("always", PermissionOptionKind::AllowAlways),
+            opt("once", PermissionOptionKind::AllowOnce),
+        ];
+        let (outcome, caveat) = choose_outcome(&allow(), &options);
+        assert_eq!(selected_id(&outcome).as_deref(), Some("once"));
+        assert!(caveat.is_none());
+    }
+
+    /// what this catches: silently retiring our own policy. Answering
+    /// "always" makes the agent stop sending permission requests — ToolPolicy
+    /// would keep passing its tests while never being consulted again.
+    #[test]
+    fn a_once_option_is_preferred_so_the_policy_stays_in_the_loop() {
+        let options = vec![
+            opt("once", PermissionOptionKind::AllowOnce),
+            opt("always", PermissionOptionKind::AllowAlways),
+        ];
+        assert_eq!(
+            selected_id(&choose_outcome(&allow(), &options).0).as_deref(),
+            Some("once")
+        );
+    }
+
+    /// what this catches: accepting a broader grant than we intended, quietly.
+    /// If only "always" is on offer we still have to answer, but the room is
+    /// told the terms changed.
+    #[test]
+    fn an_always_only_agent_still_gets_answered_but_the_room_is_told() {
+        let options = vec![opt("always", PermissionOptionKind::AllowAlways)];
+        let (outcome, caveat) = choose_outcome(&allow(), &options);
+        assert_eq!(selected_id(&outcome).as_deref(), Some("always"));
+        assert!(caveat.expect("caveat required").contains("remember"));
+    }
+
+    /// what this catches: a denial that picks an ALLOW option because it was the
+    /// only one there. Wrong-polarity is not a near-miss, it is the opposite
+    /// verdict; cancelling is the protocol's word for "no".
+    #[test]
+    fn a_denial_never_selects_an_allow_option() {
+        let options = vec![
+            opt("once", PermissionOptionKind::AllowOnce),
+            opt("always", PermissionOptionKind::AllowAlways),
+        ];
+        let (outcome, _) = choose_outcome(&deny(), &options);
+        assert!(
+            matches!(outcome, RequestPermissionOutcome::Cancelled),
+            "a deny with only allow-options must cancel, not select"
+        );
+    }
+
+    #[test]
+    fn a_denial_prefers_reject_once() {
+        let options = vec![
+            opt("rej-always", PermissionOptionKind::RejectAlways),
+            opt("rej-once", PermissionOptionKind::RejectOnce),
+        ];
+        assert_eq!(
+            selected_id(&choose_outcome(&deny(), &options).0).as_deref(),
+            Some("rej-once")
+        );
+    }
+
+    /// what this catches: an agent that offers no options at all leaving the
+    /// turn hanging. Cancel is a real answer; silence is not.
+    #[test]
+    fn no_options_at_all_is_cancelled_rather_than_hung() {
+        let (outcome, _) = choose_outcome(&allow(), &[]);
+        assert!(matches!(outcome, RequestPermissionOutcome::Cancelled));
+    }
+
+    /// what this catches: the kind vocabulary drifting between the gate and the
+    /// docs. These strings ARE the `toolsAllow` config surface.
+    #[test]
+    fn kind_keys_are_the_documented_config_vocabulary() {
+        assert_eq!(kind_key(&ToolKind::Read), "read");
+        assert_eq!(kind_key(&ToolKind::Execute), "execute");
+        assert_eq!(kind_key(&ToolKind::SwitchMode), "switch_mode");
+        // ACP's own default for an unclassified tool lands in the deny bucket.
+        assert_eq!(kind_key(&ToolKind::Other), "other");
+    }
+
+    /// End-to-end turns against a real ACP agent — in-process, so the protocol
+    /// is genuinely exercised (initialize → session/new → session/prompt →
+    /// session/update → session/request_permission) with no subprocess and no
+    /// network.
+    ///
+    /// These drive [`run_turn`], the SAME function the room path calls, rather
+    /// than a re-implementation of it. The one thing they deliberately do NOT
+    /// cover is process spawn and stdio framing — that is what the
+    /// `acp-echo-agent` fixture binary and the live Windows run are for.
+    mod round_trip {
+        use super::*;
+        use crate::{AgentSpec, PeerPolicy, ToolPolicy};
+        use agent_client_protocol::schema::v1::{
+            AgentCapabilities, ContentBlock, ContentChunk, InitializeResponse, NewSessionRequest,
+            NewSessionResponse, PromptRequest, PromptResponse, SessionId, SessionNotification,
+            SessionUpdate, StopReason, TextContent, ToolCallId, ToolCallUpdate,
+            ToolCallUpdateFields,
+        };
+        use agent_client_protocol::{Agent, ConnectionTo, Responder};
+
+        /// Build a fake agent that answers with `reply`, and — when
+        /// `ask_for` is `Some(kind)` — first asks the client for permission to
+        /// run a tool of that kind, appending the verdict it received to its
+        /// reply so the test can see what the client actually sent back.
+        fn fake_agent(
+            reply: &'static str,
+            ask_for: Option<ToolKind>,
+            offer_once: bool,
+        ) -> impl agent_client_protocol::ConnectTo<Client> + 'static {
+            Agent
+                .builder()
+                .on_receive_request(
+                    async move |req: InitializeRequest,
+                                responder: Responder<InitializeResponse>,
+                                _cx: ConnectionTo<Client>| {
+                        responder.respond(
+                            InitializeResponse::new(req.protocol_version)
+                                .agent_capabilities(AgentCapabilities::new()),
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |_req: NewSessionRequest,
+                                responder: Responder<NewSessionResponse>,
+                                _cx: ConnectionTo<Client>| {
+                        responder.respond(NewSessionResponse::new(SessionId::new("fake-session")))
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    move |req: PromptRequest,
+                          responder: Responder<PromptResponse>,
+                          cx: ConnectionTo<Client>| {
+                        let ask_for = ask_for;
+                        let cx2 = cx.clone();
+                        // The turn runs in a SPAWNED task, not inline in the
+                        // handler.
+                        //
+                        // An `on_receive_request` callback holds the connection's
+                        // dispatch loop until it returns. Awaiting a nested
+                        // `send_request(..).block_task()` inline therefore
+                        // deadlocks by construction: the reply we are waiting for
+                        // can only be delivered by the loop we are holding. The
+                        // SDK documents this under "Deadlock Risk" and the first
+                        // version of this fixture did it anyway — it hung for 20
+                        // minutes with no output, which is why every test here now
+                        // carries a deadline.
+                        //
+                        // (The BRIDGE side is not exposed to this: its permission
+                        // handler decides purely and responds without awaiting any
+                        // nested request, so it never holds the loop on a reply.)
+                        let inline = async move {
+                            let mut text = reply.to_string();
+
+                            if let Some(kind) = ask_for {
+                                let mut options = Vec::new();
+                                if offer_once {
+                                    options.push(opt("once", PermissionOptionKind::AllowOnce));
+                                    options.push(opt("rej-once", PermissionOptionKind::RejectOnce));
+                                } else {
+                                    options.push(opt("always", PermissionOptionKind::AllowAlways));
+                                }
+
+                                let fields = ToolCallUpdateFields::new()
+                                    .kind(kind)
+                                    .title("touch a file".to_string());
+                                let call = ToolCallUpdate::new(ToolCallId::new("call-1"), fields);
+
+                                let verdict = cx
+                                    .send_request(RequestPermissionRequest::new(
+                                        req.session_id.clone(),
+                                        call,
+                                        options,
+                                    ))
+                                    .block_task()
+                                    .await?;
+
+                                text.push_str(&format!(" [verdict: {:?}]", verdict.outcome));
+                            }
+
+                            cx.send_notification(SessionNotification::new(
+                                req.session_id,
+                                SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                                    ContentBlock::Text(TextContent::new(text)),
+                                )),
+                            ))?;
+                            responder.respond(PromptResponse::new(StopReason::EndTurn))
+                        };
+                        // Returns immediately, releasing the dispatch loop so the
+                        // permission reply can actually be routed.
+                        async move { cx2.spawn(inline) }
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+        }
+
+        /// Every round-trip below runs under a hard deadline.
+        ///
+        /// A deadlocked protocol test does not fail — it HANGS, and a hung CI job
+        /// looks like a slow one until someone cancels it an hour later. (That is
+        /// exactly what the first version of these tests did.) The deadline turns
+        /// that failure mode into a normal red test with a message.
+        async fn within<F, T>(what: &str, fut: F) -> T
+        where
+            F: std::future::Future<Output = T>,
+        {
+            match tokio::time::timeout(std::time::Duration::from_secs(20), fut).await {
+                Ok(v) => v,
+                Err(_) => panic!("{what} did not complete in 20s — the ACP exchange deadlocked"),
+            }
+        }
+
+        /// what this catches: the whole point of the bridge. If initialize,
+        /// session/new, prompt, or update assembly is wrong, a room gets silence
+        /// — and silence is indistinguishable from an agent with nothing to say.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn a_prompt_comes_back_as_the_agents_reply() {
+            let spec = AgentSpec::talk_only("unused-in-process");
+            let turn = within(
+                "plain reply",
+                run_turn(fake_agent("hello from the agent", None, true), &spec, "hi"),
+            )
+            .await
+            .expect("turn should complete");
+
+            assert_eq!(turn.text, "hello from the agent");
+            assert!(!turn.had_refusal(), "no tools were requested");
+            assert!(turn.refusal_lines().is_empty());
+        }
+
+        /// what this catches: the deny-by-default gate being wired to nothing.
+        /// An unconfigured agent must actually REFUSE on the wire — and the
+        /// refusal must reach the room, not just a log.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn an_unconfigured_agent_refuses_a_tool_and_says_so() {
+            let spec = AgentSpec::talk_only("unused-in-process");
+            let turn = within(
+                "refusal",
+                run_turn(
+                    fake_agent("tried to edit", Some(ToolKind::Edit), true),
+                    &spec,
+                    "edit something",
+                ),
+            )
+            .await
+            .expect("turn should complete");
+
+            assert!(
+                turn.had_refusal(),
+                "an unconfigured lane must refuse: {turn:?}"
+            );
+            let lines = turn.refusal_lines();
+            assert_eq!(lines.len(), 1, "{lines:?}");
+            assert!(lines[0].contains("toolsAllow"), "{lines:?}");
+            // And the agent must have actually been told "no" on the wire, not
+            // merely had a refusal recorded on our side.
+            assert!(turn.text.contains("rej-once"), "agent saw: {}", turn.text);
+        }
+
+        /// what this catches: an allow-list that is decorative. A permitted kind
+        /// must reach the agent as a real approval, and must NOT produce a room
+        /// line (approvals stay quiet).
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn an_allow_listed_kind_is_approved_on_the_wire() {
+            let spec =
+                AgentSpec::talk_only("unused-in-process").with_tools(ToolPolicy::allow(["edit"]));
+            let turn = within(
+                "approval",
+                run_turn(
+                    fake_agent("edited", Some(ToolKind::Edit), true),
+                    &spec,
+                    "edit something",
+                ),
+            )
+            .await
+            .expect("turn should complete");
+
+            assert!(!turn.had_refusal(), "{turn:?}");
+            assert!(turn.refusal_lines().is_empty(), "approvals stay quiet");
+            assert!(turn.text.contains("once"), "agent saw: {}", turn.text);
+        }
+
+        /// what this catches: silently accepting a broader grant than we chose.
+        /// When the agent offers only "always", the approval still happens but
+        /// the room is told the agent will remember.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn an_always_only_grant_is_reported_to_the_room() {
+            let spec =
+                AgentSpec::talk_only("unused-in-process").with_tools(ToolPolicy::allow(["edit"]));
+            let turn = within(
+                "always-only grant",
+                run_turn(
+                    fake_agent("edited", Some(ToolKind::Edit), false),
+                    &spec,
+                    "edit something",
+                ),
+            )
+            .await
+            .expect("turn should complete");
+
+            let caveated = turn
+                .decisions
+                .iter()
+                .any(|d| d.to_room_line().contains("remember"));
+            assert!(caveated, "terms change must be visible: {turn:?}");
+        }
+
+        /// what this catches: a refused peer still costing us an agent run. The
+        /// gate must fire before the transport is ever built.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn a_refused_peer_never_reaches_the_agent() {
+            let spec = AgentSpec::talk_only("definitely-not-a-real-command-xyz")
+                .with_peers(PeerPolicy::only(["peer-a"]));
+            let bridge = AcpBridge::new(spec);
+            let err = bridge.prompt("peer-b", "hi").await.unwrap_err();
+            assert!(
+                matches!(err, BridgeError::PeerRefused { .. }),
+                "expected a peer refusal, got {err:?}"
+            );
+        }
+    }
+}

--- a/crates/airc-acp/tests/subprocess_round_trip.rs
+++ b/crates/airc-acp/tests/subprocess_round_trip.rs
@@ -1,0 +1,146 @@
+//! The subprocess path: spawn a real ACP agent and talk to it over stdio.
+//!
+//! The in-process tests in `transport.rs` cover protocol logic but never fork.
+//! Everything below crosses a real process boundary, because that is a distinct
+//! risk surface — process spawn, argument parsing, and JSON-RPC framing over
+//! stdin/stdout — and it is the one that fails quietly on Windows. A child that
+//! never starts and an agent with nothing to say are indistinguishable from the
+//! room unless something checks.
+//!
+//! Gated on `test-fixtures` because that is what builds the agent binary these
+//! tests spawn. Run with:
+//!
+//! ```sh
+//! cargo test -p airc-acp --features test-fixtures
+//! ```
+#![cfg(feature = "test-fixtures")]
+
+use std::time::Duration;
+
+use airc_acp::{AcpBridge, AgentSpec, BridgeError, ToolPolicy};
+
+/// Path to the fixture agent binary, resolved by cargo.
+fn agent_command() -> String {
+    // Quoted: on Windows this path routinely contains spaces (`C:\Users\First
+    // Last\...`), and an unquoted command would be split into a nonexistent
+    // program plus stray arguments.
+    format!("\"{}\"", env!("CARGO_BIN_EXE_acp-echo-agent"))
+}
+
+/// Every subprocess test runs under a deadline. A deadlocked or never-spawning
+/// child does not fail on its own — it hangs, and a hung CI job reads as a slow
+/// one until someone kills it.
+async fn within<F, T>(what: &str, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    match tokio::time::timeout(Duration::from_secs(30), fut).await {
+        Ok(v) => v,
+        Err(_) => panic!("{what} did not complete in 30s — the subprocess exchange hung"),
+    }
+}
+
+/// what this catches: the whole subprocess path. If spawn, argv handling, or
+/// stdio framing is wrong on this platform, this is the test that says so —
+/// rather than a room that mysteriously gets no answer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_spawned_agent_answers_over_stdio() {
+    let bridge = AcpBridge::new(AgentSpec::talk_only(agent_command()));
+    let turn = within("spawned echo", bridge.prompt("peer-a", "hello"))
+        .await
+        .expect("the fixture agent should answer");
+
+    assert_eq!(turn.text, "echo: hello");
+    assert!(!turn.had_refusal());
+}
+
+/// what this catches: a deny that only exists on our side of the process
+/// boundary. The refusal has to actually reach the child AND come back as a
+/// room-visible line.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_refusal_crosses_the_process_boundary_and_is_visible() {
+    let bridge = AcpBridge::new(AgentSpec::talk_only(agent_command()));
+    let turn = within("spawned refusal", bridge.prompt("peer-a", "tool:execute"))
+        .await
+        .expect("the fixture agent should answer");
+
+    assert!(
+        turn.had_refusal(),
+        "unconfigured lane must refuse: {turn:?}"
+    );
+    let lines = turn.refusal_lines();
+    assert_eq!(lines.len(), 1, "{lines:?}");
+    assert!(lines[0].contains("toolsAllow"), "{lines:?}");
+    // The child must have been told "no", not merely had a refusal logged here.
+    assert!(turn.text.contains("rej-once"), "child saw: {}", turn.text);
+}
+
+/// what this catches: an allow-list that works in-process but not across a
+/// spawn — e.g. if identity extraction were reading a field that survives one
+/// path and not the other.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_allow_listed_kind_is_approved_across_the_boundary() {
+    let spec = AgentSpec::talk_only(agent_command()).with_tools(ToolPolicy::allow(["execute"]));
+    let turn = within(
+        "spawned approval",
+        AcpBridge::new(spec).prompt("peer-a", "tool:execute"),
+    )
+    .await
+    .expect("the fixture agent should answer");
+
+    assert!(!turn.had_refusal(), "{turn:?}");
+    assert!(turn.refusal_lines().is_empty(), "approvals stay quiet");
+    assert!(turn.text.contains("once"), "child saw: {}", turn.text);
+}
+
+/// what this catches: the failure mode this whole project keeps relearning —
+/// something stops working and says nothing. An agent that dies mid-turn must
+/// produce an ERROR, never an empty-but-successful turn, because the room
+/// cannot tell empty-success apart from a corpse.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_agent_that_dies_mid_turn_is_an_error_not_silence() {
+    let bridge = AcpBridge::new(AgentSpec::talk_only(agent_command()));
+    let result = within("dying agent", bridge.prompt("peer-a", "die")).await;
+
+    let err = match result {
+        Err(e) => e,
+        Ok(turn) => panic!("a dead agent must not look like a successful turn: {turn:?}"),
+    };
+    // It was reached and then failed — that is an Exchange failure, not a
+    // "could not start". The distinction is what tells an operator whether to
+    // install something or debug something.
+    assert!(
+        matches!(err, BridgeError::Exchange { .. }),
+        "expected an exchange failure, got {err:?}"
+    );
+    assert!(!err.to_string().is_empty(), "the error must say something");
+}
+
+/// what this catches: a missing agent being reported as a protocol problem.
+/// "Install the agent" and "debug the protocol" are different days of work.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_missing_agent_binary_is_reported_as_unavailable() {
+    let bridge = AcpBridge::new(AgentSpec::talk_only(
+        "definitely-not-an-installed-program-9c1f",
+    ));
+    let err = within("missing agent", bridge.prompt("peer-a", "hello"))
+        .await
+        .expect_err("a missing binary cannot produce a turn");
+
+    // regression: `AcpAgent::from_str` only PARSES the command, so a missing
+    // program used to sail through and surface as
+    // "ACP exchange failed: Internal error: … program not found" — sending the
+    // reader to debug the protocol when the fix is `pip install`. The classifier
+    // is now structural: nothing spoke ACP, therefore the agent is unavailable.
+    assert!(
+        matches!(err, BridgeError::AgentUnavailable { .. }),
+        "a missing binary is an install problem, not a protocol problem: {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(msg.contains("could not start"), "unhelpful error: {msg}");
+    // It must name the command, or the operator cannot tell WHAT to install.
+    assert!(
+        msg.contains("definitely-not-an-installed-program-9c1f"),
+        "error must name the command: {msg}"
+    );
+}

--- a/docs/architecture/ACP-CLIENT-BRIDGE.md
+++ b/docs/architecture/ACP-CLIENT-BRIDGE.md
@@ -1,0 +1,116 @@
+# airc as an ACP client — one bridge, N agents
+
+**Status:** design pinned against the real SDK (2026-08-10). Implementation next.
+
+## Why this shape, and not a Hermes plugin
+
+The obvious move was "write an airc plugin for Hermes", mirroring what we did for
+OpenClaw. Reading Hermes first killed that idea, in the good way:
+`hermes-agent` already ships `acp_adapter/` with an `agent-client-protocol`
+dependency, JSON-RPC over stdio, and a standard `acp_registry/agent.json`
+declaring `uvx hermes-agent[acp]` distribution. It is **already an ACP agent**.
+
+So it needs nothing from us. And a Hermes-specific plugin would buy one agent
+while coupling us to their internals forever.
+
+Making **airc an ACP client** instead inverts it: every agent that ships an ACP
+adapter becomes a room citizen, with zero upstream patches and nothing for us to
+maintain inside anyone else's codebase. Hermes today; the rest of the registry
+for free.
+
+That gives the on-ramp two classes, which is worth stating plainly because they
+are not interchangeable:
+
+| Class | Direction | Use when | Example |
+|---|---|---|---|
+| **airc as ACP client** | airc drives the agent | the agent speaks a standard | Hermes, any `acp_registry` entry |
+| **channel plugin** | the host drives airc | the *host* owns the UI/UX surface | OpenClaw (`integrations/openclaw/plugin`) |
+
+OpenClaw is not an ACP agent — it is a chat *host*, so it stays a channel plugin.
+Hermes is an agent, so it needs no plugin at all. Picking the wrong class means
+either patching upstream forever or reimplementing someone's UI.
+
+## The contract (read off the SDK, not guessed)
+
+`agent-client-protocol = "2.0.0"` (Apache-2.0, `agentclientprotocol/rust-sdk`,
+rust-version 1.88). Companion: `agent-client-protocol-tokio`.
+
+The client flow, from the SDK's own `examples/yolo_one_shot_client.rs`:
+
+```rust
+let agent = AcpAgent::from_str("hermes-acp")?;   // spawns it; implements ConnectTo
+
+Client.builder()
+    .on_receive_notification(|n: SessionNotification, _cx| async { /* stream */ },
+                             on_receive_notification!())
+    .on_receive_request(|r: RequestPermissionRequest, responder, _conn| async { /* policy */ },
+                        on_receive_request!())
+    .connect_with(agent, |conn: ConnectionTo<Agent>| async move {
+        conn.send_request(InitializeRequest::new(ProtocolVersion::V1)).block_task().await?;
+        let s = conn.send_request(NewSessionRequest::new(cwd)).block_task().await?;
+        conn.send_request(PromptRequest::new(s.session_id,
+                vec![ContentBlock::Text(TextContent::new(text))])).block_task().await?;
+        Ok(())
+    }).await?;
+```
+
+Mapping onto a room:
+
+| ACP | airc |
+|---|---|
+| `PromptRequest` | an inbound room message routed to this agent |
+| `SessionNotification` updates | the agent's reply, published back to the room |
+| `RequestPermissionRequest` | a **policy decision** — see below |
+| `session_id` | one per (room, agent) pair, so context is per-room |
+
+## Permission policy: NOT the example's
+
+The SDK example auto-approves every permission request and is honest about it —
+it is called `yolo_one_shot_client`. That is correct for a one-shot CLI where the
+human typed the prompt themselves.
+
+It is **wrong for a room**, and would be our bug, not the SDK's. In a room the
+prompt comes from a *peer*, and airc broadcasts carry no structural addressing
+(every send is `MentionTarget::All`). Auto-approving would mean any peer who can
+reach the room can induce arbitrary tool execution on this machine — file writes,
+shell, network — with no human in the loop.
+
+So the bridge's default is **deny, visibly**:
+
+- default: deny the permission request AND publish the denial into the room, so
+  the refusal is legible rather than a silent stall the agent's author will spend
+  an hour debugging;
+- an explicit per-account `toolsAllow` list may auto-approve *named* tools;
+- an explicit `allowFrom` peer list gates who can prompt at all;
+- nothing is approved because it "seemed fine" — an unlisted tool is denied and
+  said out loud.
+
+This mirrors the OpenClaw plugin's config surface (`toolsAllow`, `allowFrom`),
+which is deliberate: one mental model across both on-ramp classes.
+
+## Open questions to settle while building
+
+- **Session lifetime.** One session per room forever, or per conversation burst?
+  Forever grows context unboundedly; per-burst loses continuity. Probably
+  per-room with an idle reset, but that is a measurement, not a guess.
+- **Streaming granularity.** `SessionNotification` arrives token-ish; airc
+  messages are discrete. Publishing every update would flood the room (and hit
+  the body-clip gap, #378). Likely: buffer to completion, publish once, with a
+  `typing`-style presence signal meanwhile.
+- **Agent liveness.** A spawned agent that dies must be reported to the room, not
+  silently stop answering — the same "up is not the same as talking" rule the
+  README now leads with.
+- **Windows.** `hermes-acp` reserves stdout for JSON-RPC and mentions UTF-8 stdio
+  bootstrapping on Windows specifically. Test there first; it is the platform
+  that has broken every cross-platform assumption this week.
+
+## Verification bar
+
+Not "it compiles". A real receipt:
+
+1. `uvx hermes-agent[acp]` spawned from airc on Windows;
+2. a message posted in a room reaches the agent as a `PromptRequest`;
+3. its reply is published back into the room and visible to a *second* peer;
+4. a tool-permission request with no `toolsAllow` entry is denied AND the denial
+   is visible in the room;
+5. killing the agent process produces a room-visible failure, not silence.

--- a/docs/architecture/ACP-CLIENT-BRIDGE.md
+++ b/docs/architecture/ACP-CLIENT-BRIDGE.md
@@ -1,7 +1,7 @@
 # airc as an ACP client — one bridge, N agents
 
-**Status:** transport implemented and covered by in-process round-trip tests
-(2026-08-09). Live subprocess round-trip still outstanding — see
+**Status:** transport implemented; in-process AND subprocess round-trips green on Windows
+(2026-08-09). A live two-peer room round-trip is still outstanding — see
 [Verification bar](#verification-bar).
 
 ## Where the code lives (read this before adding a second ACP path)
@@ -186,9 +186,22 @@ merely demonstrated once.
 
 Rows 6 and 7 are the honest gaps, and they are different in kind:
 
-- **Row 6** is the airc half — the library returns the right thing, and
-  `integrations/acp` publishes it, but nobody has watched a second peer receive
-  it. "It returned a string" is not "the room saw it".
+- **Row 6** is the airc half. A live attempt on Windows found two real defects
+  before it found a result, both of the same family — *something behaves
+  perfectly and is simply not connected to anything*:
+
+  1. **The trigger was `/acp`.** Git Bash's MSYS path conversion rewrote it to
+     `C:/Program Files/Git/acp hello …` before airc ever saw the message. The
+     bridge worked; the token it was watching for never arrived. Now `@acp`,
+     which is not path-like on any platform, with a regression test.
+  2. **The bridge joined a room of its own.** With `AIRC_SOCKET` unset,
+     `Airc::open_as` opens an ISOLATED in-process scope. It logged a successful
+     join to `#general` and returned a peer id, while `airc peers` on the real
+     grid had never heard of it. Both paths look identical from the outside, so
+     the bridge now says which one it took, loudly, at startup.
+
+  Row 6 stays open: the fixes are in, but nobody has yet watched a second live
+  peer receive a reply. "It returned a string" is not "the room saw it".
 - **Row 7** is the third-party half. Our fixture agent is, unavoidably, an agent
   written against the same reading of the SDK as the client. A real agent is the
   only thing that can falsify that reading. Hermes additionally needs an LLM

--- a/docs/architecture/ACP-CLIENT-BRIDGE.md
+++ b/docs/architecture/ACP-CLIENT-BRIDGE.md
@@ -1,6 +1,26 @@
 # airc as an ACP client — one bridge, N agents
 
-**Status:** design pinned against the real SDK (2026-08-10). Implementation next.
+**Status:** transport implemented and covered by in-process round-trip tests
+(2026-08-09). Live subprocess round-trip still outstanding — see
+[Verification bar](#verification-bar).
+
+## Where the code lives (read this before adding a second ACP path)
+
+There are two pieces and they compose. An earlier version of this document
+described only the library and did not mention the binary, which is how you end
+up with two ACP efforts instead of one:
+
+| Piece | What it is | State |
+|---|---|---|
+| `crates/airc-acp` | The **library**: policy + transport. Spawns an agent, drives one turn, returns an `AgentTurn`. Knows nothing about rooms. | policy + transport landed |
+| `integrations/acp` (`airc-acp-bridge`) | The **binary**: an airc citizen (join / subscribe / publish via `airc-lib`) that calls the library for each inbound message. | slice 1 landed (citizen loop with a stub `TurnHandler`); slice 2 = swap the stub for `AcpBridge` |
+
+`integrations/acp/README.md` planned slice 2 as hand-written JSON-RPC framing over
+stdio. That is superseded: we use the published `agent-client-protocol` SDK
+instead. Framing, batching, cancellation, and protocol-version negotiation are
+things the SDK already gets right and that a hand-rolled framer would get subtly
+wrong — and "subtly wrong protocol framing" is a bug that presents as an agent
+that mysteriously goes quiet.
 
 ## Why this shape, and not a Hermes plugin
 
@@ -88,6 +108,47 @@ So the bridge's default is **deny, visibly**:
 This mirrors the OpenClaw plugin's config surface (`toolsAllow`, `allowFrom`),
 which is deliberate: one mental model across both on-ramp classes.
 
+### `toolsAllow` lists KINDS, not tool names (found while building)
+
+The stable ACP permission request identifies a tool by `ToolCallUpdateFields`:
+`title` is a per-call human string ("Write file src/main.rs"), `kind` is a fixed
+enum. The *programmatic* name is behind the `unstable_tool_call_name` feature.
+
+So allow-listing by name would mean matching free text that changes per
+invocation — a rule that silently stops matching when an agent rewords its own
+label. `kind` is stable across agents and is the decision an operator actually
+wants to make. The vocabulary is exactly ACP's `ToolKind`:
+
+```
+read  edit  delete  move  search  execute  think  fetch  switch_mode  other
+```
+
+Two consequences worth stating because both are load-bearing:
+
+- **`other` is ACP's default** for an unclassified tool, and it is also where any
+  *future* `ToolKind` variant lands (the enum is `#[non_exhaustive]`). So a new
+  protocol capability arrives **closed**, not open.
+- **Both `kind` and `title` are `Option`.** An agent may request permission
+  without declaring what for. That is refused, explicitly: "did not declare" and
+  "declared something harmless" are different facts, and the request carrying the
+  *least* information is the last one that should get the benefit of the doubt.
+
+### Answer `AllowOnce`, never `AllowAlways`
+
+Permission options come in once/always pairs. Replying `AllowAlways` tells the
+agent to remember the grant and **stop sending permission requests** — which would
+leave `ToolPolicy` wired up, passing all its tests, and never consulted again.
+That is the silently-unwired-capability failure in miniature, arrived at by
+choosing the obvious-looking option.
+
+The bridge therefore selects by *kind*, preferring the once-scoped option in both
+directions. (The SDK example picks `options.first()`; option order is the agent's
+choice, so "first" can mean "always".) If an agent offers only an always-scoped
+option we still answer — the policy did say yes — but the room is told the terms
+changed. If it offers no option of the needed polarity, the request is
+`Cancelled`, which is the protocol's own word for "no", rather than guessing at an
+option of the wrong polarity.
+
 ## Open questions to settle while building
 
 - **Session lifetime.** One session per room forever, or per conversation burst?
@@ -108,9 +169,41 @@ which is deliberate: one mental model across both on-ramp classes.
 
 Not "it compiles". A real receipt:
 
-1. `uvx hermes-agent[acp]` spawned from airc on Windows;
-2. a message posted in a room reaches the agent as a `PromptRequest`;
-3. its reply is published back into the room and visible to a *second* peer;
-4. a tool-permission request with no `toolsAllow` entry is denied AND the denial
-   is visible in the room;
-5. killing the agent process produces a room-visible failure, not silence.
+| # | Claim | State |
+|---|---|---|
+| 1 | An agent is spawned as a subprocess and speaks ACP over stdio | ✅ `tests/subprocess_round_trip.rs`, on Windows |
+| 2 | A prompt reaches the agent and its reply comes back assembled | ✅ in-process + subprocess |
+| 3 | A tool request with no `toolsAllow` entry is denied, the denial crosses the process boundary, and it is room-visible | ✅ subprocess test asserts both halves |
+| 4 | An agent that dies mid-turn produces an error, not an empty success | ✅ `an_agent_that_dies_mid_turn_is_an_error_not_silence` |
+| 5 | A missing agent binary is reported as *unavailable*, distinctly from a protocol failure | ✅ |
+| 6 | The reply is published into a real room and visible to a **second peer** | ❌ **not yet** — needs two live airc peers |
+| 7 | A real third-party agent (`uvx hermes-agent[acp]`) works, not just our fixture | ❌ **not yet** |
+
+Rows 1–5 are covered by tests that run on every platform in CI, using an in-repo
+fixture agent (`acp-echo-agent`, gated behind the `test-fixtures` feature) rather
+than a network download — so the subprocess path is *regression-protected*, not
+merely demonstrated once.
+
+Rows 6 and 7 are the honest gaps, and they are different in kind:
+
+- **Row 6** is the airc half — the library returns the right thing, and
+  `integrations/acp` publishes it, but nobody has watched a second peer receive
+  it. "It returned a string" is not "the room saw it".
+- **Row 7** is the third-party half. Our fixture agent is, unavoidably, an agent
+  written against the same reading of the SDK as the client. A real agent is the
+  only thing that can falsify that reading. Hermes additionally needs an LLM
+  backend configured, which makes it a slower and less deterministic test — worth
+  doing once as a receipt, not worth putting in CI.
+
+### A trap worth knowing before you write an ACP agent
+
+`on_receive_request` callbacks hold the connection's dispatch loop until they
+return. Awaiting a nested `send_request(..).block_task()` *inside* one therefore
+deadlocks by construction — the reply can only be delivered by the loop you are
+holding. The SDK documents this under "Deadlock Risk"; the first version of our
+test fixture did it anyway and hung for twenty minutes producing no output at
+all, which is why every test in this crate now runs under an explicit deadline.
+A hung test is strictly worse than a failing one: it looks like slowness.
+
+The bridge's own permission handler is not exposed to this — it decides purely
+and responds without awaiting anything — but any agent you write is.

--- a/integrations/acp/Cargo.toml
+++ b/integrations/acp/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "proce
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+airc-acp = { version = "0.1.0", path = "../../crates/airc-acp" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/integrations/acp/README.md
+++ b/integrations/acp/README.md
@@ -67,15 +67,47 @@ appropriate `TrustTier`. The bridge is the agent's grounded presence on the grid
 
 ## Build slices
 
-- **Slice 1 — airc-citizen half (known-cold):** the bin scaffold + join /
-  subscribe / publish loop over `airc-lib`, ACP side stubbed (echo). Proves the
-  airc seam end-to-end; compiles + a smoke test (joins a room, round-trips a
-  message through the stub).
-- **Slice 2 — ACP client half:** spawn the agent subprocess, JSON-RPC framing,
-  `initialize`/`session/new`/`session/prompt`/`session/update`. Replace the stub
-  with the real agent turn.
-- **Slice 3 — judgment + permissions:** the respond decision (not a gate) and
-  `requestPermission` policy wired to the grid ACL.
+- **Slice 1 — airc-citizen half — DONE:** the bin scaffold + join / subscribe /
+  publish loop over `airc-lib`, ACP side stubbed.
+- **Slice 2 — ACP client half — DONE:** the ACP work lives in the
+  **`airc-acp` crate** (`crates/airc-acp`), which this binary consumes. Spawn +
+  `initialize` / `session/new` / `session/prompt` / `session/update` + the
+  permission policy.
+
+  **Superseded plan:** this slice originally said "hand-write JSON-RPC framing".
+  It uses the published `agent-client-protocol` SDK instead. Framing, batching,
+  cancellation, and version negotiation are things the SDK already gets right and
+  a hand-rolled framer would get subtly wrong — and subtly-wrong framing presents
+  as an agent that mysteriously goes quiet, which is the most expensive bug shape
+  we have. See `docs/architecture/ACP-CLIENT-BRIDGE.md`.
+- **Slice 3 — judgment:** replace the `/acp` trigger with the registered
+  `ai/should-respond` handler described below. The trigger is a scaffold, not the
+  design: it exists so the bridge isn't an echo bot in a shared room while
+  cognition's decision path is still being wired.
+
+## Running it
+
+```sh
+ACP_BRIDGE_COMMAND='uvx hermes-agent[acp] hermes-acp' \
+ACP_BRIDGE_ROOM=general \
+  cargo run -p airc-acp-bridge
+```
+
+Then in the room: `/acp what changed in this repo today?`
+
+| Env var | Meaning | Default |
+|---|---|---|
+| `ACP_BRIDGE_COMMAND` | Command that starts the ACP agent | **required** — no silent no-op |
+| `ACP_BRIDGE_AGENT` | Name the bridge is grounded under | `acp-agent` |
+| `ACP_BRIDGE_ROOM` | Room to join | `general` |
+| `ACP_BRIDGE_TOOLS` | Comma-separated tool **kinds** the agent may run (`read,search,…`) | none — every tool refused |
+| `ACP_BRIDGE_ALLOW_FROM` | Comma-separated peers allowed to prompt | anyone in the room |
+| `ACP_BRIDGE_WORKSPACE` | Directory the agent treats as its workspace | the bridge's cwd |
+
+`ACP_BRIDGE_TOOLS` lists **kinds**, not tool names — the stable ACP permission
+request identifies a tool by kind, and its human-readable title changes per call.
+Unset means the agent can chat and can run nothing, which is the useful-but-safe
+default when the prompter is an arbitrary peer.
 
 ## The respond decision: ONE command, N handlers (resolved, Intel Mac 2026-06-17)
 

--- a/integrations/acp/README.md
+++ b/integrations/acp/README.md
@@ -80,7 +80,7 @@ appropriate `TrustTier`. The bridge is the agent's grounded presence on the grid
   a hand-rolled framer would get subtly wrong — and subtly-wrong framing presents
   as an agent that mysteriously goes quiet, which is the most expensive bug shape
   we have. See `docs/architecture/ACP-CLIENT-BRIDGE.md`.
-- **Slice 3 — judgment:** replace the `/acp` trigger with the registered
+- **Slice 3 — judgment:** replace the `@acp` trigger with the registered
   `ai/should-respond` handler described below. The trigger is a scaffold, not the
   design: it exists so the bridge isn't an echo bot in a shared room while
   cognition's decision path is still being wired.
@@ -93,7 +93,7 @@ ACP_BRIDGE_ROOM=general \
   cargo run -p airc-acp-bridge
 ```
 
-Then in the room: `/acp what changed in this repo today?`
+Then in the room: `@acp what changed in this repo today?`
 
 | Env var | Meaning | Default |
 |---|---|---|

--- a/integrations/acp/src/main.rs
+++ b/integrations/acp/src/main.rs
@@ -30,7 +30,21 @@ use futures::StreamExt;
 /// not to an `if` in the loop. Until that lands, an explicit trigger is the
 /// honest placeholder: it is obviously a stand-in rather than a gate pretending
 /// to be judgment, and it makes the live round-trip deterministic to test.
-const TRIGGER: &str = "/acp";
+///
+/// ## Why `@acp` and not `/acp`
+///
+/// It WAS `/acp`, until a live test on Windows showed the message arriving as
+/// `C:/Program Files/Git/acp hello …`. Git Bash's MSYS path conversion rewrites
+/// a leading `/token` into a Windows path, silently, before airc ever sees it.
+/// Every agent driving airc from a shell — which is most of them — would have
+/// hit that, and the symptom is the worst kind: the bridge behaves perfectly and
+/// simply never answers, because the trigger it was watching for never arrived.
+///
+/// `@` is not path-like on any platform, and it reads as addressing, which is
+/// what this actually is. (airc has no structural addressing — every broadcast
+/// is `MentionTarget::All` — so a textual convention is what we have to work
+/// with either way.)
+const TRIGGER: &str = "@acp";
 
 /// A turn handler: given who spoke and what they said, produce the lines to
 /// publish, in order. Empty = PASS (stay quiet) — the decision lives HERE, never
@@ -78,9 +92,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bridge = Arc::new(AcpBridge::new(spec));
 
+    // Attached vs isolated is the difference between "in the room" and "in a
+    // room of its own", and it is invisible from the outside: both paths log a
+    // successful join and hand back a peer id.
+    //
+    // A live test on Windows lost twenty minutes to exactly that — the bridge
+    // reported joining #general, and `airc peers` on the real grid had never
+    // heard of it, because `open_as` opens an isolated in-process scope. So say
+    // which one this is, out loud, at startup.
     let airc = match std::env::var("AIRC_SOCKET").ok() {
-        Some(socket) => Airc::attach_as(home, &agent_name, socket).await?,
-        None => Airc::open_as(home, &agent_name).await?,
+        Some(socket) => {
+            eprintln!("airc-acp-bridge: attaching to the running daemon at {socket}");
+            Airc::attach_as(home, &agent_name, socket).await?
+        }
+        None => {
+            eprintln!(
+                "airc-acp-bridge: AIRC_SOCKET is unset — opening an ISOLATED in-process scope. \
+                 This bridge will NOT see traffic from a running airc daemon, and peers on the \
+                 live grid will not see it. Set AIRC_SOCKET to join the real grid."
+            );
+            Airc::open_as(home, &agent_name).await?
+        }
     };
     airc.publish_identity().await?; // ground by name (room_roster + whois see it)
     airc.join(&room).await?;
@@ -263,30 +295,45 @@ mod tests {
             triggered_prompt("what do you all think about the merge?"),
             None
         );
-        assert_eq!(triggered_prompt("the /acp thing is neat"), None);
+        assert_eq!(triggered_prompt("the @acp thing is neat"), None);
     }
 
     #[test]
     fn a_triggered_message_yields_just_the_prompt() {
         assert_eq!(
-            triggered_prompt("/acp summarize the diff"),
+            triggered_prompt("@acp summarize the diff"),
             Some("summarize the diff")
         );
-        assert_eq!(triggered_prompt("/acp   padded  "), Some("padded"));
+        assert_eq!(triggered_prompt("@acp   padded  "), Some("padded"));
     }
 
-    /// what this catches: a prefix match swallowing an unrelated word. `/acpfoo`
+    /// what this catches: a prefix match swallowing an unrelated word. `@acpfoo`
     /// is not the trigger, and treating it as one would make a typo silently
     /// spend an agent turn.
     #[test]
     fn the_trigger_requires_a_separator() {
-        assert_eq!(triggered_prompt("/acpfoo bar"), None);
+        assert_eq!(triggered_prompt("@acpfoo bar"), None);
+    }
+
+    /// regression: the trigger used to be `/acp`, and a live Windows test showed
+    /// Git Bash rewriting it to `C:/Program Files/Git/acp ...` via MSYS path
+    /// conversion before airc ever saw it. The bridge then behaved perfectly and
+    /// never answered, which is the most expensive way for this to fail.
+    /// what this catches: anyone reintroducing a path-like trigger.
+    #[test]
+    fn the_trigger_is_not_path_like() {
+        assert!(
+            !TRIGGER.starts_with('/'),
+            "a leading-slash trigger is rewritten by MSYS path conversion on Windows"
+        );
+        // And the mangled form must not accidentally still fire.
+        assert_eq!(triggered_prompt("C:/Program Files/Git/acp hello"), None);
     }
 
     /// what this catches: a bare trigger spawning an agent with an empty prompt.
     #[test]
     fn a_bare_trigger_is_not_a_prompt() {
-        assert_eq!(triggered_prompt("/acp"), None);
-        assert_eq!(triggered_prompt("/acp    "), None);
+        assert_eq!(triggered_prompt("@acp"), None);
+        assert_eq!(triggered_prompt("@acp    "), None);
     }
 }

--- a/integrations/acp/src/main.rs
+++ b/integrations/acp/src/main.rs
@@ -2,37 +2,45 @@
 //!
 //! Adapter outlier #2 (see ../README.md). The bridge is simultaneously an
 //! airc citizen (links `airc-lib`: join / subscribe / publish, grounded by
-//! `publish_identity`) and — in later slices — an ACP client driving the agent
-//! over JSON-RPC/stdio.
+//! `publish_identity`) and an ACP client driving the agent over JSON-RPC/stdio.
 //!
 //! ## Slices
-//! - **Slice 1 (this file):** the airc-citizen loop. Joins a room, subscribes,
-//!   and for each inbound message calls a TURN HANDLER, posting any reply. The
-//!   handler is a closure so slice 3 swaps the stub for the real
-//!   `ai/should-respond` handler (delegating to the ACP agent) with zero loop
-//!   change. The stub is conservative — it PASSES on everything except an
-//!   explicit `/acp-ping` (so even slice 1 is not a chatty echo-bot, honouring
-//!   no-rust-gates: the decision to speak is the handler's, not the loop's).
-//! - **Slice 2:** spawn the ACP agent subprocess; JSON-RPC `initialize` /
-//!   `session/new` / `session/prompt` / stream `session/update`.
-//! - **Slice 3:** the turn handler becomes the registered `ai/should-respond`
+//! - **Slice 1:** the airc-citizen loop. Joins a room, subscribes, and for each
+//!   inbound message calls a TURN HANDLER, posting whatever it returns.
+//! - **Slice 2 (this file):** the handler is backed by [`AcpBridge`], which
+//!   spawns the real agent and drives initialize / session/new / session/prompt.
+//!   The protocol itself comes from the published `agent-client-protocol` SDK
+//!   rather than hand-written framing — see `docs/architecture/ACP-CLIENT-BRIDGE.md`
+//!   for why that supersedes this README's original slice-2 plan.
+//! - **Slice 3:** the trigger below becomes the registered `ai/should-respond`
 //!   handler for this ACP citizen's lane, returning the `Decision` wire enum.
 
 use std::sync::Arc;
 
+use airc_acp::{AcpBridge, AgentSpec, BridgeError, PeerPolicy, ToolPolicy};
 use airc_core::{PeerId, TranscriptEvent, TranscriptKind};
 use airc_lib::Airc;
 use futures::StreamExt;
 
-/// A turn handler: given the inbound message text, decide what (if anything)
-/// to say back. `None` = PASS (stay quiet) — the decision lives HERE, never in
-/// the loop. Slice 3 replaces the stub with the ACP-delegating
-/// `ai/should-respond` handler.
-type TurnHandler = dyn Fn(&str) -> Option<String> + Send + Sync;
+/// The slice-2 trigger prefix.
+///
+/// This is a SCAFFOLD, not the design. A bridge that answered every message
+/// would be an echo bot in a shared room, and the no-rust-gates doctrine says
+/// the decision to speak belongs to cognition (slice 3's `ai/should-respond`),
+/// not to an `if` in the loop. Until that lands, an explicit trigger is the
+/// honest placeholder: it is obviously a stand-in rather than a gate pretending
+/// to be judgment, and it makes the live round-trip deterministic to test.
+const TRIGGER: &str = "/acp";
+
+/// A turn handler: given who spoke and what they said, produce the lines to
+/// publish, in order. Empty = PASS (stay quiet) — the decision lives HERE, never
+/// in the loop.
+type TurnHandler =
+    Arc<dyn Fn(String, String) -> futures::future::BoxFuture<'static, Vec<String>> + Send + Sync>;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let agent = std::env::var("ACP_BRIDGE_AGENT").unwrap_or_else(|_| "acp-agent".to_string());
+    let agent_name = std::env::var("ACP_BRIDGE_AGENT").unwrap_or_else(|_| "acp-agent".to_string());
     let room = std::env::var("ACP_BRIDGE_ROOM").unwrap_or_else(|_| "general".to_string());
     let home = std::env::var("AIRC_HOME")
         .map(std::path::PathBuf::from)
@@ -43,34 +51,92 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::path::Path::new(&base).join(".airc")
         });
 
-    // Attach to a running daemon when a socket is given (live grid); otherwise
-    // open an in-process scope. Named so the bridge is a grounded citizen.
+    // The command that launches the agent in ACP mode, e.g.
+    // `uvx hermes-agent[acp] hermes-acp`. Required: a bridge with no agent is not
+    // a degraded bridge, it is a misconfiguration, and it should say so at
+    // startup rather than go quiet on the first message.
+    let command = std::env::var("ACP_BRIDGE_COMMAND").map_err(|_| {
+        "ACP_BRIDGE_COMMAND is not set — it must be the command that starts the ACP agent \
+         (e.g. ACP_BRIDGE_COMMAND='uvx hermes-agent[acp] hermes-acp'). \
+         Without it there is no agent to bridge to."
+    })?;
+
+    let mut spec = AgentSpec::talk_only(&command);
+    // Opt-in widening, both deny-shaped by default. See ACP-CLIENT-BRIDGE.md:
+    // ACP_BRIDGE_TOOLS lists KINDS (read, edit, execute, …), not tool names.
+    if let Ok(tools) = std::env::var("ACP_BRIDGE_TOOLS") {
+        spec = spec.with_tools(ToolPolicy::allow(tools.split(',')));
+    }
+    if let Ok(peers) = std::env::var("ACP_BRIDGE_ALLOW_FROM") {
+        spec = spec.with_peers(PeerPolicy::only(
+            peers.split(',').map(|p| p.trim().to_string()),
+        ));
+    }
+    if let Ok(ws) = std::env::var("ACP_BRIDGE_WORKSPACE") {
+        spec = spec.with_workspace(ws);
+    }
+
+    let bridge = Arc::new(AcpBridge::new(spec));
+
     let airc = match std::env::var("AIRC_SOCKET").ok() {
-        Some(socket) => Airc::attach_as(home, &agent, socket).await?,
-        None => Airc::open_as(home, &agent).await?,
+        Some(socket) => Airc::attach_as(home, &agent_name, socket).await?,
+        None => Airc::open_as(home, &agent_name).await?,
     };
     airc.publish_identity().await?; // ground by name (room_roster + whois see it)
     airc.join(&room).await?;
     let me = airc.peer_id();
-    eprintln!("airc-acp-bridge: '{agent}' joined #{room} as {me} (slice 1: stub turn handler)");
+    eprintln!(
+        "airc-acp-bridge: '{agent_name}' joined #{room} as {me}; agent = `{command}`; \
+         say `{TRIGGER} <prompt>` to reach it"
+    );
 
-    // Slice-1 stub: conservative PASS-everything except an explicit ping, so the
-    // round-trip is smoke-testable without the bridge being a chatty echo.
-    let turn: Arc<TurnHandler> = Arc::new(|incoming: &str| {
-        if incoming.trim() == "/acp-ping" {
-            Some("acp-bridge alive (slice 1 stub — ACP client lands in slice 2)".to_string())
-        } else {
-            None
+    let turn: TurnHandler = {
+        let bridge = Arc::clone(&bridge);
+        Arc::new(move |peer: String, text: String| {
+            let bridge = Arc::clone(&bridge);
+            Box::pin(async move { acp_turn(&bridge, &peer, &text).await })
+        })
+    };
+
+    run_bridge(&airc, me, &turn).await
+}
+
+/// Run one ACP turn and render it as room lines.
+///
+/// The error mapping is the load-bearing part:
+///
+/// - `PeerRefused` → **silence**. It is a configured policy, and announcing it
+///   would let an unauthorized peer make the bridge post on demand.
+/// - `AgentUnavailable` / `Exchange` → **spoken**. These are failures the room
+///   must see. An agent that died must produce a visible failure rather than
+///   silently stopping — "up is not the same as talking", and a bridge that goes
+///   quiet on a crash is indistinguishable from one with nothing to say.
+async fn acp_turn(bridge: &AcpBridge, peer: &str, text: &str) -> Vec<String> {
+    match bridge.prompt(peer, text).await {
+        Ok(turn) => {
+            let mut lines = Vec::new();
+            let reply = turn.text.trim();
+            if !reply.is_empty() {
+                lines.push(reply.to_string());
+            }
+            // Refusals ride out with the reply; approvals stay quiet.
+            lines.extend(turn.refusal_lines());
+            if lines.is_empty() {
+                // The agent completed and said nothing. Say THAT, rather than
+                // leaving the room unable to tell it apart from a dead bridge.
+                lines.push("(the agent completed its turn without producing any text)".to_string());
+            }
+            lines
         }
-    });
-
-    run_bridge(&airc, me, turn.as_ref()).await
+        Err(BridgeError::PeerRefused { .. }) => Vec::new(),
+        Err(e) => vec![format!("ACP bridge could not answer: {e}")],
+    }
 }
 
 /// The airc-citizen loop: subscribe to the current room and, for each inbound
-/// message from another peer, run `turn` and post any reply. Factored out of
-/// `main` so the turn handler is injectable (tests, and the slice-3 handler
-/// swap).
+/// message from another peer, run `turn` and post whatever it returns. Factored
+/// out of `main` so the turn handler is injectable (tests, and the slice-3
+/// handler swap).
 async fn run_bridge(
     airc: &Airc,
     me: PeerId,
@@ -83,8 +149,11 @@ async fn run_bridge(
                 let Some(text) = inbound_text(&event, me) else {
                     continue;
                 };
-                if let Some(reply) = turn(text) {
-                    airc.say(&reply).await?;
+                let Some(prompt) = triggered_prompt(text) else {
+                    continue;
+                };
+                for line in turn(event.peer_id.to_string(), prompt.to_string()).await {
+                    airc.say(&line).await?;
                 }
             }
             Err(lag) => eprintln!("airc-acp-bridge: live stream lagged: {lag}"),
@@ -109,6 +178,26 @@ fn inbound_text(event: &TranscriptEvent, me: PeerId) -> Option<&str> {
         None
     } else {
         Some(text)
+    }
+}
+
+/// The prompt carried by a triggered message, or `None` when this message was
+/// not addressed to the agent.
+///
+/// Pure so the trigger rule is testable without a room, and so slice 3 has one
+/// obvious function to delete when `ai/should-respond` takes over.
+fn triggered_prompt(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix(TRIGGER)?;
+    // Require a separator so `/acpfoo` isn't read as a trigger for `foo`.
+    let prompt = match rest.chars().next() {
+        None => "",
+        Some(c) if c.is_whitespace() => rest.trim(),
+        Some(_) => return None,
+    };
+    if prompt.is_empty() {
+        None
+    } else {
+        Some(prompt)
     }
 }
 
@@ -163,5 +252,41 @@ mod tests {
         let me = PeerId::from_u128(1);
         let other = PeerId::from_u128(2);
         assert_eq!(inbound_text(&msg(other, "   "), me), None);
+    }
+
+    /// what this catches: the bridge turning into an echo bot. Ordinary room
+    /// chatter must NOT reach the agent — every message that did would be a
+    /// subprocess spawn and, on a paid backend, a bill.
+    #[test]
+    fn ordinary_chatter_does_not_reach_the_agent() {
+        assert_eq!(
+            triggered_prompt("what do you all think about the merge?"),
+            None
+        );
+        assert_eq!(triggered_prompt("the /acp thing is neat"), None);
+    }
+
+    #[test]
+    fn a_triggered_message_yields_just_the_prompt() {
+        assert_eq!(
+            triggered_prompt("/acp summarize the diff"),
+            Some("summarize the diff")
+        );
+        assert_eq!(triggered_prompt("/acp   padded  "), Some("padded"));
+    }
+
+    /// what this catches: a prefix match swallowing an unrelated word. `/acpfoo`
+    /// is not the trigger, and treating it as one would make a typo silently
+    /// spend an agent turn.
+    #[test]
+    fn the_trigger_requires_a_separator() {
+        assert_eq!(triggered_prompt("/acpfoo bar"), None);
+    }
+
+    /// what this catches: a bare trigger spawning an agent with an empty prompt.
+    #[test]
+    fn a_bare_trigger_is_not_a_prompt() {
+        assert_eq!(triggered_prompt("/acp"), None);
+        assert_eq!(triggered_prompt("/acp    "), None);
     }
 }


### PR DESCRIPTION
Design pinned before implementation, against the **actual SDK** (`agent-client-protocol 2.0.0`), not a guess.

**Reading Hermes killed my first plan, in the good way.** It already ships `acp_adapter/` with an `agent-client-protocol` dep, JSON-RPC over stdio, and a standard `acp_registry/agent.json` — it *is* an ACP agent. A Hermes-specific plugin would buy one agent and couple us to their internals forever.

Making **airc an ACP client** inverts it: every agent shipping an ACP adapter becomes a room citizen, zero upstream patches.

So the on-ramp has **two classes**, and picking wrong is expensive:

| Class | Use when | Example |
|---|---|---|
| airc as ACP client | the agent speaks a standard | Hermes, any registry entry |
| channel plugin | the **host** owns the UI surface | OpenClaw |

**The one deliberate divergence from the SDK's example:** it auto-approves every permission request — and is honest about it, being named `yolo_one_shot_client`. Fine for a CLI where the human typed the prompt. **Wrong for a room**, where the prompt comes from a *peer* and airc broadcasts carry no structural addressing, so any peer reaching the room could induce arbitrary tool execution on this machine. Default is **deny-and-say-so**, with explicit `toolsAllow`/`allowFrom` opt-ins — the same config surface the OpenClaw plugin already exposes, so both classes share one mental model.

Also records what is **not** decided (session lifetime, streaming granularity, agent-death reporting) as things to *measure*, and a verification bar that is a live Windows round-trip — not "it compiles".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc