### PR TITLE
fix(ci): cap test concurrency — the gate itself was nondeterministic (#404)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -211,7 +211,30 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
+      # #404 — THE GATE ITSELF WAS UNRELIABLE. Measured 2026-08-12:
+      # three consecutive runs on two PRs (whose diffs were roster string
+      # logic and one pool constant) failed FOUR DIFFERENT daemon tests
+      # with zero overlap — peer_add_with_tier_flag ("pool timed out"),
+      # daemon_survives_shutdown_and_restart, healed_identity_rebinds_
+      # stale_subscription, cursors_stay_monotonic. Not one defect: a
+      # suite that is nondeterministic under this runner.
+      #
+      # Cause is capacity, not logic. These are INTEGRATION tests that
+      # spawn REAL daemon processes, bind sockets and open SQLite; the
+      # default harness runs every test binary concurrently with one
+      # thread per core on top of that. A 2-core hosted runner — with
+      # Windows' slower process spawn and file locking — cannot carry
+      # that many live daemons at once, so waits that are comfortable on
+      # a dev box expire in CI. Capping concurrency matches the harness
+      # to the machine; it is not a timeout band-aid.
+      #
+      # A red gate is worse than a slow one: when green carries no
+      # information, real regressions pass and every PR needs a re-run
+      # war. Acceptance for this change is N CONSECUTIVE green runs,
+      # never a single lucky pass.
       - name: cargo test --workspace --all-features
+        env:
+          RUST_TEST_THREADS: "2"
         run: cargo test --workspace --all-features
       # Card f122b5b5 ZERO-LEAK GUARD (see matrix job for rationale).
       - name: zero leaked temp-home daemons
@@ -316,7 +339,30 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
+      # #404 — THE GATE ITSELF WAS UNRELIABLE. Measured 2026-08-12:
+      # three consecutive runs on two PRs (whose diffs were roster string
+      # logic and one pool constant) failed FOUR DIFFERENT daemon tests
+      # with zero overlap — peer_add_with_tier_flag ("pool timed out"),
+      # daemon_survives_shutdown_and_restart, healed_identity_rebinds_
+      # stale_subscription, cursors_stay_monotonic. Not one defect: a
+      # suite that is nondeterministic under this runner.
+      #
+      # Cause is capacity, not logic. These are INTEGRATION tests that
+      # spawn REAL daemon processes, bind sockets and open SQLite; the
+      # default harness runs every test binary concurrently with one
+      # thread per core on top of that. A 2-core hosted runner — with
+      # Windows' slower process spawn and file locking — cannot carry
+      # that many live daemons at once, so waits that are comfortable on
+      # a dev box expire in CI. Capping concurrency matches the harness
+      # to the machine; it is not a timeout band-aid.
+      #
+      # A red gate is worse than a slow one: when green carries no
+      # information, real regressions pass and every PR needs a re-run
+      # war. Acceptance for this change is N CONSECUTIVE green runs,
+      # never a single lucky pass.
       - name: cargo test --workspace --all-features
+        env:
+          RUST_TEST_THREADS: "2"
         run: cargo test --workspace --all-features
       # Card f122b5b5 ZERO-LEAK GUARD: the acceptance is that a full
       # `cargo test --workspace` leaves ZERO airc daemon processes whose


### PR DESCRIPTION
**Three consecutive runs, four different daemon tests, zero overlap**, on two PRs whose diffs were roster string logic and one pool constant:

| run | failed |
|---|---|
| 1 | `peer_add_with_tier_flag_persists_explicit_tier` — "pool timed out while waiting for an open connection" |
| 2 | `daemon_survives_shutdown_and_restart_with_durable_history_intact` |
| 3 | `healed_identity_rebinds_stale_subscription_to_the_converged_room` + `cursors_stay_monotonic_across_local_and_bridged_events` |

That is not a set of bugs. It is a suite that is nondeterministic under the hosted runner.

**Cause is capacity, not logic.** These are integration tests that spawn REAL daemon processes, bind sockets and open SQLite — and the default harness runs every test binary concurrently with a thread per core on top of that. A 2-core runner (Windows especially: slower process spawn, harder file locks) cannot carry that many live daemons, so waits that are comfortable on a dev box expire in CI. Capping concurrency matches the harness to the machine; it is not a timeout band-aid.

**Why this outranks the bugs it was masking:** the gate decides what reaches canary. When it fails randomly, no PR lands without a re-run war, a GREEN result carries no information so real regressions can pass, and both maintainers spend their sessions re-running instead of building.

Acceptance is **N consecutive green runs**, not one lucky pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
