### PR TITLE
doctor: delivery truth SPEAKS when it has no evidence — silence was reading as a pass

### DIFF
--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -695,12 +695,47 @@ async fn check_delivery_truth(home: &Path) -> Vec<Finding> {
                     )),
                 }
             }
-            (false, None) => findings.push(Finding::ok(
+            // NEVER-CONFIRMED. `last_ack_ms == None` means this peer has not
+            // acked ONCE — not "the last ack is old", but "there has never been
+            // one". The old arm called that `ok … (within tolerance)` at ANY
+            // attempt count, so 63 attempts with zero confirmations printed as
+            // healthy. Measured on BigMama 2026-08-11, on a peer that was in a
+            // different SCOPE and could not possibly have received anything.
+            //
+            // Tolerance is a concept for a route that has proven it works and
+            // may have one confirmation in flight. A route that has never
+            // confirmed anything has proven nothing, and the count is the whole
+            // signal: 1-2 attempts is a new route mid-handshake; dozens is a
+            // peer that is not there. The suspect-detector owns the sophisticated
+            // half-open case — this is the blunt one it does not cover, because
+            // `suspect` is false when frames were never successfully flushed at
+            // all.
+            // NEVER CONFIRMED — a different TYPE of fact, not a worse degree of
+            // one. `last_ack_ms == None` is not "the last ack is old", it is
+            // "there has never been an ack", so there is nothing to be within
+            // tolerance OF: tolerance is derived from the peer's measured rtt,
+            // and a peer with no ack has no rtt. The old arm applied a tolerance
+            // that could not exist and stamped `ok` at any attempt count — 63
+            // attempts, zero confirmations, printed healthy, on a peer that was
+            // in a different SCOPE and could not physically receive anything.
+            //
+            // No attempt threshold here, deliberately. The file's own rule is
+            // that the ledger already holds the evidence and no arbitrary
+            // constant is needed, and picking "N attempts is fine, N+1 is not"
+            // would invent exactly that. The honest report is the type itself:
+            // this route is UNPROVEN. One attempt unproven and fifty attempts
+            // unproven differ in how much was lost, not in whether anything was
+            // confirmed — and the count is printed so the reader can weigh it.
+            (false, None) => findings.push(Finding::warn(
                 "delivery truth",
                 format!(
-                    "{}: {} attempt(s), none confirmed yet (within tolerance)",
+                    "{}: UNPROVEN — {} attempt(s), never once confirmed. \
+                     Nothing sent to this peer can be shown to have arrived.",
                     peer.peer_id, peer.attempts
                 ),
+                "if this is a new route it clears on the first ack; if it does not, \
+                 check you are in the scope the peer is enrolled in (`airc peers` — \
+                 a peer absent there can never receive), then `airc transport health`",
             )),
         }
     }

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -581,17 +581,40 @@ async fn check_delivery_truth(home: &Path) -> Vec<Finding> {
     let socket = crate::cli::default_socket_path_in(home);
     let stats = match airc_ipc::DaemonClient::new(socket).delivery_stats().await {
         Ok(response) => response.peers,
-        Err(_) => {
-            // No daemon (or an older build without the verb): delivery
-            // truth is unknown, not fine. Quietly informational — the
-            // daemon-liveness check above already reports the daemon.
-            return Vec::new();
+        Err(error) => {
+            // The old comment said "delivery truth is unknown, not fine" and
+            // then returned an EMPTY vec — which prints NOTHING. The one check
+            // whose entire job is proving delivery said nothing at all, and a
+            // missing line reads as a passing line to every operator alive.
+            //
+            // Measured 2026-08-11: eight messages sent, `delivery truth`
+            // printed no row whatsoever, and the sender could not tell whether
+            // a single one had landed. Unknown must be SPOKEN.
+            return vec![Finding::warn(
+                "delivery truth",
+                format!("UNKNOWN — the daemon did not answer delivery_stats ({error})"),
+                "no delivery can be confirmed while this is unknown; \
+                 `airc join` respawns the daemon, then re-run doctor",
+            )];
         }
     };
     if stats.is_empty() {
-        return vec![Finding::ok(
+        // NOT `ok`, and NOT "no deliveries attempted yet" — the ledger being
+        // empty is not evidence that nothing was sent. A broadcast that reaches
+        // zero connected peers records no attempt at all, so the emptiest
+        // ledger and the healthiest idle node are the same picture, and the
+        // caller who just watched "reached 0 of 87 enrolled peer(s)" scroll by
+        // gets told everything is fine.
+        //
+        // An empty ledger means NO EVIDENCE EITHER WAY. Report the absence as
+        // the finding rather than dressing it as a clean bill.
+        return vec![Finding::warn(
             "delivery truth",
-            "no cross-machine deliveries attempted yet (nothing to confirm)",
+            "ledger EMPTY — no cross-machine delivery has been confirmed, and \
+             an empty ledger is NOT proof that none was attempted (a send to \
+             zero connected peers records nothing)",
+            "send one message and re-run; if the ledger stays empty while peers \
+             are enrolled, outbound is not reaching anyone",
         )];
     }
     let now_ms = std::time::SystemTime::now()


### PR DESCRIPTION
The one check whose job is proving delivery had two ways to say nothing, and both looked like health.

**1. Daemon didn't answer → `return Vec::new()`.** Its own comment said *"delivery truth is unknown, not fine"* — then returned an empty vec, printing **no line at all**. A missing line reads as a passing line.

Measured tonight on BigMama: eight messages sent to a peer, `doctor --health` printed no delivery-truth row at all, and I could not tell whether one had landed.

**2. Empty ledger → `Finding::ok("no cross-machine deliveries attempted yet")`.** That asserts a fact it cannot know. A broadcast reaching zero *connected* peers records no attempt — so "nobody is listening" and "healthy idle node" produce an identical empty ledger, and the operator who just watched `reached 0 of 87 enrolled peer(s)` scroll past is told everything is fine.

Both are absence-rendered-as-a-positive-fact, in the check built to prevent exactly that. NOT_FOUND and COULD_NOT_LOOK are different types; this collapsed them into `ok` and ``.

Now: a warn naming the daemon error, and a warn saying **no evidence either way** with the discriminating test — send one and re-run; a ledger that stays empty while peers are enrolled means outbound reaches nobody.

**What it would have caught:** an evening spent relaying a collaborator's replies as established fact while holding zero proof any send arrived. The event store, checked afterward, holds eight Messages from my own peer and none from theirs.

`cargo check -p airc-cli` clean; rebased on canary.