### PR TITLE
airc update from a project scope takes the node DARK — the second daemon spawn site

### DIFF
--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -595,10 +595,33 @@ fn wait_daemon_ready(
 }
 
 fn daemon_command(airc_exe: &Path, home: &Path, subcommand: &str, socket: &Path) -> Command {
+    // THE SECOND SPAWN SITE. `commands.rs::ensure_daemon_running` was fixed to
+    // start the daemon under the home that OWNS the socket; this one was not,
+    // and it is the path `airc update` uses to bring the daemon back after
+    // replacing the binary.
+    //
+    // Measured immediately after the ownership guard landed on canary, running
+    // `airc update` from a git-project scope:
+    //
+    //   Updated (canary): binary f5976b4 -> 6294c35
+    //   airc: daemon did not become ready after update:
+    //     \\?\C:\Users\joelt\development\continuum\.airc
+    //
+    // The guard did its job — that IS a foreign scope for the machine-account
+    // socket — and the node went dark, because the updater had spawned the
+    // daemon with the caller's project home. So updating from a project
+    // directory took the node OFF the mesh, which is the failure the guard
+    // exists to prevent, arriving through the door the guard could not watch.
+    //
+    // One rule, now applied at every spawn: the daemon serving a socket is the
+    // scope that owns it. Fixing it at both sites rather than relaxing the
+    // guard — a guard that has to be weakened to accommodate a caller is a
+    // guard that will be weakened again.
+    let owning_home = airc_lib::machine_account_home(home);
     let mut command = Command::new(airc_exe);
     command
         .arg("--home")
-        .arg(home)
+        .arg(&owning_home)
         .arg(subcommand)
         .arg("--socket")
         .arg(socket);


### PR DESCRIPTION
**Critical: `airc update` run from a git-project directory kills the daemon and the node leaves the mesh.**

`commands.rs::ensure_daemon_running` was fixed to spawn the daemon under the home that OWNS the socket. `update_commands.rs::daemon_command` was not — and that's the path `airc update` uses to restart the daemon after swapping the binary.

Measured on BIGMAMA minutes after the ownership guard reached canary:

```
Updated (canary): binary f5976b4 -> 6294c35
airc: daemon did not become ready after update:
  \?\C:\Users\joelt\development\continuum\.airc
```

The guard did exactly its job — that **is** a foreign scope for the machine-account socket — and the node went dark. So updating from a project directory takes the machine off the mesh: the precise failure the guard exists to prevent, arriving through the one door the guard couldn't watch.

The SOS fallback stopped being polled at the same instant, because the daemon it rides on was gone. **An unmonitored channel, caused by the fix for unmonitored channels.**

## Fixed at the spawn, not by relaxing the guard

A guard that gets weakened to accommodate a caller is a guard that will be weakened again — and this one is load-bearing, since a daemon serving a foreign scope is what produced the original one-way mirror.

One rule, now at every spawn site: **the daemon serving a socket is the scope that owns it.** Two sites were enough to miss one; a third should call a shared helper rather than re-derive.

`cargo check -p airc-cli` clean.