### PR TITLE
fix(store): the pool acquire timeout is a deadlock backstop, not a load limiter

### DIFF
--- a/crates/airc-store/src/bus_sink.rs
+++ b/crates/airc-store/src/bus_sink.rs
@@ -41,6 +41,20 @@ use airc_core::{ClientId, EventId, Headers, PeerId, RoomId};
 
 use crate::entities::bus_event;
 
+/// Deadlock backstop for the single-connection pool — NOT a load limit.
+///
+/// These pools are `max_connections(1)`: concurrent callers queue by
+/// design, so a caller waiting is normal operation, not a fault. At the
+/// previous 5s this timeout behaved as a load limiter and turned routine
+/// queuing into a hard error — it took down `peer_add_with_tier_flag_
+/// persists_explicit_tier` on windows CI (2026-08-12) with "pool timed
+/// out while waiting for an open connection" during `airc init`, a
+/// failure that has nothing to do with the code under test. A backstop
+/// should only fire when something is genuinely stuck, so it is sized
+/// for the slowest legitimate wait (loaded CI, cold Windows I/O),
+/// leaving real deadlocks still bounded.
+const POOL_ACQUIRE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// SQLite-backed durable tier for the owner-core (§3.3).
 ///
 /// Single-writer (the daemon owns it) + WAL — exactly the SQLite shape
@@ -61,7 +75,7 @@ impl SqliteDurableSink {
         // Single writer (the daemon). One connection avoids SQLite
         // write-lock contention entirely (§3.3).
         opts.connect_timeout(std::time::Duration::from_secs(5))
-            .acquire_timeout(std::time::Duration::from_secs(5))
+            .acquire_timeout(POOL_ACQUIRE_TIMEOUT)
             .max_connections(1);
         let db = Database::connect(opts)
             .await

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -44,6 +44,20 @@ use crate::scoped_state::StoredScopedState;
 use crate::store::EventStore;
 use crate::subscriptions::StoredSubscription;
 
+/// Deadlock backstop for the single-connection pool — NOT a load limit.
+///
+/// These pools are `max_connections(1)`: concurrent callers queue by
+/// design, so a caller waiting is normal operation, not a fault. At the
+/// previous 5s this timeout behaved as a load limiter and turned routine
+/// queuing into a hard error — it took down `peer_add_with_tier_flag_
+/// persists_explicit_tier` on windows CI (2026-08-12) with "pool timed
+/// out while waiting for an open connection" during `airc init`, a
+/// failure that has nothing to do with the code under test. A backstop
+/// should only fire when something is genuinely stuck, so it is sized
+/// for the slowest legitimate wait (loaded CI, cold Windows I/O),
+/// leaving real deadlocks still bounded.
+const POOL_ACQUIRE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 pub struct SqliteEventStore {
     db: DatabaseConnection,
 }
@@ -60,7 +74,7 @@ impl SqliteEventStore {
         // Keep timeouts predictable for tests — long enough to absorb
         // a slow CI box, short enough to fail fast on a bad URL.
         opts.connect_timeout(std::time::Duration::from_secs(5))
-            .acquire_timeout(std::time::Duration::from_secs(5))
+            .acquire_timeout(POOL_ACQUIRE_TIMEOUT)
             .max_connections(1);
         // Card 127816bd Phase 1.C — chat throughput.
         //


### PR DESCRIPTION
**The brittleness signature: a real defect masquerading as a flake.**

`peer_add_with_tier_flag_persists_explicit_tier` failed on windows CI tonight with `pool timed out while waiting for an open connection` during `airc init` — on a PR (#1348) whose diff is pure roster string logic and never touches an identity store. The normal response is "windows flake, re-run". It isn't.

These pools are `max_connections(1)`. Concurrent callers **queue by design**, so a caller waiting is normal operation, not a fault. At 5s the acquire timeout was acting as a *load limiter* — routine queuing under parallel test load became a hard error. A backstop should only fire when something is genuinely stuck.

Now a named constant sized for the slowest legitimate wait (loaded CI, cold Windows I/O), with the reasoning at the definition so the next person tuning it knows what it's for. Real deadlocks stay bounded.

Applies to `sqlite.rs` and `bus_sink.rs` (identical pool config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo