### PR TITLE
fix(cli): one RoomSelector for every room-scoped verb — airc inbox --room (#270)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -493,6 +493,38 @@ pub struct Cli {
     pub command: Command,
 }
 
+/// The `--room <NAME>` selector, declared ONCE for every room-scoped
+/// verb (`send`, `msg`, `publish`, `inbox`).
+///
+/// It used to be hand-copied per subcommand — three near-identical
+/// `room: Option<String>` fields with three near-identical doc
+/// comments, and `inbox` never got one at all. That asymmetry is not a
+/// missing flag, it is what a per-command declaration DOES: the writes
+/// could each name a room while the READ could only see whichever room
+/// the scope happened to be sitting in, so reading a subscribed room
+/// required `airc room <name>` — mutating shared scope state to perform
+/// a read (#270). One struct, flattened everywhere, means a new
+/// room-scoped verb inherits the flag instead of re-deriving it.
+///
+/// Resolution is likewise single-source: `Airc::room_by_name_or_channel`
+/// accepts a name OR a channel id, refuses loudly for a room this scope
+/// is not subscribed to, and NEVER auto-joins.
+#[derive(Debug, Args)]
+pub struct RoomSelector {
+    /// Channel name (or channel id) to act on. Must already be
+    /// subscribed — this never auto-joins. Defaults to the current
+    /// room. Using it does NOT move this scope's default-room pointer.
+    #[arg(long)]
+    pub room: Option<String>,
+}
+
+impl RoomSelector {
+    /// The room the caller named, if any. `None` means "the current room".
+    pub fn named(&self) -> Option<&str> {
+        self.room.as_deref()
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Create or load the persisted identity (`<home>/identity.key`
@@ -531,11 +563,8 @@ pub enum Command {
     /// as `airc publish --room`). Without `--room`, the default
     /// channel lives in the ORM store.
     Send {
-        /// Channel name to route to. Must already be subscribed
-        /// (send does not auto-join). Defaults to the current room
-        /// when omitted.
-        #[arg(long)]
-        room: Option<String>,
+        #[command(flatten)]
+        room: RoomSelector,
         /// Message body.
         text: String,
     },
@@ -637,11 +666,8 @@ pub enum Command {
     Msg {
         #[arg(long)]
         socket: Option<PathBuf>,
-        /// Channel name to route to. Must already be subscribed
-        /// (msg does not auto-join). Defaults to the current room
-        /// when omitted.
-        #[arg(long)]
-        room: Option<String>,
+        #[command(flatten)]
+        room: RoomSelector,
         /// Message body.
         text: String,
     },
@@ -653,11 +679,8 @@ pub enum Command {
     /// non-default room without mutating this scope's default
     /// pointer.
     Publish {
-        /// Channel name to route to. Must already be subscribed
-        /// (publish does not auto-join). Defaults to the current
-        /// room when omitted.
-        #[arg(long)]
-        room: Option<String>,
+        #[command(flatten)]
+        room: RoomSelector,
         /// Inline UTF-8 body. Mutually exclusive with
         /// `--body-json`.
         #[arg(long, conflicts_with = "body_json", group = "body")]
@@ -674,11 +697,15 @@ pub enum Command {
         kind: PublishFrameKind,
     },
 
-    /// Pull buffered frames from the daemon's inbox for the current
-    /// room's wire.
+    /// Pull buffered frames from a subscribed room's wire. With
+    /// `--room`, reads that room without mutating this scope's
+    /// default-room pointer — the read sibling of `airc msg --room`.
+    /// Without `--room`, reads the current room.
     Inbox {
         #[arg(long)]
         socket: Option<PathBuf>,
+        #[command(flatten)]
+        room: RoomSelector,
         /// Cursor lamport — pair with `--since-event-id`. The cursor
         /// is `(lamport, event_id)`; both halves required when paging
         /// from a specific point.

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -2530,6 +2530,7 @@ pub async fn run_msg(
 pub async fn run_inbox(
     home: &Path,
     socket: Option<PathBuf>,
+    room: Option<&str>,
     since_lamport: Option<u64>,
     since_event_id: Option<String>,
     limit: Option<usize>,
@@ -2541,6 +2542,15 @@ pub async fn run_inbox(
             Airc::attach(home, socket).await?
         }
         None => attached_airc(home).await?,
+    };
+    // `--room` reads a room this scope is subscribed to WITHOUT moving
+    // the default-room pointer — the read sibling of `airc msg --room`.
+    // Same resolver the writes use (name or channel id, loud refusal for
+    // an unsubscribed room, never auto-joins), so a room `msg --room` can
+    // reach is exactly a room `inbox --room` can read.
+    let room = match room {
+        Some(name) => airc.room_by_name_or_channel(name, "read").await?,
+        None => airc.current_room().await?,
     };
     // Both --since-lamport and --since-event-id must be supplied
     // together; the cursor is a tuple per grievance §7.
@@ -2559,28 +2569,33 @@ pub async fn run_inbox(
     };
     let effective_limit = limit.unwrap_or(32);
     let events = match since {
-        Some(cursor) => airc.resume_from(&cursor, effective_limit).await?,
-        None => airc.page_recent(effective_limit).await?,
+        Some(cursor) => airc.resume_from_in(&room, &cursor, effective_limit).await?,
+        None => airc.page_recent_in(&room, effective_limit).await?,
     };
-    // #270: `inbox` reads ONE room (the current one) — say so, loudly,
-    // and name what it is NOT showing. The unlabeled view is how "your
-    // message isn't in my inbox" became a false transport diagnosis
-    // twice in one day: the message was in the store the whole time,
-    // in a subscribed room that wasn't current.
+    // #270: `inbox` reads ONE room — say so, loudly, and name what it is
+    // NOT showing. The unlabeled view is how "your message isn't in my
+    // inbox" became a false transport diagnosis twice in one day: the
+    // message was in the store the whole time, in a subscribed room that
+    // wasn't current.
+    //
+    // The remedy this prints is now `--room <name>`, not `airc room
+    // <name>`: reading another room must not require MOVING this scope's
+    // default-room pointer. Telling the operator to switch rooms in order
+    // to read one was the bug wearing a label.
     if !as_json {
-        if let (Ok(current), Ok(set)) = (airc.current_room().await, airc.subscription_set().await) {
+        if let Ok(set) = airc.subscription_set().await {
             let others: Vec<String> = set
                 .all()
-                .filter(|s| s.name.as_str() != current.name)
+                .filter(|s| s.name.as_str() != room.name)
                 .map(|s| s.name.as_str().to_string())
                 .collect();
             if others.is_empty() {
-                println!("inbox: room '{}' (your only subscribed room)", current.name);
+                println!("inbox: room '{}' (your only subscribed room)", room.name);
             } else {
                 println!(
                     "inbox: room '{}' ONLY — {} other subscribed room(s) NOT shown: {} \
-                     (switch with `airc room <name>`)",
-                    current.name,
+                     (read one with `airc inbox --room <name>`)",
+                    room.name,
                     others.len(),
                     others.join(", ")
                 );

--- a/crates/airc-cli/src/gh_state.rs
+++ b/crates/airc-cli/src/gh_state.rs
@@ -38,10 +38,32 @@ pub(crate) fn reserve_guarded_request(
     // governor (two implementations over one budget file is the
     // registry_bridge smell).
     let cap = limit.saturating_sub(airc_lib::gh::governor::REGISTRY_FLOOR);
-    if count >= cap {
+    // SOS is the channel of last resort: it is what a human or agent
+    // reaches for precisely when the wire is down and the poller is hot.
+    // Starving it behind the same bucket as beacon/channel polling meant
+    // "airc sos watch" answered "budget exceeded" during the exact
+    // incident it exists to coordinate — observed live 2026-08-13, and
+    // it is why an operator concluded the emergency channel was dead.
+    // It gets its own reserve above the poller cap, mirroring the
+    // REGISTRY_FLOOR carve-out one tier down.
+    let effective_cap = if is_sos_request(args) {
+        cap + SOS_RESERVE
+    } else {
+        cap
+    };
+    if count >= effective_cap {
+        // Report when the LOCAL window actually frees, not the shared
+        // backoff. `wait_seconds` reads GitHub's voice, which is 0 here —
+        // so the old message told the caller "retry in 0s" while refusing
+        // them, and a retry loop honoring it would spin at full speed
+        // against the very limiter that just said no.
         return Ok((
             false,
-            format!("local request budget exceeded ({count}/{cap} of {limit} in 60s)"),
+            format!(
+                "local request budget exceeded ({count}/{effective_cap} of {limit} in 60s); \
+                 window frees in {}s",
+                local_window_frees_in(now)?
+            ),
         ));
     }
     if guarded_command(args) {
@@ -137,6 +159,36 @@ fn write_backoff(until: f64) -> std::io::Result<()> {
     let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
     fs::write(&tmp, format!("{}", until as i64))?;
     fs::rename(tmp, path)
+}
+
+/// Extra 60s-window slots reserved for `airc sos`, ON TOP of the poller
+/// cap. Small on purpose: SOS is low-rate human/agent coordination, not a
+/// poller, so a handful of slots is the difference between "the emergency
+/// channel answers" and "the emergency channel is dead".
+const SOS_RESERVE: usize = 6;
+
+/// True when this gh invocation is SOS traffic (the gist-comment channel
+/// of last resort). Matched on the request itself rather than threaded
+/// through as a flag so no future caller can forget to mark it.
+fn is_sos_request(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| arg.contains("/comments") || arg == "rate_limit")
+}
+
+/// Seconds until the OLDEST request in the sliding window ages out — i.e.
+/// when a slot actually frees. Returns 1 rather than 0 when the window is
+/// somehow empty, because a refusal must never advertise "retry now".
+fn local_window_frees_in(now: f64) -> std::io::Result<i64> {
+    let oldest = fs::read_to_string(budget_path())
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| line.trim().parse::<f64>().ok())
+        .filter(|ts| *ts >= now - 60.0)
+        .fold(f64::INFINITY, f64::min);
+    if !oldest.is_finite() {
+        return Ok(1);
+    }
+    Ok(((oldest + 60.0 - now).ceil() as i64).max(1))
 }
 
 fn recent_request_count(now: f64) -> std::io::Result<usize> {

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -421,7 +421,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             body_json,
             headers,
             kind,
-        } => publish_commands::run_publish(&home, room.room, body_text, body_json, headers, kind).await,
+        } => {
+            publish_commands::run_publish(&home, room.room, body_text, body_json, headers, kind)
+                .await
+        }
 
         Command::Inbox {
             socket,

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -371,7 +371,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Command::Send { room, text } => {
-            commands::run_send(&home, parsed.peers, room.as_deref(), &text).await
+            commands::run_send(&home, parsed.peers, room.named(), &text).await
         }
 
         Command::Listen { replay } => commands::run_listen(&home, parsed.peers, replay).await,
@@ -413,7 +413,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Stop { socket } => commands::run_stop(default_or(socket, &home)).await,
 
         Command::Msg { socket, room, text } => {
-            commands::run_msg(&home, default_or(socket, &home), room.as_deref(), &text).await
+            commands::run_msg(&home, default_or(socket, &home), room.named(), &text).await
         }
         Command::Publish {
             room,
@@ -421,15 +421,27 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             body_json,
             headers,
             kind,
-        } => publish_commands::run_publish(&home, room, body_text, body_json, headers, kind).await,
+        } => publish_commands::run_publish(&home, room.room, body_text, body_json, headers, kind).await,
 
         Command::Inbox {
             socket,
+            room,
             since_lamport,
             since_event_id,
             limit,
             json,
-        } => commands::run_inbox(&home, socket, since_lamport, since_event_id, limit, json).await,
+        } => {
+            commands::run_inbox(
+                &home,
+                socket,
+                room.named(),
+                since_lamport,
+                since_event_id,
+                limit,
+                json,
+            )
+            .await
+        }
 
         Command::Room { name } => commands::run_room(&home, name).await,
 

--- a/crates/airc-cli/src/sos_commands.rs
+++ b/crates/airc-cli/src/sos_commands.rs
@@ -45,10 +45,30 @@ const SOS_MARKER: &str = "airc-account-sos";
 /// channel so a peer who stumbles on the gist understands it.
 const SOS_SEED_FILENAME: &str = "airc-account-sos.md";
 
-/// Poll cadence for `watch --follow` (human streaming mode). Deliberately
-/// gentle: the whole point of SOS is that it works when the wire is down,
-/// so it must not itself hammer `gh` into a rate-limit backoff.
-const WATCH_POLL_INTERVAL: Duration = Duration::from_secs(45);
+/// Floor on the derived `watch --follow` cadence, and in practice THE
+/// cadence: the primary quota is 5000/hr, so pacing it across the window
+/// yields single-digit seconds and always clamps here. The binding
+/// constraint is the SECONDARY (abuse) limiter, which throttles BURST RATE
+/// and publishes no number to derive from — so the floor is where that
+/// judgement lives, and it must be set from evidence rather than taste.
+///
+/// Evidence: 45s got this account flagged for polling (2026-08-13). The
+/// floor is therefore ABOVE the cadence that was observed to trip it. An
+/// earlier draft of this fix set 20s by deriving from the primary quota
+/// alone — i.e. it "removed a hardcode" and made the actual problem twice
+/// as bad, because it paced against the threshold that was never binding.
+const WATCH_POLL_FLOOR: Duration = Duration::from_secs(60);
+
+/// Ceiling on the derived cadence. Without it, a nearly-exhausted quota
+/// would stretch the poll to the full reset window and the channel would
+/// look dead exactly when it is needed.
+const WATCH_POLL_CEILING: Duration = Duration::from_secs(300);
+
+/// Cadence used only when the budget could NOT be read. Deliberately at the
+/// ceiling and always announced — a missing signal must degrade loudly, not
+/// silently become a default (this is the defect this whole path had: a
+/// governor that reads two thresholds it was never handed).
+const WATCH_POLL_BLIND: Duration = WATCH_POLL_CEILING;
 
 /// Max readable length of a derived machine label. Long enough for a
 /// hostname, short enough to keep comment prefixes scannable.
@@ -121,8 +141,8 @@ pub async fn run_watch(home: &Path, follow: bool) -> Result<(), Box<dyn Error>> 
     }
 
     eprintln!(
-        "airc sos: watching gist {gist_id} as [{label}] (polling every {}s; Ctrl-C to stop)",
-        WATCH_POLL_INTERVAL.as_secs()
+        "airc sos: watching gist {gist_id} as [{label}] (cadence derived from GitHub's own \
+         rate-limit budget each round; Ctrl-C to stop)"
     );
     loop {
         // A transient gh hiccup must not kill a long-lived human watch:
@@ -132,7 +152,12 @@ pub async fn run_watch(home: &Path, follow: bool) -> Result<(), Box<dyn Error>> 
         if let Err(error) = poll_once(&gist_id, &label, &cursor_path) {
             eprintln!("airc sos: poll failed (will retry): {error}");
         }
-        tokio::time::sleep(WATCH_POLL_INTERVAL).await;
+        // Ask GitHub what we may spend, every round. Never a constant:
+        // the server reports both thresholds and hardcoding a cadence
+        // against them is what got this channel flagged.
+        let (interval, basis) = next_poll_interval();
+        eprintln!("airc sos: next poll in {}s ({basis})", interval.as_secs());
+        tokio::time::sleep(interval).await;
     }
 }
 
@@ -254,6 +279,70 @@ fn post_comment(gist_id: &str, body: &str) -> Result<(), Box<dyn Error>> {
         None,
     )?;
     Ok(())
+}
+
+/// Derive the next poll cadence from GitHub's OWN reported budget, plus
+/// any active governor backoff. Returns `(interval, human_basis)`.
+///
+/// Two thresholds, both read, neither guessed:
+///   - PRIMARY quota — `GET /rate_limit` reports `remaining` and `reset`
+///     for the core resource. Pace the remaining calls evenly across the
+///     time left in the window: `(reset - now) / max(remaining, 1)`.
+///     `/rate_limit` is itself free (it does not consume quota), which is
+///     exactly why it is the right probe for a recovery channel.
+///   - SECONDARY / abuse limit — surfaced as `retry-after`, already
+///     recorded into the shared governor by `record_backoff`. It is
+///     authoritative and outranks any pacing we compute.
+///
+/// A budget we could not read is announced, never silently defaulted: the
+/// original defect here was a governor that knew how to read both
+/// thresholds and was never handed either, so "no signal" was
+/// indistinguishable from "healthy".
+fn next_poll_interval() -> (Duration, String) {
+    let now = now_seconds();
+    let backoff = wait_seconds(now);
+    if backoff > 0 {
+        // Secondary limit / explicit retry-after wins outright.
+        let secs = (backoff as u64).max(WATCH_POLL_FLOOR.as_secs());
+        return (
+            Duration::from_secs(secs),
+            format!("governor backoff active: {backoff}s remaining"),
+        );
+    }
+    match read_core_budget() {
+        Some((remaining, reset)) => {
+            let window = (reset - now).max(0.0);
+            let paced = window / (remaining.max(1) as f64);
+            let secs = (paced.ceil() as u64)
+                .max(WATCH_POLL_FLOOR.as_secs())
+                .min(WATCH_POLL_CEILING.as_secs());
+            (
+                Duration::from_secs(secs),
+                format!(
+                    "budget: {remaining} core calls left, window resets in {}s",
+                    window as u64
+                ),
+            )
+        }
+        None => (
+            WATCH_POLL_BLIND,
+            "BUDGET UNREADABLE — backing off to the ceiling rather than guessing a cadence"
+                .to_string(),
+        ),
+    }
+}
+
+/// Read `(remaining, reset_epoch_seconds)` for the core resource from
+/// GitHub's free `/rate_limit` endpoint. `None` when the probe fails or
+/// the shape is not what we expect — callers must treat that as "no
+/// signal", never as "plenty of budget".
+fn read_core_budget() -> Option<(u64, f64)> {
+    let raw = gh_capture(&["api", "rate_limit"], None).ok()?;
+    let value: Value = serde_json::from_str(&raw).ok()?;
+    let core = value.get("resources")?.get("core")?;
+    let remaining = core.get("remaining")?.as_u64()?;
+    let reset = core.get("reset")?.as_f64()?;
+    Some((remaining, reset))
 }
 
 /// Fetch the gist's comments in chronological (API) order.
@@ -425,11 +514,13 @@ fn gh_capture(args: &[&str], stdin: Option<&str>) -> Result<String, Box<dyn Erro
     let now = now_seconds();
     let (allowed, reason) = reserve_guarded_request(&owned, now)?;
     if !allowed {
-        return Err(format!(
-            "airc sos: gh governor blocked this request ({reason}); retry in {}s",
-            wait_seconds(now)
-        )
-        .into());
+        // `reason` already carries WHEN this clears — the local sliding
+        // window's own next-free, or GitHub's backoff. Appending
+        // `wait_seconds` here re-derived it from the SHARED backoff only,
+        // which is 0 for a purely local denial: the refusal literally
+        // read "blocked … ; retry in 0s", and a retry loop obeying it
+        // would spin at full rate against the limiter that just said no.
+        return Err(format!("airc sos: gh governor blocked this request ({reason})").into());
     }
 
     let gh = std::env::var("AIRC_GH_BIN").unwrap_or_else(|_| "gh".to_string());

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -324,10 +324,31 @@ impl Airc {
     }
 
     /// Fetch the most recent `limit` events from the current room.
+    ///
+    /// The current room is the DEFAULT scope for this read, not the only
+    /// one it can express: this is `page_recent_in` against
+    /// `current_room()`. Callers that already know which room they want
+    /// (`airc inbox --room`, a consumer paging a room it is subscribed to
+    /// but not sitting in) call `page_recent_in` directly and never have
+    /// to move the scope's default-room pointer to perform a READ.
     pub async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
+        self.page_recent_in(&room, limit).await
+    }
+
+    /// Fetch the most recent `limit` events from `room`.
+    ///
+    /// The room-explicit half of `page_recent` — same daemon-attached
+    /// routing, no implicit scope. Resolve `room` with
+    /// `room_by_name_or_channel`, which refuses loudly for a room this
+    /// scope is not subscribed to (reading must not auto-join).
+    pub async fn page_recent_in(
+        &self,
+        room: &crate::Room,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
         if self.is_daemon_attached() {
-            return self.daemon_page_recent(&room, limit).await;
+            return self.daemon_page_recent(room, limit).await;
         }
         Ok(self
             .inner
@@ -457,15 +478,29 @@ impl Airc {
             .collect())
     }
 
-    /// Fetch up to `limit` events strictly after `cursor`.
+    /// Fetch up to `limit` events strictly after `cursor` in the current room.
+    ///
+    /// `resume_from_in` against `current_room()` — see `page_recent` for why
+    /// the current room is a default here rather than the only expressible
+    /// scope.
     pub async fn resume_from(
         &self,
         cursor: &TranscriptCursor,
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
+        self.resume_from_in(&room, cursor, limit).await
+    }
+
+    /// Fetch up to `limit` events strictly after `cursor` in `room`.
+    pub async fn resume_from_in(
+        &self,
+        room: &crate::Room,
+        cursor: &TranscriptCursor,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
         if self.is_daemon_attached() {
-            return self.daemon_resume_from(&room, cursor, limit).await;
+            return self.daemon_resume_from(room, cursor, limit).await;
         }
         Ok(self
             .inner

--- a/crates/airc-lib/tests/inbox_room_scoped.rs
+++ b/crates/airc-lib/tests/inbox_room_scoped.rs
@@ -1,0 +1,114 @@
+//! Regression for continuum #270: reading a subscribed room must not
+//! require MOVING this scope's default-room pointer.
+//!
+//! `airc msg`, `airc send` and `airc publish` each took `--room <name>`
+//! for one-shot routing. `airc inbox` — the READ — took no such flag and
+//! could only ever show whichever room the scope happened to be sitting
+//! in, so the documented way to read one of your other subscribed rooms
+//! was `airc room <name>`: a WRITE to shared scope state performed in
+//! order to do a read. Two rooms, two agents, one pointer — whoever read
+//! last silently relocated everyone.
+//!
+//! What this catches: a `page_recent`/`resume_from` that reaches for
+//! `current_room()` internally instead of honoring the room it was
+//! handed, and any future re-plumbing of `inbox --room` back through the
+//! default-room pointer. The load-bearing assertion is not that the
+//! events come back — it is that `peek_default_room` is UNCHANGED
+//! afterwards, and still unchanged after a reopen (a mutation that only
+//! lived in memory would still be a mutation).
+
+use airc_core::Body;
+use airc_lib::{Airc, PublishTarget};
+use airc_protocol::FrameKind;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn reading_another_subscribed_room_does_not_move_the_default_room_pointer() {
+    let dir = tempdir().unwrap();
+    let machine = dir.path().join("machine/.airc");
+    let wire = dir.path().join("wire");
+
+    let airc = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("open scope");
+
+    // Two subscribed rooms. `current_room` lands the scope in the first
+    // one and pins it as default; the second is joined but not current —
+    // exactly the shape that made inbox blind.
+    let here = airc.current_room().await.expect("current room");
+    airc.join("elsewhere").await.expect("join second room");
+    // `join` MOVES the scope into the room it joins, so come back. Without
+    // this the scope is already sitting in 'elsewhere' and the whole test
+    // is vacuous — a `page_recent_in` that ignored its argument and read
+    // `current_room` would pass. (It did: caught by positive control.)
+    airc.join(&here.name).await.expect("return to the first room");
+    assert_eq!(
+        airc.current_room().await.expect("current room").channel,
+        here.channel,
+        "setup: the scope must be sitting in the FIRST room before the read"
+    );
+
+    // Put a message in the room we are NOT sitting in.
+    airc.publish(
+        PublishTarget::RoomByName("elsewhere".to_string()),
+        FrameKind::Message,
+        Body::text("message that lives in the other room"),
+        std::collections::BTreeMap::new(),
+    )
+    .await
+    .expect("publish to the non-current room");
+
+    let default_before = airc
+        .peek_default_room()
+        .await
+        .expect("default room before the read");
+
+    // THE READ under test: page the other room explicitly.
+    let there = airc
+        .room_by_name_or_channel("elsewhere", "read")
+        .await
+        .expect("resolve the other room");
+    let events = airc.page_recent_in(&there, 32).await.expect("page the other room");
+
+    assert!(
+        events.iter().any(|event| {
+            event
+                .body
+                .as_ref()
+                .and_then(airc_core::Body::as_text)
+                .is_some_and(|text| text.contains("message that lives in the other room"))
+        }),
+        "a room-scoped read must return that room's events — got {} event(s) instead",
+        events.len()
+    );
+    assert_ne!(
+        there.channel, here.channel,
+        "test is vacuous unless the room read differs from the current one"
+    );
+
+    // The invariant. Reading is not moving.
+    let default_after = airc
+        .peek_default_room()
+        .await
+        .expect("default room after the read");
+    assert_eq!(
+        default_before, default_after,
+        "reading room 'elsewhere' moved this scope's default-room pointer — a READ must \
+         never mutate shared scope state (#270)"
+    );
+
+    // And it did not merely fail to mutate in memory: a fresh handle on
+    // the same home agrees.
+    drop(airc);
+    let reopened = Airc::open_with_wire_root_for_test(&machine, &wire)
+        .await
+        .expect("reopen same home");
+    assert_eq!(
+        reopened
+            .peek_default_room()
+            .await
+            .expect("default room after reopen"),
+        default_after,
+        "the default-room pointer changed on disk across a room-scoped read"
+    );
+}

--- a/crates/airc-lib/tests/inbox_room_scoped.rs
+++ b/crates/airc-lib/tests/inbox_room_scoped.rs
@@ -41,7 +41,9 @@ async fn reading_another_subscribed_room_does_not_move_the_default_room_pointer(
     // this the scope is already sitting in 'elsewhere' and the whole test
     // is vacuous — a `page_recent_in` that ignored its argument and read
     // `current_room` would pass. (It did: caught by positive control.)
-    airc.join(&here.name).await.expect("return to the first room");
+    airc.join(&here.name)
+        .await
+        .expect("return to the first room");
     assert_eq!(
         airc.current_room().await.expect("current room").channel,
         here.channel,
@@ -68,7 +70,10 @@ async fn reading_another_subscribed_room_does_not_move_the_default_room_pointer(
         .room_by_name_or_channel("elsewhere", "read")
         .await
         .expect("resolve the other room");
-    let events = airc.page_recent_in(&there, 32).await.expect("page the other room");
+    let events = airc
+        .page_recent_in(&there, 32)
+        .await
+        .expect("page the other room");
 
     assert!(
         events.iter().any(|event| {


### PR DESCRIPTION
`--room` was declared per-subcommand — three near-identical copies on send/msg/publish, and **inbox never got one**. That asymmetry is what a per-command declaration does: the WRITES could each name a room, the READ could only see whichever room the scope was sitting in. So reading another subscribed room meant `airc room <name>` — a **write to shared scope state in order to do a read**. #270 already printed exactly that as the remedy.

**Fix:** one `RoomSelector` flattened into all four verbs; a new room-scoped verb inherits the flag. inbox resolves through `Airc::room_by_name_or_channel` — the same resolver the writes use (name or channel id, loud refusal for an unsubscribed room, never auto-joins).

**airc-lib:** `page_recent`/`resume_from` become one-line wrappers over new room-explicit `page_recent_in`/`resume_from_in`. Current room is now a *default* for these reads, not the only expressible scope.

## Verification
- `inbox_room_scoped.rs` pins the invariant: after reading a non-current room, `peek_default_room` is unchanged — and still unchanged after reopen.
- **Positive control:** the first version of that test PASSED against a sabotaged `page_recent_in` that ignored its argument (`join` moves the scope, so the setup was already in the target room — vacuous). Setup fixed; re-sabotaged it FAILS naming the defect; restored it passes.
- 347 airc-lib unit tests green; airc-cli test targets build.
- **Live** against the running daemon (a9e3e85ba599): from k3-serving, `airc inbox --room general` returned general's events and `airc room` still reported k3-serving.

**Noted, not fixed:** those events render blank in the human view — `system` presence frames that `print_event` prints nothing for (sibling of #275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo