### PR TITLE
fix(update): the merge names its target — self-update cannot stall on an ambiguous FETCH_HEAD

### DIFF
--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -231,12 +231,35 @@ fn prepare_build_source(
     let branch = git_text(source, ["rev-parse", "--abbrev-ref", "HEAD"])?;
     if branch == channel {
         let before = git_text(source, ["rev-parse", "--short", "HEAD"])?;
+        // Advance to the ref the fetch above ALREADY resolved, rather than
+        // letting a bare `git pull` re-fetch and re-derive what to merge.
+        //
+        // `git pull --ff-only` with no argument runs its own fetch and then
+        // merges whatever `FETCH_HEAD` marks for-merge. When more than one
+        // entry carries that mark it aborts with
+        //
+        //     fatal: Cannot fast-forward to multiple branches.
+        //
+        // and the node silently stays on its old binary. Observed on the
+        // Windows node 2026-08-13: `airc update` printed that line while
+        // `git pull --ff-only` run by hand in the same directory succeeded,
+        // so the condition depends on the state the preceding explicit fetch
+        // leaves behind — which is exactly the kind of dependency a
+        // self-update path must not have.
+        //
+        // `git merge --ff-only origin/<channel>` names its target, so it has
+        // no branch to be ambiguous about. It is also strictly less work: the
+        // fetch two statements up already did the network round trip, and the
+        // bare pull was repeating it.
+        let origin_ref = format!("origin/{channel}");
         run_checked(
-            Command::new("git")
-                .arg("-C")
-                .arg(source)
-                .args(["pull", "--ff-only", "--quiet"]),
-            "git pull --ff-only",
+            Command::new("git").arg("-C").arg(source).args([
+                "merge",
+                "--ff-only",
+                "--quiet",
+                &origin_ref,
+            ]),
+            "git merge --ff-only (channel)",
         )?;
         let after = git_text(source, ["rev-parse", "--short", "HEAD"])?;
         return Ok((source.to_path_buf(), before, after));


### PR DESCRIPTION
## The defect

`airc update` fetched the channel explicitly, then ran a bare `git pull --ff-only`, which re-fetches and merges whatever `FETCH_HEAD` marks for-merge. When more than one entry carries that mark, git aborts:

```
fatal: Cannot fast-forward to multiple branches.
```

and the node stays on its old binary.

Measured on the Windows node today: `airc update` printed that line, while `git pull --ff-only` run by hand in the **same directory** moments later fast-forwarded `a9e3e85..6498165` without complaint. The failure depends on the state the preceding explicit fetch leaves behind — precisely the dependency a self-update path must not have.

A node that cannot update quietly drifts off the grid's build, and every measurement it reports afterwards is taken on stale code. That is not hypothetical: a full night of cross-node airc findings turned out to be two agents diagnosing each other on different builds.

## The fix

Advance to the ref the fetch already resolved:

```
git merge --ff-only origin/<channel>
```

It names its target, so there is no branch for it to be ambiguous about. It is also strictly less work — the network round trip happened two statements earlier and the bare pull was repeating it.

## Note on how this was found

I hit the failure, pulled the update worktree **by hand**, and moved on — which fixed exactly one machine and left the defect in place for every other operator. Joel caught it. This PR is the repo fix; the hand-pull was the bug's disguise, not its remedy.

## Verification

`cargo test -p airc-cli update` — 18 passed, 0 failed. fmt + clippy pre-push gates passed without skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc