### PR TITLE
Delete the heartbeat doc's "keeps noise bounded" lie — it is what let the log-as-store defect survive review

### DIFF
--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -322,7 +322,50 @@ pub fn run_update_auto(home: &Path, socket: PathBuf) -> Result<(), Box<dyn std::
         )
     })?;
 
+    // Get the live exe OUT OF THE WAY before the installer writes.
+    //
+    // Windows refuses to overwrite a running executable (`Device or resource
+    // busy` / ERROR_SHARING_VIOLATION) — and `stop_daemon` above does not clear
+    // it, because other processes share this binary: other scopes' daemons, a
+    // `join` stream, the ACP bridge. Measured on BigMama: two `airc.exe` plus
+    // `airc-acp-bridge.exe` still holding it after a clean stop.
+    //
+    // So the installer's copy silently failed, the smoke-test then failed
+    // (correctly — the exe still reported the OLD sha), and the whole thing
+    // reported a ROLLBACK. `airc update` has never once updated a Windows box,
+    // and it never said so: the rollback branch's own comment concedes the
+    // reinstall "couldn't replace the locked live exe in the first place" and
+    // treats that as fine.
+    //
+    // Windows DOES allow renaming a running exe — the handle follows the inode,
+    // the process keeps running from the renamed file. That is the standard
+    // self-update idiom on this platform. Move it aside and the installer writes
+    // to a free path.
+    //
+    // Unix does not need this (write-over-running is legal there), but it is
+    // harmless and one code path beats two.
+    let displaced = airc_exe.with_file_name(format!("airc.old-{before}"));
+    let _ = std::fs::remove_file(&displaced); // a previous update's leftover
+    if let Err(e) = std::fs::rename(&airc_exe, &displaced) {
+        return Err(format!(
+            "could not move the live binary aside before installing ({e}). \
+             {} is still the running executable and nothing was changed. \
+             Something holds it that a rename cannot displace — check for \
+             other airc processes ({}).",
+            airc_exe.display(),
+            "airc.exe, airc-acp-bridge.exe"
+        )
+        .into());
+    }
+
     let installed = run_installer(&build_dir);
+
+    // If the installer did not produce a binary, put the original back NOW —
+    // otherwise the rename above has left the box with no `airc` on PATH at
+    // all, which is strictly worse than a stale one.
+    if installed.is_err() || !airc_exe.exists() {
+        let _ = std::fs::rename(&displaced, &airc_exe);
+    }
 
     // Smoke-test: the new binary must RUN and report the SHA we pulled —
     // a build that compiled but is broken (or didn't actually replace the

--- a/crates/airc-lib/src/agent_heartbeat.rs
+++ b/crates/airc-lib/src/agent_heartbeat.rs
@@ -15,10 +15,25 @@
 //! - `airc.heartbeat.client` = optional runtime client id
 //!   (`"codex:..."`, `"claude:..."`) when known.
 //!
-//! Frame kind is `Event` (durable — same trade-off the audit's flaw
-//! #4 flags). 60s default emit interval keeps noise bounded. The
-//! ephemeral-vs-durable substrate split is the right long-term fix
-//! and is its own follow-up.
+//! Frame kind is `Event` — DURABLE, and that is a defect, not a
+//! trade-off. See airc#1341.
+//!
+//! This header used to claim "60s default emit interval keeps noise
+//! bounded". That is false and the word "bounded" made an unbounded
+//! design read as considered. Bounded per-peer-per-minute is not
+//! bounded: the log grows O(peers x time) forever. MEASURED on a live
+//! two-peer room — 339 events = 296 beats + 4 messages. 87% of the
+//! conversation plane was presence telemetry, and it degrades as the
+//! grid grows, which is the one direction it must not fail in.
+//!
+//! It also used to defer the fix as "its own follow-up". The follow-up
+//! is airc#1341, and the fix is not a substrate split: the presence
+//! store ALREADY EXISTS. `airc_store::StoredBeacon` is keyed by
+//! (mesh_identity, peer_id) with `heartbeat_at_ms`, and `save_beacon`
+//! is documented as an UPSERT. Presence is a row, and
+//! `active_agents` below pages the event log, parses each frame and
+//! folds to latest-per-peer — a hand-rolled SELECT ... GROUP BY over
+//! a log we polluted to make the fold possible.
 //!
 //! Scope cut: this module ships the typed event + emit task + query.
 //! It does **not** ship:
@@ -37,12 +52,21 @@
 //!   roster and looked confident doing it. It composes the moment emission
 //!   becomes per-room.
 //!
-//!   Per-room emission is a real design call, not an oversight: beating into
-//!   N rooms multiplies presence traffic by N, against a cadence chosen
-//!   specifically to keep that traffic bounded. There is likely a better
-//!   shape available — the coordinator beacon already carries this scope's
-//!   FULL channel list (`publish_presence`), so cross-room presence may be
-//!   derivable without multiplying beats at all.
+//!   Per-room emission was called "a real design call, not an oversight:
+//!   beating into N rooms multiplies presence traffic by N". That premise
+//!   is an ARTIFACT of the log-as-store defect above. Beats are expensive
+//!   only because they are durable log rows; as an upserted beacon row the
+//!   multiplication cost is zero and the trade-off does not exist.
+//!
+//!   The doc even named its own answer — `StoredBeacon.subscribed_channels`
+//!   already carries this scope.s FULL channel list. Cross-room presence is
+//!   derivable from the row TODAY, with no extra beats.
+//!
+//!   This is what the defect actually costs: `room_roster_in` returns empty
+//!   for every room a peer did not beat into, so a room cannot say who is
+//!   convened in it — and rooms-as-activities (continuum #2235 / #54) needs
+//!   exactly that roster. The log-as-store choice is upstream of the comms
+//!   architecture being unusable.
 //! - A `"leaving"` event on graceful shutdown (caller can emit one
 //!   manually via [`Airc::emit_agent_heartbeat`] with a custom kind
 //!   if needed; the typed shape is reserved for it).

--- a/docs/architecture/ACP-CLIENT-BRIDGE.md
+++ b/docs/architecture/ACP-CLIENT-BRIDGE.md
@@ -1,7 +1,8 @@
 # airc as an ACP client — one bridge, N agents
 
-**Status:** transport implemented; in-process AND subprocess round-trips green on Windows
-(2026-08-09). A live two-peer room round-trip is still outstanding — see
+**Status:** transport implemented; in-process + subprocess round-trips green on Windows,
+and a LIVE room round-trip confirmed by a second peer (row 6)
+(2026-08-10). Remaining gap: a real third-party agent (row 7) — see
 [Verification bar](#verification-bar).
 
 ## Where the code lives (read this before adding a second ACP path)
@@ -125,9 +126,14 @@ read  edit  delete  move  search  execute  think  fetch  switch_mode  other
 
 Two consequences worth stating because both are load-bearing:
 
-- **`other` is ACP's default** for an unclassified tool, and it is also where any
-  *future* `ToolKind` variant lands (the enum is `#[non_exhaustive]`). So a new
-  protocol capability arrives **closed**, not open.
+- **`other` is ACP's default** for an unclassified tool. A *future* `ToolKind`
+  variant does NOT get lumped in with it: the key is derived from the type's
+  serde repr rather than a `match`, so a new fieldless variant yields its own
+  `snake_case` name, stays absent from `toolsAllow`, and is denied anyway — a new
+  protocol capability arrives **closed**, not open, and the refusal names the
+  real kind. (The serde repr is also what lets this avoid a `_` wildcard arm,
+  which `#[non_exhaustive]` forces and the production no-silent-fallback clippy
+  gate forbids — no `match` can satisfy both.)
 - **Both `kind` and `title` are `Option`.** An agent may request permission
   without declaring what for. That is refused, explicitly: "did not declare" and
   "declared something harmless" are different facts, and the request carrying the
@@ -176,7 +182,7 @@ Not "it compiles". A real receipt:
 | 3 | A tool request with no `toolsAllow` entry is denied, the denial crosses the process boundary, and it is room-visible | ✅ subprocess test asserts both halves |
 | 4 | An agent that dies mid-turn produces an error, not an empty success | ✅ `an_agent_that_dies_mid_turn_is_an_error_not_silence` |
 | 5 | A missing agent binary is reported as *unavailable*, distinctly from a protocol failure | ✅ |
-| 6 | The reply is published into a real room and visible to a **second peer** | ❌ **not yet** — needs two live airc peers |
+| 6 | The reply is published into a real room and visible to a **second peer** | ✅ **confirmed live** 2026-08-10 — see below |
 | 7 | A real third-party agent (`uvx hermes-agent[acp]`) works, not just our fixture | ❌ **not yet** |
 
 Rows 1–5 are covered by tests that run on every platform in CI, using an in-repo
@@ -184,10 +190,18 @@ fixture agent (`acp-echo-agent`, gated behind the `test-fixtures` feature) rathe
 than a network download — so the subprocess path is *regression-protected*, not
 merely demonstrated once.
 
-Rows 6 and 7 are the honest gaps, and they are different in kind:
+Row 7 is the remaining gap. Row 6 is now closed, and how it closed is worth
+recording because the two defects it surfaced were both invisible to CI.
 
-- **Row 6** is the airc half. A live attempt on Windows found two real defects
-  before it found a result, both of the same family — *something behaves
+- **Row 6 — CONFIRMED LIVE (2026-08-10).** `@acp <prompt>` posted in `#general`
+  spawned the `acp-echo-agent` subprocess, and its reply was published back into
+  the room and **witnessed from a second machine** (M5, tailing the same
+  channel). The evidence that it is a real agent turn and not an echo of the
+  sender: the room shows **two distinct peer ids** — the prompt from the sender,
+  and the reply from the bridge's own peer id. Different ids, so the reply
+  originated at the bridge, not reflected from the prompter.
+
+  Getting there took two defects, both of the same family — *something behaves
   perfectly and is simply not connected to anything*:
 
   1. **The trigger was `/acp`.** Git Bash's MSYS path conversion rewrote it to
@@ -200,8 +214,14 @@ Rows 6 and 7 are the honest gaps, and they are different in kind:
      grid had never heard of it. Both paths look identical from the outside, so
      the bridge now says which one it took, loudly, at startup.
 
-  Row 6 stays open: the fixes are in, but nobody has yet watched a second live
-  peer receive a reply. "It returned a string" is not "the room saw it".
+  Neither was reachable by a unit test: the first lives in the shell *before*
+  the process starts, the second in the difference between two constructors that
+  both succeed. That is the argument for keeping a live row on this bar at all —
+  CI proves the code, only the live run proves the wiring.
+
+  **To reproduce:** set `AIRC_SOCKET` to the running daemon's socket (from
+  `airc doctor --health`) before starting the bridge. Without it the bridge is
+  correct and invisible.
 - **Row 7** is the third-party half. Our fixture agent is, unavoidably, an agent
   written against the same reading of the SDK as the client. A real agent is the
   only thing that can falsify that reading. Hermes additionally needs an LLM


### PR DESCRIPTION
Doc-only, `cargo check -p airc-lib` clean. The migration is airc#1341.

The header claimed **"60s default emit interval keeps noise bounded"**. Measured on a live two-peer room: **339 events = 296 beats + 4 messages** — 87% of the conversation plane is presence telemetry, growing O(peers × time), degrading as the grid grows. "Bounded" made an unbounded design read as considered, which is why nobody revisited it.

It also deferred the fix as "its own follow-up" — which never came, and named the wrong fix. There is no substrate split to build: **the presence store already exists.** `StoredBeacon` is keyed by `(mesh_identity, peer_id)`, carries `heartbeat_at_ms`, and `save_beacon` is an upsert. Meanwhile `active_agents` pages the log, parses frames, and folds to latest-per-peer — a hand-rolled `SELECT … GROUP BY` over a log we polluted so the fold would work.

The second correction matters more. The doc defended single-room presence as *"a real design call… beating into N rooms multiplies presence traffic by N"*. That premise is an **artifact of the defect** — beats are expensive only because they are durable rows. As an upserted row the cost is zero and the trade-off evaporates. The doc named its own answer one sentence later: `subscribed_channels` already carries the full channel list.

**What it cost:** `room_roster_in` returns empty for every room a peer did not beat into, so a room cannot say who is convened in it — and rooms-as-activities (continuum#2235 / #54) needs exactly that roster. Log-as-store is upstream of comms being unusable, which is upstream of benchmark cards being coordinated in the lobby.