### PR TITLE
feat(gh): GhClient.issue_view — the first ISSUE verb, as the outlier-B check on the trait (#356)

### DIFF
--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -29,8 +29,9 @@ use async_trait::async_trait;
 use tokio::process::Command;
 
 pub use airc_lib::gh::client::{
-    parse_pr_url, parse_pr_view, BranchCheckRollupArgs, GhCheck, GhClient, GhError, MergeReceipt,
-    PrCreateArgs, PrCreated, PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
+    parse_issue_view, parse_pr_url, parse_pr_view, BranchCheckRollupArgs, GhCheck, GhClient,
+    GhError, IssueView, IssueViewArgs, MergeReceipt, PrCreateArgs, PrCreated, PrEditBaseArgs,
+    PrMergeArgs, PrView, PrViewArgs,
 };
 // parse_check_runs is only used inside merger's #[cfg(test)] block — accessed
 // via the airc_lib path there to avoid a "unused re-export" lint in non-test
@@ -151,6 +152,31 @@ impl GhClient for ShellGhClient {
             return Err(classify_gh_failure(&output));
         }
         airc_lib::gh::client::parse_check_runs(&output.stdout)
+    }
+
+    /// Card #356. Same addressing and the same failure classification
+    /// as the PR verbs — `--json` field list mirrors what
+    /// [`IssueView`] deserializes, so a gh schema drift surfaces as a
+    /// loud `JsonParse` rather than a silently empty body (which the
+    /// closer would read as "no envelope, skip this card").
+    async fn issue_view(&self, args: IssueViewArgs) -> Result<IssueView, GhError> {
+        let output = Command::new("gh")
+            .args([
+                "issue",
+                "view",
+                &args.number.to_string(),
+                "--repo",
+                args.repo.as_str(),
+                "--json",
+                "number,title,body,state",
+            ])
+            .output()
+            .await
+            .map_err(map_spawn_error)?;
+        if !output.status.success() {
+            return Err(classify_gh_failure(&output));
+        }
+        parse_issue_view(&output.stdout)
     }
 }
 

--- a/crates/airc-cli/src/gh_reqwest.rs
+++ b/crates/airc-cli/src/gh_reqwest.rs
@@ -8,8 +8,8 @@
 use async_trait::async_trait;
 
 use airc_lib::gh::client::{
-    BranchCheckRollupArgs, GhCheck, GhClient, GhError, MergeReceipt, PrCreateArgs, PrCreated,
-    PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
+    parse_issue_view, BranchCheckRollupArgs, GhCheck, GhClient, GhError, IssueView, IssueViewArgs,
+    MergeReceipt, PrCreateArgs, PrCreated, PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
 };
 use tokio::process::Command;
 
@@ -472,6 +472,28 @@ impl GhClient for ReqwestGhClient {
         } else {
             Err(map_http_error_status(resp.status(), resp).await)
         }
+    }
+
+    /// Card #356. `GET /repos/{owner}/{repo}/issues/{number}` — the
+    /// REST issue object already carries every field [`IssueView`]
+    /// needs, so unlike `pr_view` this is a SINGLE call with no
+    /// second rollup fetch.
+    ///
+    /// Deserialized through the shared [`parse_issue_view`] rather
+    /// than hand-built from a `Value`, so the null-body and
+    /// state-casing normalization live in ONE place and both
+    /// implementations are genuinely interchangeable — which is the
+    /// property the trait exists to provide.
+    async fn issue_view(&self, args: IssueViewArgs) -> Result<IssueView, GhError> {
+        let url = format!(
+            "{}/repos/{}/issues/{}",
+            self.api_base, args.repo, args.number
+        );
+        let response = self
+            .send_authed(reqwest::Method::GET, &url, NO_BODY)
+            .await?;
+        let json: serde_json::Value = handle_response(response).await?;
+        parse_issue_view(&serde_json::to_vec(&json)?)
     }
 
     async fn branch_check_rollup(

--- a/crates/airc-lib/src/gh/client.rs
+++ b/crates/airc-lib/src/gh/client.rs
@@ -138,6 +138,24 @@ pub trait GhClient: Send + Sync {
         &self,
         args: BranchCheckRollupArgs,
     ) -> Result<Vec<GhCheck>, GhError>;
+
+    /// `gh issue view <number> --repo <owner/name> --json number,title,body,state`.
+    ///
+    /// Card #356 — the queue-card closer needs the issue BODY to verify
+    /// the `airc-queue-card-v1` envelope and to apply the status-log
+    /// mutation before closing. Every verb above operates on pull
+    /// requests and none of them reads a body, so this is the first
+    /// ISSUE verb on the trait and the first that treats free-form
+    /// content as the payload.
+    ///
+    /// That makes it the deliberate outlier-B check on this trait's
+    /// shape (CLAUDE.md's methodical process): if `GhClient` only fit
+    /// PR-shaped operations, this is where it would have to be forced.
+    /// It is not forced — issues reuse `repo` + `number` addressing and
+    /// the same `GhError` classification — so the remaining closer
+    /// verbs (`issue_edit_body`, `issue_close`) are the same pattern
+    /// and are deliberately NOT built until a caller needs them.
+    async fn issue_view(&self, args: IssueViewArgs) -> Result<IssueView, GhError>;
 }
 
 #[derive(Debug, Clone)]
@@ -170,6 +188,61 @@ pub struct PrEditBaseArgs {
     pub repo: String,
     pub number: u64,
     pub base: String,
+}
+
+/// Address an issue the same way the PR verbs address a PR: `repo` +
+/// `number`. No `cwd` field — unlike `pr_create`, nothing here resolves
+/// a remote from a worktree, so offering one would be a lie.
+#[derive(Debug, Clone)]
+pub struct IssueViewArgs {
+    pub repo: String,
+    pub number: u64,
+}
+
+/// An issue as the queue-card closer needs it. `body` is the payload:
+/// the `airc-queue-card-v1` envelope lives there, and the closer both
+/// VERIFIES it (skip anything that isn't a queue card) and MUTATES it
+/// (status=merged + a status-log line) before closing.
+///
+/// `state` is the idempotence guard — a card already `CLOSED` is a
+/// silent skip, which is what makes the workflow safe to re-run.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct IssueView {
+    #[serde(default)]
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    /// An issue with no body serializes as JSON `null` on the REST API
+    /// (and as `""` from the gh CLI). Both mean "no envelope here,
+    /// skip this card", so both must deserialize — a bare
+    /// `#[serde(default)]` covers the MISSING key but still errors on
+    /// an explicit null, which would abort the workflow on the most
+    /// ordinary input there is.
+    #[serde(default, deserialize_with = "null_to_empty_string")]
+    pub body: String,
+    /// NORMALIZED UPPERCASE by every implementation. The gh CLI reports
+    /// `OPEN`/`CLOSED` (GraphQL-backed) while REST reports
+    /// `open`/`closed`; leaving that divergence in place would make the
+    /// closer's idempotence check silently implementation-dependent.
+    /// The trait's contract is the uppercase form.
+    #[serde(default, deserialize_with = "upper_state")]
+    pub state: String,
+}
+
+fn null_to_empty_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+fn upper_state<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?
+        .unwrap_or_default()
+        .to_uppercase())
 }
 
 #[derive(Debug, Clone)]
@@ -235,6 +308,18 @@ pub struct MergeReceipt {
 /// close-guard both depend on this shape, so this is where the
 /// schema round-trip is pinned in tests.
 pub fn parse_pr_view(json: &[u8]) -> Result<PrView, GhError> {
+    Ok(serde_json::from_slice(json)?)
+}
+
+/// Decode `gh issue view --json number,title,body,state`. Pure — JSON
+/// in, typed value out — so the closer's envelope/idempotence logic is
+/// unit-testable without a network or a `gh` binary. Card #356.
+///
+/// Every field is `#[serde(default)]` on [`IssueView`]: gh omits keys
+/// it has no value for, and an issue with an empty body is ordinary
+/// (a card whose envelope was stripped), not a parse failure. Failing
+/// there would turn a skippable non-card into a workflow abort.
+pub fn parse_issue_view(json: &[u8]) -> Result<IssueView, GhError> {
     Ok(serde_json::from_slice(json)?)
 }
 
@@ -368,6 +453,40 @@ pub fn parse_pr_url(stdout: &str) -> Result<PrCreated, GhError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// what this catches (#356): the two `GhClient` impls read the SAME
+    /// issue from DIFFERENT APIs — gh's CLI is GraphQL-backed and
+    /// reports `OPEN`/`CLOSED`, REST reports `open`/`closed`. The
+    /// closer's idempotence check ("already closed? skip") would then
+    /// silently depend on which backend was configured. The trait's
+    /// contract is the uppercase form; this pins it for both shapes.
+    #[test]
+    fn issue_view_state_is_normalized_uppercase_across_backends() {
+        let rest = parse_issue_view(br#"{"number":7,"title":"t","body":"b","state":"closed"}"#)
+            .expect("rest shape parses");
+        let cli = parse_issue_view(br#"{"number":7,"title":"t","body":"b","state":"CLOSED"}"#)
+            .expect("cli shape parses");
+        assert_eq!(rest.state, "CLOSED");
+        assert_eq!(cli.state, "CLOSED");
+        assert_eq!(rest, cli, "both backends must yield an identical IssueView");
+    }
+
+    /// what this catches (#356): REST sends `"body": null` for an issue
+    /// with no description, and a bare `#[serde(default)]` covers a
+    /// MISSING key but still errors on an explicit null. That would
+    /// abort the whole close-merged run on the most ordinary input
+    /// there is — an issue that simply has no body (hence no
+    /// queue-card envelope, hence a card the closer should SKIP).
+    #[test]
+    fn issue_view_tolerates_null_and_missing_body() {
+        let null_body = parse_issue_view(br#"{"number":1,"title":"t","body":null,"state":"open"}"#)
+            .expect("null body must parse, not abort the run");
+        assert_eq!(null_body.body, "");
+
+        let missing_body = parse_issue_view(br#"{"number":1,"title":"t","state":"open"}"#)
+            .expect("missing body parses");
+        assert_eq!(missing_body.body, "");
+    }
 
     #[test]
     fn parse_pr_view_decodes_all_fields() {
@@ -554,8 +673,8 @@ pub mod mock {
     use async_trait::async_trait;
 
     use super::{
-        BranchCheckRollupArgs, GhCheck, GhClient, GhError, MergeReceipt, PrCreateArgs, PrCreated,
-        PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
+        BranchCheckRollupArgs, GhCheck, GhClient, GhError, IssueView, IssueViewArgs, MergeReceipt,
+        PrCreateArgs, PrCreated, PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
     };
 
     /// Per-method response queue + per-method call record. All state
@@ -568,12 +687,14 @@ pub mod mock {
         pr_merge_queue: Mutex<VecDeque<Result<MergeReceipt, GhError>>>,
         pr_edit_base_queue: Mutex<VecDeque<Result<(), GhError>>>,
         branch_check_rollup_queue: Mutex<VecDeque<Result<Vec<GhCheck>, GhError>>>,
+        issue_view_queue: Mutex<VecDeque<Result<IssueView, GhError>>>,
 
         pr_view_calls: Mutex<Vec<PrViewArgs>>,
         pr_create_calls: Mutex<Vec<PrCreateArgs>>,
         pr_merge_calls: Mutex<Vec<PrMergeArgs>>,
         pr_edit_base_calls: Mutex<Vec<PrEditBaseArgs>>,
         branch_check_rollup_calls: Mutex<Vec<BranchCheckRollupArgs>>,
+        issue_view_calls: Mutex<Vec<IssueViewArgs>>,
     }
 
     impl MockGhClient {
@@ -605,6 +726,11 @@ pub mod mock {
                 .lock()
                 .unwrap()
                 .push_back(result);
+        }
+
+        /// Queue the next [`GhClient::issue_view`] outcome. FIFO. Card #356.
+        pub fn queue_issue_view(&self, result: Result<IssueView, GhError>) {
+            self.issue_view_queue.lock().unwrap().push_back(result);
         }
 
         // --- call records ---
@@ -642,6 +768,9 @@ pub mod mock {
         }
         pub fn received_branch_check_rollup_calls(&self) -> Vec<BranchCheckRollupArgs> {
             self.branch_check_rollup_calls.lock().unwrap().clone()
+        }
+        pub fn received_issue_view_calls(&self) -> Vec<IssueViewArgs> {
+            self.issue_view_calls.lock().unwrap().clone()
         }
     }
 
@@ -703,6 +832,15 @@ pub mod mock {
                 .unwrap()
                 .pop_front()
                 .unwrap_or_else(|| Err(unqueued("branch_check_rollup")))
+        }
+
+        async fn issue_view(&self, args: IssueViewArgs) -> Result<IssueView, GhError> {
+            self.issue_view_calls.lock().unwrap().push(args);
+            self.issue_view_queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Err(unqueued("issue_view")))
         }
     }
 


### PR DESCRIPTION
Slice 1 of #356, and deliberately **one verb**.

## Why this exists

`auto-close-queue-cards` has failed on every merge since ~Aug 5. Two breaks: it runs `./airc` (a repo-root dispatcher that no longer exists — this is a Rust workspace now), and it calls `queue close-merged <PR_URL> --merge-sha --actor`, a verb shape that exists in **no** form. The CLI has two file-based primitives that take `gh pr view` JSON and close nothing. The composing layer died with the dispatcher.

Joel ruled it gets rebuilt in Rust rather than workflow bash. The repo already agreed: `airc_lib::gh::client` owns a `GhClient` trait, `ShellGhClient` confines the `gh` spawn to one file, and `ReqwestGhClient` speaks REST directly. The YAML was the single caller routing around all of it.

## Why only one verb

Per CLAUDE.md's methodical process: build outlier A + outlier B, validate the interface fits **without forcing**, then stop. Every verb on this trait is PR-shaped. `issue_view` is the first that addresses an issue and the first whose payload is free-form body content — if `GhClient` only fit PRs, this is where it would have to be forced.

It isn't. Issues reuse `repo` + `number` addressing and the same `GhError` classification. So `issue_edit_body` and `issue_close` are the same pattern, and are **not** built until a caller needs them.

## What the slice surfaced

The backends disagree on the same field, and the trait was hiding it:

| | `state` | empty body |
|---|---|---|
| gh CLI (GraphQL-backed) | `OPEN` / `CLOSED` | `""` |
| REST | `open` / `closed` | `null` |

Left alone, the closer's idempotence check ("already closed? skip") would silently depend on which backend was configured, and a bodyless issue would abort the run through serde instead of being skipped — and a bodyless issue is the *most ordinary* input, since it just means "no queue-card envelope here."

Both normalized in one place (`parse_issue_view`), so the impls are genuinely interchangeable. That's the property the trait exists to provide, and it's exactly what an outlier-B slice is for.

## Scope

Three impls, because a trait method lands in all of them: `ShellGhClient`, `ReqwestGhClient`, `MockGhClient`.

## Gates

- `cargo fmt --all --check` clean
- `cargo clippy -p airc-lib -p airc-cli --all-targets -- -D warnings` clean
- airc-lib 347 tests (+2 new), airc-cli 345 tests — all green

Remaining on #356 (documented on the card, not started): `issue_edit_body`, `issue_close`, the `CloseMerged` composing subcommand, and the workflow rewrite to a single typed invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
