### PR TITLE
fix(tests): a subsystem-named room does not belong in a fixture either

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -2921,10 +2921,10 @@ mod publish_identity_tests {
         );
 
         // And the operator verb still means join-and-focus, unchanged.
-        airc.join("k3-serving").await.expect("operator join");
+        airc.join("bench-swe-run-1").await.expect("operator join");
         assert_eq!(
             airc.current_room().await.expect("current room").name,
-            "k3-serving",
+            "bench-swe-run-1",
             "join still moves the focus — this split must not change the operator's verb"
         );
     }

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -818,7 +818,7 @@ mod tests {
             IdTokenResolution::NotAnId
         ));
         assert!(matches!(
-            set.resolve_id_token("k3-serving"),
+            set.resolve_id_token("bench-swe-run-1"),
             IdTokenResolution::NotAnId
         ));
         assert!(matches!(


### PR DESCRIPTION
`k3-serving` was a room named for a SUBSYSTEM — no lifetime, so it never died. It sat as a durable subscription for a month and every board read taken from it was a corpse. Parted from both scopes.

It was also sitting in **test fixtures**, which is the transmission vector rather than a cosmetic leftover: fixtures teach the next reader the convention. A fixture naming a room after a subsystem teaches *rooms are named for subsystems*, and the next room minted that way outlives its purpose the same way.

Renamed to `bench-swe-run-1` — an activity with a lifetime, which is what a room is. Assertions unchanged. 347 airc-lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo