### PR TITLE
fix(join): id-shaped tokens resolve against subscribed channels — never mint a ghost room

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1743,19 +1743,6 @@ impl Airc {
     }
 
     async fn join_channel(&self, name: &str, focus: Focus) -> Result<Room, AircError> {
-        // Card c409eaf5: refuse uuid-shaped names. `ChannelName::new`
-        // hashes the name into a derived UUID; a uuid-shaped string
-        // re-hashes into a DIFFERENT channel UUID, silently. The
-        // resulting subscription registers on the wrong channel and
-        // the fan-out misses every publish. Better to fail loudly at
-        // the API boundary than to let the trap close on the next
-        // consumer like it closed on the continuum demo 2026-06-01.
-        if uuid::Uuid::parse_str(name.trim()).is_ok() {
-            return Err(AircError::JoinUuidString {
-                string: name.to_string(),
-            });
-        }
-        let channel = ChannelName::new(name)?;
         let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         // Self-healing join: `mesh_identity()` above may have HEALED
@@ -1765,6 +1752,43 @@ impl Airc {
         // room while inbound frames land in the converged one. Saved +
         // re-beaconed by the save/publish_presence below.
         warn_subscription_rebinds(&set.rebind_diverged(&identity));
+        // Card c409eaf5, both octaves: an id-shaped token must RESOLVE
+        // against the channels this scope already knows, never reach
+        // `ChannelName::new` (which would hash it into a brand-new
+        // channel). Octave 1 (2026-06-01, continuum demo): a FULL uuid
+        // string minted a diverged channel — refused since. Octave 2
+        // (2026-08-11): the 8-hex SHORT id walked past that guard and
+        // minted ghost room 7d1a76de from academy's prefix "3be59578" —
+        // this scope then wrote and read a room nobody else was in, and
+        // every store read looked like a monologue. Resolution wins
+        // over refusal: a token matching exactly one subscribed channel
+        // binds to THAT room; no match or several is a loud error.
+        let channel = match set.resolve_id_token(name) {
+            subscriptions::IdTokenResolution::Match(sub) => sub.name.clone(),
+            subscriptions::IdTokenResolution::NotAnId => ChannelName::new(name)?,
+            subscriptions::IdTokenResolution::Unknown => {
+                // Preserve the documented c409eaf5 error for full-uuid
+                // tokens; the short-id form gets its own guidance.
+                return Err(if uuid::Uuid::parse_str(name.trim()).is_ok() {
+                    AircError::JoinUuidString {
+                        string: name.to_string(),
+                    }
+                } else {
+                    AircError::JoinIdUnknown {
+                        token: name.trim().to_string(),
+                    }
+                });
+            }
+            subscriptions::IdTokenResolution::Ambiguous(subs) => {
+                return Err(AircError::JoinIdAmbiguous {
+                    token: name.trim().to_string(),
+                    candidates: subs
+                        .iter()
+                        .map(|s| format!("{} ({})", s.name.as_str(), s.room_id))
+                        .collect(),
+                });
+            }
+        };
         let subscription =
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         if focus == Focus::MakeDefault {

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -106,6 +106,31 @@ pub enum AircError {
     )]
     JoinUuidString { string: String },
 
+    /// Card c409eaf5, octave 2: the join token is id-shaped (8..=32
+    /// hex chars) but matches no subscribed channel. Refusing here is
+    /// what keeps `ChannelName::new` from hashing the id into a NEW
+    /// channel — the ghost-room mint that split a room's readers from
+    /// its writers on 2026-08-11 ("3be59578" → ghost 7d1a76de while
+    /// academy's traffic lived on 3be59578…).
+    #[error(
+        "join refused: {token:?} is id-shaped (hex) but matches no subscribed channel. \
+         If you meant an existing room, run `airc room` and pass its NAME. \
+         If you truly want a room NAMED this, pick a name with a non-hex character — \
+         an id-shaped name would mint a NEW channel and split the room."
+    )]
+    JoinIdUnknown { token: String },
+
+    /// Card c409eaf5, octave 2: the id-shaped join token is a prefix
+    /// of more than one subscribed channel UUID.
+    #[error(
+        "join refused: {token:?} matches multiple subscribed channels: {candidates:?}. \
+         Pass the room NAME or a longer id prefix."
+    )]
+    JoinIdAmbiguous {
+        token: String,
+        candidates: Vec<String>,
+    },
+
     /// Caller attempted to mutate a work card from a room whose work
     /// projection does not contain that card. Work cards are
     /// room-scoped coordination state; transitions from another room

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -228,6 +228,23 @@ pub fn derive_room_id(identity: &MeshIdentity, channel: &ChannelName) -> RoomId 
     RoomId::from_uuid(Uuid::new_v5(&SUBSCRIPTIONS_NAMESPACE, &bytes))
 }
 
+/// Outcome of [`SubscriptionSet::resolve_id_token`] — how a join
+/// token that might be a channel ID resolves against this scope's
+/// subscriptions.
+#[derive(Debug)]
+pub enum IdTokenResolution<'a> {
+    /// Not id-shaped — treat the token as a channel NAME.
+    NotAnId,
+    /// Id-shaped and identifies exactly this subscribed channel.
+    Match(&'a Subscription),
+    /// Id-shaped but no subscribed channel matches — almost certainly
+    /// a mis-pasted id; minting a room named after it would split the
+    /// real room (the ghost-room trap).
+    Unknown,
+    /// Id-shaped and a prefix of MORE than one subscribed channel.
+    Ambiguous(Vec<&'a Subscription>),
+}
+
 /// One channel this scope is subscribed to.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Subscription {
@@ -414,6 +431,50 @@ impl SubscriptionSet {
     /// monitor/hook iteration so the user's experience is stable).
     pub fn all(&self) -> impl Iterator<Item = &Subscription> {
         self.subscribed.values()
+    }
+
+    /// Resolve a join TOKEN that may be a channel ID rather than a
+    /// name (card c409eaf5, octave 2 — glass-boxed 2026-08-11).
+    ///
+    /// `ChannelName::new` hashes whatever it is given, so an id-shaped
+    /// token that reaches it mints a brand-new channel: passing
+    /// `"3be59578"` (the hex prefix of academy's channel UUID) created
+    /// ghost room `7d1a76de…`, and from then on this scope wrote and
+    /// read a channel nobody else was in — every store read looked
+    /// like a monologue and the transport took the blame. The original
+    /// c409eaf5 guard refused FULL uuid strings; the 8-hex short id —
+    /// the form every other id surface in the system accepts — walked
+    /// straight past it into the mint.
+    ///
+    /// An id-shaped token is an ID in the caller's head, so treat it
+    /// as one: a run of 8..=32 hex chars (dashes ignored) resolves as
+    /// a prefix of a subscribed channel's UUID. Exactly one match
+    /// binds to that existing room; zero or several is the caller's
+    /// answer, never a mint. Anything else is a plain name.
+    pub fn resolve_id_token(&self, token: &str) -> IdTokenResolution<'_> {
+        let compact: String = token.trim().chars().filter(|c| *c != '-').collect();
+        let id_shaped =
+            (8..=32).contains(&compact.len()) && compact.chars().all(|c| c.is_ascii_hexdigit());
+        if !id_shaped {
+            return IdTokenResolution::NotAnId;
+        }
+        let needle = compact.to_ascii_lowercase();
+        let matches: Vec<&Subscription> = self
+            .subscribed
+            .values()
+            .filter(|s| {
+                s.room_id
+                    .as_uuid()
+                    .as_simple()
+                    .to_string()
+                    .starts_with(&needle)
+            })
+            .collect();
+        match matches.len() {
+            0 => IdTokenResolution::Unknown,
+            1 => IdTokenResolution::Match(matches[0]),
+            _ => IdTokenResolution::Ambiguous(matches),
+        }
     }
 
     /// Just the names of subscribed channels — what Codex's
@@ -717,6 +778,53 @@ mod tests {
             &ChannelName::new("c").unwrap(),
         );
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn resolve_id_token_binds_id_shaped_tokens_to_existing_channels() {
+        // what this catches: the ghost-room mint (card c409eaf5 octave 2,
+        // 2026-08-11) — an 8-hex short id of a SUBSCRIBED channel passed as a
+        // join token must resolve to that channel, and an id-shaped token
+        // matching nothing must be Unknown (refused upstream), never a fresh
+        // v5 mint that splits the room's readers from its writers.
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let id = MeshIdentity::new("joelteply");
+        let mut set = SubscriptionSet::empty();
+        let academy = set
+            .subscribe(home, &id, ChannelName::new("academy").unwrap())
+            .unwrap();
+
+        let simple = academy.room_id.as_uuid().as_simple().to_string();
+
+        // 8-hex short id → binds to academy.
+        match set.resolve_id_token(&simple[..8]) {
+            IdTokenResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
+            other => panic!("short id must Match, got {other:?}"),
+        }
+        // Full dashed uuid → binds too (resolution wins over the old refusal).
+        match set.resolve_id_token(&academy.room_id.to_string()) {
+            IdTokenResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
+            other => panic!("full uuid must Match, got {other:?}"),
+        }
+        // Id-shaped, no such channel → Unknown (join refuses; no mint).
+        assert!(matches!(
+            set.resolve_id_token("deadbeef"),
+            IdTokenResolution::Unknown
+        ));
+        // Plain names — including hexy-but-short and dashed ones — stay names.
+        assert!(matches!(
+            set.resolve_id_token("academy"),
+            IdTokenResolution::NotAnId
+        ));
+        assert!(matches!(
+            set.resolve_id_token("k3-serving"),
+            IdTokenResolution::NotAnId
+        ));
+        assert!(matches!(
+            set.resolve_id_token("cafe"),
+            IdTokenResolution::NotAnId
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## The night this cost (glass-boxed 2026-08-11)

An operator passed `3be59578` — the 8-hex prefix of **academy**'s channel UUID — as a room token. The c409eaf5 guard only refuses FULL uuid strings; the short id walked past it into `ChannelName::new`, which hashed it into brand-new channel `7d1a76de…`. That scope then wrote and read a room nobody else was in: **736 messages of real academy traffic sat one channel over while every store read returned a monologue**, and two machines spent the night diagnosing the transport. Delivery and persistence were healthy the whole time (M5 machine store: 637k bus_events, peer messages present and current to the second).

## The rule

An id-shaped token (8..=32 hex chars, dashes ignored) is an ID in the caller's head, never a name.

- `SubscriptionSet::resolve_id_token` resolves it as a prefix of subscribed channel UUIDs.
- Exactly one match → join binds to **that** room. (This also upgrades the full-uuid case: it previously refused even when the uuid named a channel we hold — resolution wins over refusal.)
- Zero matches → loud error (`JoinUuidString` for full uuids, new `JoinIdUnknown` for short ids). The mint path is unreachable for id-shaped tokens.
- Several → `JoinIdAmbiguous` listing candidates.
- Plain names — hexy-but-short (`cafe`), dashed (`k3-serving`) — untouched.

## Proof

Regression test pins Match (short id + full dashed uuid), Unknown (unmatched id), NotAnId (real names). 344 airc-lib tests green, airc-cli green, cargo-fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo