### PR TITLE
daemon: serve the scope that OWNS the socket, and refuse one that doesn't

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -245,11 +245,58 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
         None
     };
 
+    // SOS rides ALONG with the live feed instead of waiting to be remembered.
+    //
+    // The out-of-band channel exists for the case where the wire is down — and
+    // that is precisely the case where nobody thinks to run `airc sos watch`,
+    // because the wire being down is not announced, it is INFERRED from silence.
+    // On 2026-08-12 two operators sat in that silence for hours; the human
+    // relayed between them by hand, and `airc sos` had been merged only that
+    // night after sitting unmerged through the exact outage it was built for.
+    //
+    // So: whenever this node streams a join, it also surfaces peer SOS posts.
+    // No flag, no verb to recall, no decision to make while blind. `poll_once`
+    // is cursor-gated and self-filtering, so a healthy node sees nothing and
+    // pays one `gh` call per interval; a blind one sees its peers.
+    //
+    // Best-effort and detached ON PURPOSE: SOS is the recovery channel, so it
+    // must never be able to take down the feed it backs up. A missing `gh`, an
+    // unauthenticated shell, or no SOS gist yet all degrade to "no fallback",
+    // which is exactly where we were before this existed.
+    let _sos_fallback = runtime_context
+        .should_stream_join()
+        .then(|| start_sos_fallback(home));
+
     if runtime_context.should_stream_join() {
         crate::join_feed::run(&airc).await?;
     }
     Ok(())
 }
+
+/// Poll the SOS gist alongside the live feed, printing any NEW peer posts.
+///
+/// Returns a task handle whose drop cancels the poll — it lives exactly as long
+/// as the join it accompanies.
+fn start_sos_fallback(home: &Path) -> tokio::task::JoinHandle<()> {
+    let home = home.to_path_buf();
+    tokio::spawn(async move {
+        // First poll is delayed: a node that just joined is the LEAST likely to
+        // need the fallback, and an immediate `gh` call on every join would tax
+        // the healthy path to serve the broken one.
+        loop {
+            tokio::time::sleep(SOS_FALLBACK_POLL_INTERVAL).await;
+            // Errors are swallowed rather than reported every tick: `gh` absent
+            // or unauthenticated is a STANDING condition, not an event, and a
+            // recurring complaint in a live feed is its own kind of noise. The
+            // explicit `airc sos status` says so plainly when asked.
+            let _ = crate::sos_commands::poll_fallback_once(&home).await;
+        }
+    })
+}
+
+/// How often a joined node checks the out-of-band channel. Deliberately slow:
+/// this is a rendezvous, not a bus, and the healthy case must stay cheap.
+const SOS_FALLBACK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(120);
 
 async fn start_join_heartbeat(
     airc: &Airc,

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -392,10 +392,39 @@ pub async fn ensure_daemon_running(
         .open(&log)?;
     let stderr = stdout.try_clone()?;
     let exe = std::env::current_exe()?;
+    // The daemon's HOME must be the home that OWNS the socket, not the
+    // caller's scope.
+    //
+    // `default_socket_path_in` resolves through `machine_account_home`, so a
+    // caller in a git-project scope (`<repo>/.airc`) legitimately shares the
+    // MACHINE-account socket — one daemon per machine is the design. But this
+    // spawn passed the CALLER's `home` through, so whichever scope happened to
+    // start the daemon first imposed ITS identity on every scope that later
+    // attached to that socket. Nothing detected it: both paths are real, the
+    // daemon is healthy, and `doctor` reports a clean bill.
+    //
+    // Measured on BIGMAMA 2026-08-12, the whole night's blackout in one line:
+    //
+    //   airc.exe --home \\?\C:\...\development\continuum\.airc \
+    //            daemon --socket C:\Users\joelt\.airc\runtime\airc-machine-...sock
+    //
+    // Downstream, all diagnosed separately as unrelated bugs before the cause
+    // was found: messages sent through the machine socket were served by the
+    // PROJECT identity, so they landed in a scope the intended peer was not
+    // enrolled in (a one-way mirror — our sends left, their replies could not
+    // arrive); the wrong scope means a different `peer_id`, hence a different
+    // `stable_lan_port`, so the advertised endpoint moved and peers' stored
+    // endpoints went stale (read from the far side as "SYN dropped / stale
+    // ports / firewall"); and the event store read as a monologue because it
+    // was the other scope's store.
+    //
+    // Deriving it here rather than at the call sites keeps ONE rule: the
+    // daemon serving a socket is always the scope that owns it.
+    let daemon_home = airc_lib::machine_account_home(home);
     let mut command = Command::new(exe);
     command
         .arg("--home")
-        .arg(home)
+        .arg(&daemon_home)
         .arg("daemon")
         .arg("--socket")
         .arg(&socket)
@@ -1440,6 +1469,43 @@ pub async fn run_daemon(
     peers: Vec<PeerSpec>,
     socket: PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // REFUSE a socket this home does not own.
+    //
+    // A daemon serves ONE scope's identity to every client that attaches. If
+    // its `--home` is not the home the socket resolves from, it serves the
+    // wrong identity to everyone — silently, while looking completely healthy.
+    // That is not a degraded mode worth limping in; it is a wrong answer to
+    // every question, so it fails at startup instead of running.
+    //
+    // This is the guard that was missing on 2026-08-12. The spawn passed the
+    // caller's project home through to a machine-account socket, and NOTHING
+    // objected: daemon up, routes healthy, doctor 10/10 clean, while sends
+    // went into a scope the intended peer was not enrolled in. Two operators
+    // spent a night diagnosing the symptoms (stale ports, dropped SYNs, a
+    // monologue event store, a phantom "inbound not persisting" bug) because
+    // the one condition that explained all of them was never checked.
+    //
+    // The spawn is now correct, so this can only fire on a hand-rolled
+    // invocation — which is exactly when a human needs to be told, by name,
+    // which two scopes disagree.
+    let owning_home = airc_lib::machine_account_home(home);
+    let expected_socket = crate::cli::default_socket_path_in(&owning_home);
+    if socket != expected_socket {
+        return Err(format!(
+            "refusing to serve a socket this scope does not own.\n  \
+             --home  {}\n  \
+             --socket {}\n  \
+             this home's socket is {}\n\
+             A daemon serves ITS home's identity to every client on that socket, so \
+             serving a foreign one silently gives every caller the wrong peer_id, the \
+             wrong rooms, and the wrong advertised endpoint. Start the daemon with the \
+             home that owns the socket, or let `airc join` spawn it.",
+            home.display(),
+            socket.display(),
+            expected_socket.display(),
+        )
+        .into());
+    }
     // Card 800ce5bd: install a tracing subscriber so the existing
     // `tracing::warn!` / `tracing::info!` calls in airc-bus, airc-lib,
     // airc-relay, etc. actually emit. Before this, every tracing call

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1535,21 +1535,27 @@ pub async fn run_daemon(
     // The spawn is now correct, so this can only fire on a hand-rolled
     // invocation — which is exactly when a human needs to be told, by name,
     // which two scopes disagree.
+    // The invariant that is actually derivable HERE: a daemon's home must
+    // BE a machine-account root, not a project scope that merely resolves
+    // to one. `machine_account_home` is idempotent on a real machine home,
+    // so `machine_account_home(home) != home` is exactly "this is somebody
+    // else's scope". The socket path can NOT be re-derived for comparison —
+    // `resolve_socket_path` takes the scope home AND the machine home, so
+    // the same socket is minted from many scopes by design.
     let owning_home = airc_lib::machine_account_home(home);
-    let expected_socket = crate::cli::default_socket_path_in(&owning_home);
-    if socket != expected_socket {
+    if owning_home != home {
         return Err(format!(
             "refusing to serve a socket this scope does not own.\n  \
              --home  {}\n  \
              --socket {}\n  \
-             this home's socket is {}\n\
+             this home's machine account is {}\n\
              A daemon serves ITS home's identity to every client on that socket, so \
              serving a foreign one silently gives every caller the wrong peer_id, the \
              wrong rooms, and the wrong advertised endpoint. Start the daemon with the \
              home that owns the socket, or let `airc join` spawn it.",
             home.display(),
             socket.display(),
-            expected_socket.display(),
+            owning_home.display(),
         )
         .into());
     }

--- a/crates/airc-cli/src/doctor/delivery.rs
+++ b/crates/airc-cli/src/doctor/delivery.rs
@@ -53,8 +53,34 @@ const NO_RTT_GRACE_MS: u64 = 2_000 * RTT_GRACE_MULTIPLE;
 const _: () = assert!(NO_RTT_GRACE_MS >= 50 * RTT_GRACE_MULTIPLE);
 const _: () = assert!(NO_RTT_GRACE_MS <= 2_000 * RTT_GRACE_MULTIPLE);
 
+/// Which peers are THIS operator's own machines.
+///
+/// A `TrustTier::OwnAccount` ack proves the loopback: our own node received our
+/// own broadcast. It says nothing about whether any OTHER operator's node did.
+/// Returning a set (rather than filtering here) keeps the caller free to report
+/// per tier instead of hiding self-traffic — self-acks are real, they are just
+/// not evidence of a grid.
+async fn own_account_peers(home: &Path) -> std::collections::HashSet<airc_core::PeerId> {
+    airc_trust::load(home)
+        .await
+        .map(|peers| {
+            peers
+                .into_iter()
+                .filter(|peer| peer.tier == airc_store::TrustTier::OwnAccount)
+                .map(|peer| peer.peer_id)
+                .collect()
+        })
+        // A trust-store read failure must not silently reclassify every peer as
+        // cross-machine — that is the direction that INVENTS proof. An empty set
+        // means nothing is marked self, so every ack reports as cross-operator
+        // and the operator sees an over-claim rather than a hidden one... which
+        // is still wrong, so the caller states the tier it used.
+        .unwrap_or_default()
+}
+
 async fn check_delivery_truth(home: &Path) -> Vec<Finding> {
     let socket = crate::cli::default_socket_path_in(home);
+    let own = own_account_peers(home).await;
     let stats = match airc_ipc::DaemonClient::new(socket).delivery_stats().await {
         Ok(response) => response.peers,
         Err(error) => {
@@ -178,15 +204,87 @@ async fn check_delivery_truth(home: &Path) -> Vec<Finding> {
                     )),
                 }
             }
-            (false, None) => findings.push(Finding::ok(
+            // NEVER CONFIRMED is a different TYPE of fact, not a milder degree
+            // of one. `last_ack_ms == None` is not "the last ack is old", it is
+            // "there has never been an ack" — so there is nothing to be within
+            // tolerance OF: tolerance derives from the peer's measured rtt, and
+            // a peer that never acked has no rtt. The old arm applied a
+            // tolerance that cannot exist and stamped `ok` at ANY attempt count.
+            //
+            // Measured on BIGMAMA 2026-08-12: 63 attempts, zero confirmations,
+            // printed `[ok] within tolerance` — for a peer whose daemon was
+            // serving a different scope entirely and could not have received
+            // any of them.
+            //
+            // No attempt threshold, deliberately. This file's own rule is that
+            // the ledger holds the evidence and no arbitrary constant is needed;
+            // picking "N is fine, N+1 is not" would be exactly that constant.
+            // The honest report is the type: UNPROVEN. The count is printed so
+            // the reader can weigh how much was lost.
+            (false, None) => findings.push(Finding::warn(
                 "delivery truth",
                 format!(
-                    "{}: {} attempt(s), none confirmed yet (within tolerance)",
+                    "{}: UNPROVEN - {} attempt(s), never once confirmed. \
+                     Nothing sent to this peer can be shown to have arrived.",
                     peer.peer_id, peer.attempts
                 ),
+                "a new route clears this on its first ack; if it does not, check you are in \
+                 the scope the peer is enrolled in (`airc peers`) and that the daemon serves \
+                 THAT scope, then `airc transport health` for the dial errors",
             )),
         }
     }
+    // SELF IS NOT OTHER. A confirmed delivery to one of THIS operator's own
+    // machines proves the loopback — our node received our own broadcast — and
+    // says nothing about whether any other operator's node did.
+    //
+    // Measured on BIGMAMA 2026-08-12, and it cost a night: doctor reported
+    // `[ok] delivery truth: 2f0aed7f … rtt ~93ms (4 of 4 acked)` and it was
+    // read, by me, as "airc delivery is proven". `2f0aed7f` is tier=OwnAccount.
+    // There were FORTY own-account peers on that scope. Every ack was this node
+    // acking itself, while zero frames had ever reached the intended peer —
+    // whose daemon, it turned out, was serving a different scope entirely.
+    //
+    // Per-tier partition rather than filtering self out (M5's shape, and it is
+    // the better one): self-acks are REAL and worth printing — they prove the
+    // local pipe — they are just not grid evidence. Hiding them would trade one
+    // wrong impression for another.
+    let (self_acked, grid_acked): (Vec<_>, Vec<_>) = stats
+        .iter()
+        .filter(|peer| peer.acked > 0)
+        .partition(|peer| own.contains(&peer.peer_id));
+    if grid_acked.is_empty() {
+        if self_acked.is_empty() {
+            findings.push(Finding::warn(
+                "cross-operator delivery",
+                "NO delivery confirmed to any peer, own-account or otherwise".to_string(),
+                "nothing here proves the wire works; send one message and re-run",
+            ));
+        } else {
+            findings.push(Finding::warn(
+                "cross-operator delivery",
+                format!(
+                    "NONE CONFIRMED. {} own-account peer(s) acked (that is the LOOPBACK - this \
+                     node receiving its own broadcasts), and {} non-self peer(s) never did. \
+                     Self-acks are not grid delivery.",
+                    self_acked.len(),
+                    stats.len().saturating_sub(self_acked.len()),
+                ),
+                "check `airc peers` for the peer's tier, and that the daemon's --home is the \
+                 scope that peer is enrolled in",
+            ));
+        }
+    } else {
+        findings.push(Finding::ok(
+            "cross-operator delivery",
+            format!(
+                "{} non-self peer(s) confirmed ({} own-account ack(s) excluded as loopback)",
+                grid_acked.len(),
+                self_acked.len()
+            ),
+        ));
+    }
+
     findings
 }
 

--- a/crates/airc-cli/src/doctor/health.rs
+++ b/crates/airc-cli/src/doctor/health.rs
@@ -72,10 +72,54 @@ async fn check_health(home: &Path) -> Vec<Finding> {
         .iter()
         .filter(|sample| sample.state != TransportHealthState::Healthy)
         .count();
-    if degraded == 0 {
+    // UNMEASURED IS NOT HEALTHY.
+    //
+    // `TransportHealthState::Healthy` with `rtt_ms: None` and
+    // `success_ppm: None` means "optimistically marked usable, never actually
+    // exercised" — `airc transport health` prints it honestly as
+    // `state=healthy (not measured)`. Doctor counted those rows toward
+    // "N route(s) healthy", so a route that had never carried a single frame
+    // reported as proof the wire works.
+    //
+    // Measured on BIGMAMA 2026-08-12: `[ok] route health: 1 route(s) healthy`
+    // on a lan-tcp row with no rtt and no success rate, while every frame this
+    // node sent went to a peer it could not reach. The count was true and the
+    // conclusion it invited was false.
+    //
+    // Same family as the delivery-truth self-ack fix in this branch, one layer
+    // up: there, SELF was rendered as OTHER; here, UNMEASURED is rendered as
+    // MEASURED. Both let a green board describe a dead wire.
+    //
+    // Not downgraded to a warning on its own — an unmeasured route is not a
+    // fault, it is an unknown, and a fresh route legitimately starts here. It
+    // is simply not evidence, so it is counted and named separately.
+    let unmeasured = snapshot
+        .health
+        .iter()
+        .filter(|sample| {
+            sample.state == TransportHealthState::Healthy
+                && sample.rtt_ms.is_none()
+                && sample.success_ppm.is_none()
+        })
+        .count();
+    if degraded == 0 && unmeasured == total {
+        vec![Finding::warn(
+            "route health",
+            format!(
+                "{total} route(s) present but NONE MEASURED - no rtt, no success rate, \
+                 so nothing here shows a frame has ever crossed"
+            ),
+            "send one message and re-run; a route that stays unmeasured while peers are \
+             enrolled is not carrying traffic",
+        )]
+    } else if degraded == 0 {
         vec![Finding::ok(
             "route health",
-            format!("{total} route(s) healthy"),
+            if unmeasured > 0 {
+                format!("{total} route(s) healthy ({unmeasured} not yet measured)")
+            } else {
+                format!("{total} route(s) healthy")
+            },
         )]
     } else {
         vec![Finding::warn(

--- a/crates/airc-cli/src/sos_commands.rs
+++ b/crates/airc-cli/src/sos_commands.rs
@@ -291,6 +291,36 @@ fn parse_comments(raw: &str) -> Result<Vec<SosComment>, Box<dyn Error>> {
 /// One poll: fetch comments, print any past the cursor that are NOT our
 /// own, advance the cursor to the highest id seen. Returns the number of
 /// peer comments printed.
+/// One SOS poll for the ALWAYS-ON fallback that rides along with `airc join`.
+///
+/// Same cursor and same self-filter as `airc sos watch`, on purpose: the
+/// automatic path and the manual one must not disagree about what has already
+/// been seen, or an operator who runs `watch` after a join would be shown
+/// nothing and conclude the channel is empty.
+///
+/// Prints peer posts under a marker, because a message arriving here means the
+/// LIVE WIRE did not carry it — the reader needs to know which channel they are
+/// looking at before they act on the content.
+pub(crate) async fn poll_fallback_once(home: &Path) -> Result<usize, Box<dyn Error>> {
+    let label = node_label(home).await?;
+    // Resolve, never CREATE, from the automatic path: an unattended join must
+    // not mint an SOS gist on the operator's account as a side effect of
+    // starting up. `airc sos send` creates it deliberately, when a human or an
+    // agent has something to say.
+    let Some(gist_id) = find_sos_gist()? else {
+        return Ok(0);
+    };
+    let cursor_path = watch_cursor_path(home);
+    let printed = poll_once(&gist_id, &label, &cursor_path)?;
+    if printed > 0 {
+        eprintln!(
+            "airc: {printed} message(s) above arrived over the SOS fallback, NOT the live wire \
+             — the mesh did not carry them. `airc doctor --health` for why."
+        );
+    }
+    Ok(printed)
+}
+
 fn poll_once(gist_id: &str, my_label: &str, cursor_path: &Path) -> Result<usize, Box<dyn Error>> {
     let comments = fetch_comments(gist_id)?;
     let cursor = read_cursor(cursor_path);

--- a/install.ps1
+++ b/install.ps1
@@ -546,6 +546,48 @@ if ($ghAvail -and $gitAvail) {
     }
 }
 
+# -- Mesh autostart ------------------------------------------------------
+#
+# An unsupervised daemon dying is the STEADY STATE, not an edge case: a
+# Windows Update reboot, a crash, or a closed shell all end it, and nothing
+# brought it back. Measured on BIGMAMA 2026-08-12 - a scheduled servicing
+# reboot took the node off the mesh and it stayed off until a human noticed
+# hours later. Every "peer unreachable" in that window was this.
+#
+# The INSTALLER registers it, deliberately. The same lifecycle was first
+# hand-rolled onto one operator's machine, which is worse than not having
+# it: the operator's box stops exhibiting the bug, so it reads as fixed,
+# while every other node keeps dropping off the mesh exactly as before.
+#
+# User-scoped (no elevation), idempotent (-Force replaces), and self-healing:
+# RestartCount 999 at 2-minute intervals so a crash loop recovers without a
+# human; ExecutionTimeLimit 0 because a mesh daemon is meant to run forever;
+# IgnoreNew so re-running this installer cannot stack duplicate daemons -
+# which matters more than it sounds, because two daemons racing the same
+# identity-derived port is how a node ends up on an ephemeral one and stales
+# every peer's stored endpoint for it.
+Write-Host ''
+Write-Host '  Mesh autostart'
+Write-Host '  --------------'
+try {
+    $aircExe = (Get-Command airc -ErrorAction Stop).Source
+    $action   = New-ScheduledTaskAction -Execute $aircExe -Argument 'join' -WorkingDirectory $HOME
+    $trigger  = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable `
+        -RestartInterval (New-TimeSpan -Minutes 2) -RestartCount 999 `
+        -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew
+    Register-ScheduledTask -TaskName 'airc-join' -Action $action -Trigger $trigger `
+        -Settings $settings -Force `
+        -Description 'Keep this node on the airc mesh: start the scope daemon at logon, restart it if it dies.' | Out-Null
+    Write-Ok "autostart registered (task 'airc-join' - at logon, auto-restart)"
+} catch {
+    # Never fail the install for this. A node without autostart still works
+    # when started by hand; a failed install leaves the operator nothing.
+    Write-Warn2 "could not register the autostart task: $($_.Exception.Message)"
+    Write-Warn2 "airc still works - run 'airc join' by hand, or re-run this installer from a normal session"
+}
+
 # -- Final guidance ------------------------------------------------------
 Write-Host ''
 Write-Ok 'airc installed.'


### PR DESCRIPTION
The 2026-08-12 blackout was one line, and nothing detected it.

`default_socket_path_in` resolves through `machine_account_home`, so a caller in a git-project scope legitimately shares the **machine-account socket** — one daemon per machine is the design. But the spawn forwarded the **caller's** home, so whichever scope started the daemon first imposed its identity on every scope that later attached:

```
airc.exe --home \?\C:\...\development\continuum\.airc          daemon --socket C:\Users\joelt\.airc\runtime\airc-machine-...sock
```

`--home` is the project scope; `--socket` belongs to the machine account. A daemon serves ONE identity to every client on its socket.

## What it caused — each diagnosed separately as its own bug

- Sends landed in a scope the intended peer was not enrolled in: a **one-way mirror**. Our messages left; their replies could not arrive.
- Wrong scope ⇒ different `peer_id` ⇒ different `stable_lan_port` ⇒ advertised endpoint moved every restart, so peers' stored endpoints went stale. From the far side that reads as *"stale ports / SYN dropped / add a firewall rule."*
- The event store read as a monologue, because it was the other scope's store.

## Two fixes

1. **Spawn the right home** — derive the daemon's home from the socket's owner instead of forwarding the caller's. One rule: the daemon serving a socket is always the scope that owns it.
2. **Refuse a foreign socket** — `run_daemon` fails at startup when its home isn't the socket's owner, naming both paths. This is the guard that was missing: daemon up, routes healthy, `doctor` **10/10 clean**, and every answer wrong.

## What it was NOT

Wrong causes were published twice while chasing this, so they're worth killing explicitly: **not** the firewall (inbound rules already allowed the exe on any port/profile), **not** a missing stable-port mechanism (`stable_lan_port(peer_id)` exists and is correct), **not** a hardcoded port, **not** inbound messages failing to persist (that was #1341 blinding a 300-event query).

`cargo check -p airc-cli` clean.