### PR TITLE
fix(msg): an unnamed roster cannot prove absence — 'cannot verify', never 'not seen'

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1004,6 +1004,14 @@ async fn mention_audience_warning(
         )
         .await
         .ok()?;
+    // A roster whose members have published NO names cannot answer "is this
+    // peer here" — every match must fail, so asserting absence would be a
+    // fabricated negative. Live 2026-08-12: this warning fired against a peer
+    // who demonstrably speaks in the room, because her identity card was
+    // unpublished (#262). Absence of evidence, reported as evidence, is the
+    // exact class this whole receipt family exists to kill — so when nobody
+    // is named, say what is actually known.
+    let anybody_named = roster.iter().any(|m| m.display_name.is_some());
     let needle = mention.to_ascii_lowercase();
     let heard = roster.iter().any(|member| {
         member
@@ -1016,14 +1024,22 @@ async fn mention_audience_warning(
                 .to_ascii_lowercase()
                 .starts_with(&needle)
     });
-    (!heard).then(|| {
-        format!(
-            "⚠ '@{mention}' has not been seen in '{channel_name}' (48h presence window) — \
-             if they are not subscribed to this room they will NEVER receive this. \
-             Check where they speak (`airc events list --limit 5000 --kind message`) \
-             and send in a room they read, e.g. `airc msg --room general ...`."
-        )
-    })
+    if heard {
+        return None;
+    }
+    if !anybody_named {
+        return Some(format!(
+            "⚠ cannot verify '@{mention}' reaches '{channel_name}': no member of this room \
+             has published an identity card, so a name match cannot succeed either way \
+             (#262). Confirm with `airc events list --limit 5000 --kind message`."
+        ));
+    }
+    Some(format!(
+        "⚠ '@{mention}' has not been seen in '{channel_name}' (48h presence window) — \
+         if they are not subscribed to this room they will NEVER receive this. \
+         Check where they speak (`airc events list --limit 5000 --kind message`) \
+         and send in a room they read, e.g. `airc msg --room general ...`."
+    ))
 }
 
 /// `send` — local-fs single-shot send to the current room. Routes


### PR DESCRIPTION
Dogfooded against a live peer within an hour of shipping #1345: the mention warning fired for a peer who demonstrably speaks in that room. The roster joins presence with *published identity*, and that peer has never published an identity card (#262) — so no name match can succeed, and the check turned "nobody here is named" into "this person is not here."

Absence of evidence rendered as a positive fact is precisely the class this receipt family exists to kill (#1344, #351, delivery truth). When no member of the room has a published name, the warning now says what is actually known and points at the deep query; the confident wording survives only where a match was possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo