### PR TITLE
fix(rooms): a room is addressed by its ID — kill name-as-identity end to end

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -209,12 +209,11 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
                 println!("  #{} ({})", room.name, room.channel);
             }
             if let Some(before) = default_before {
-                if before.as_str() != current.name {
+                if before != current.channel {
                     eprintln!(
-                        "WARNING: default room CHANGED: {} -> #{} — `airc msg` now targets #{}",
-                        before.display_with_hash(),
-                        current.name,
-                        current.name
+                        "WARNING: default room CHANGED: {} -> #{} ({}) — `airc msg` now \
+                         targets that room",
+                        before, current.name, current.channel
                     );
                 }
             }

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -239,13 +239,13 @@ fn humanize_age_ms(age_ms: u64) -> String {
     }
 }
 
-/// Channel names a beacon subscribes to, as plain strings for display
-/// and convergence comparison (apples-to-apples with `Room::name`).
+/// Room ids a beacon subscribes to, as strings for display and
+/// comparison (apples-to-apples with `Room::channel`).
 fn beacon_channels(beacon: &PresenceBeacon) -> Vec<String> {
     beacon
-        .subscribed_channels
+        .subscribed_rooms
         .iter()
-        .map(|channel| channel.as_str().to_string())
+        .map(|room_id| room_id.to_string())
         .collect()
 }
 

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -622,13 +622,13 @@ mod tests {
     // surfaces a label-alphabetical order and fails the assert.
     #[test]
     fn stale_summary_groups_by_label_count_descending() {
-        use airc_lib::{ChannelName, PresenceBeacon};
+        use airc_lib::{PresenceBeacon, RoomId};
         use std::path::PathBuf;
         let beacon = |id: u128, home: &str| PresenceBeacon {
             version: 1,
             peer_id: airc_lib::PeerId(uuid::Uuid::from_u128(id)),
             scope_home: PathBuf::from(home),
-            subscribed_channels: vec![ChannelName::new("general").unwrap()],
+            subscribed_rooms: vec![RoomId::from_u128(1)],
             pid: 1,
             published_at_ms: 0,
             heartbeat_at_ms: 0,

--- a/crates/airc-core/src/ids.rs
+++ b/crates/airc-core/src/ids.rs
@@ -73,6 +73,29 @@ macro_rules! uuid_newtype {
                 self.0.fmt(f)
             }
         }
+
+        /// The inverse of `Display`, so an id crosses a TEXT boundary
+        /// — an env var, a CLI argument, a config file — by being
+        /// PARSED into its type, once, here.
+        ///
+        /// Without this every such boundary hand-rolls
+        /// `Uuid::parse_str(..).map($name::from_uuid)`, and a boundary
+        /// that finds that tedious keeps the `String` instead. That is
+        /// how a display label becomes an identity: not by a decision,
+        /// but by the typed path being fractionally less convenient
+        /// than the untyped one. Rendering was already free; parsing
+        /// is now free too.
+        ///
+        /// Surrounding whitespace is trimmed because these values
+        /// arrive from humans and shells. Nothing else is accepted —
+        /// no prefixes, no truncation, no partial ids.
+        impl std::str::FromStr for $name {
+            type Err = uuid::Error;
+
+            fn from_str(raw: &str) -> Result<Self, Self::Err> {
+                Uuid::parse_str(raw.trim()).map(Self)
+            }
+        }
     };
 }
 

--- a/crates/airc-core/src/ids.rs
+++ b/crates/airc-core/src/ids.rs
@@ -26,8 +26,14 @@ use uuid::Uuid;
 macro_rules! uuid_newtype {
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
+        // `Ord`/`PartialOrd` so an id can KEY an ordered collection. Ids
+        // address things — rooms, peers, events — so the maps and sets
+        // that hold them must sort by the id, not by some display string
+        // that happens to be attached. Without this the only sortable
+        // handle on a room was its name, which is exactly how a display
+        // label ended up as the key for durable membership.
         #[derive(
-            Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+            Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
         )]
         #[serde(transparent)]
         pub struct $name(pub Uuid);

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -77,7 +77,7 @@ pub fn merge_registry_documents(
 ) -> RegistryMergeOutcome {
     let mut ignored_temp_beacons = 0usize;
     let mut generated_at_ms = 0u64;
-    let mut rooms: Vec<RoomId> = Vec::new();
+    let mut rooms: Vec<AccountRoom> = Vec::new();
     // peer_id -> (heartbeat_at_ms, doc generated_at_ms, beacon)
     let mut freshest: HashMap<airc_core::PeerId, (u64, u64, AccountPeerBeacon)> = HashMap::new();
     // peer_id -> (heartbeat_at_ms, doc generated_at_ms, endpoints,
@@ -99,9 +99,16 @@ pub fn merge_registry_documents(
         }
         matched_any = true;
         generated_at_ms = generated_at_ms.max(document.generated_at_ms);
-        for room_id in &document.rooms {
-            if !rooms.contains(room_id) {
-                rooms.push(*room_id);
+        for room in &document.rooms {
+            // A LABELLED entry supersedes an unlabelled one for the same
+            // id: the label is what a later peer needs to find the room
+            // by name, and dropping it would strand that room.
+            if let Some(existing) = rooms.iter_mut().find(|r| r.room_id == room.room_id) {
+                if existing.label.is_none() {
+                    existing.label = room.label.clone();
+                }
+            } else {
+                rooms.push(room.clone());
             }
         }
         for beacon in document.peers {
@@ -212,13 +219,36 @@ pub fn prune_stale_peers(peers: &mut Vec<AccountPeerBeacon>, now_ms: u64, ttl_ms
     before - peers.len()
 }
 
+/// One room the account knows: its ADDRESS plus the label it was filed
+/// under. An unlabelled room (dispatched into, handed over by a peer) is
+/// still a perfectly good entry — it simply cannot be reached by name.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AccountRoom {
+    pub room_id: RoomId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl AccountRoom {
+    pub fn new(room_id: RoomId, label: Option<String>) -> Self {
+        Self { room_id, label }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountRegistryDocument {
     pub schema_version: u16,
     pub mesh_identity: MeshIdentity,
     pub generated_at_ms: u64,
-    /// Every room the account knows, BY ID.
-    pub rooms: Vec<RoomId>,
+    /// Every room the account knows, BY ID, each carrying the display
+    /// label the account filed it under.
+    ///
+    /// The label is the DIRECTORY's payload, never the room's identity:
+    /// it is what lets a peer that types `#general` learn the id the
+    /// account already minted, instead of minting a second room nobody
+    /// else is in. Delivery still routes on the id alone — a label on
+    /// the wire buys discovery, never addressing.
+    pub rooms: Vec<AccountRoom>,
     pub peers: Vec<AccountPeerBeacon>,
 }
 
@@ -226,7 +256,7 @@ impl AccountRegistryDocument {
     pub fn new(
         mesh_identity: MeshIdentity,
         generated_at_ms: u64,
-        rooms: Vec<RoomId>,
+        rooms: Vec<AccountRoom>,
         peers: Vec<AccountPeerBeacon>,
     ) -> Self {
         Self {
@@ -283,7 +313,14 @@ impl AccountRegistryDocument {
         Self::new(
             snapshot.mesh_identity.clone(),
             generated_at_ms,
-            snapshot.live_rooms.clone(),
+            // A snapshot knows ids only — beacons carry addresses, not
+            // labels. The labels are merged in by the scope's own
+            // subscriptions (below) and by peers' published documents.
+            snapshot
+                .live_rooms
+                .iter()
+                .map(|room_id| AccountRoom::new(*room_id, None))
+                .collect(),
             peers,
         )
     }
@@ -606,15 +643,24 @@ impl Airc {
             // is [] even while this scope is subscribed; identity, key,
             // and endpoints already follow the publisher-is-alive
             // doctrine and the room list must too.
-            let subscribed_rooms: Vec<RoomId> = self
-                .subscriptions()
-                .await?
-                .into_iter()
-                .map(|subscription| subscription.room_id)
-                .collect();
-            for room_id in &subscribed_rooms {
-                if !document.rooms.contains(room_id) {
-                    document.rooms.push(*room_id);
+            let subscriptions = self.subscriptions().await?;
+            let subscribed_rooms: Vec<RoomId> =
+                subscriptions.iter().map(|s| s.room_id).collect();
+            for subscription in &subscriptions {
+                let label = (!subscription.name.as_str().is_empty())
+                    .then(|| subscription.name.as_str().to_string());
+                if let Some(existing) = document
+                    .rooms
+                    .iter_mut()
+                    .find(|r| r.room_id == subscription.room_id)
+                {
+                    if existing.label.is_none() {
+                        existing.label = label;
+                    }
+                } else {
+                    document
+                        .rooms
+                        .push(AccountRoom::new(subscription.room_id, label));
                 }
             }
             document.rooms.sort();
@@ -721,6 +767,22 @@ impl Airc {
         // of one) leaves its peers `Untrusted`. Using `document.mesh_identity`
         // for both sides would be circular — a document vouching for itself.
         let self_mesh = self.mesh_identity().await?;
+        // Learn the account's LABELS. This is what closes cross-machine
+        // rendezvous without letting a name address anything: a peer
+        // that types `#general` now finds the id the account already
+        // minted instead of minting a second room nobody else is in.
+        // `claim_room_label` is insert-or-ignore, so an entry this scope
+        // already holds wins and a peer can never re-point a label we
+        // are using.
+        for room in &document.rooms {
+            let Some(label) = room.label.as_deref() else {
+                continue;
+            };
+            self.coordinator_store()
+                .claim_room_label(label, room.room_id, now_ms)
+                .await
+                .map_err(crate::subscriptions::SubscriptionError::from)?;
+        }
         for peer in document.peers {
             if peer.peer_id() == self.inner.identity.peer_id {
                 continue;
@@ -918,7 +980,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
@@ -986,7 +1048,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
@@ -1024,7 +1086,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
@@ -1059,7 +1121,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
@@ -1128,7 +1190,7 @@ mod tests {
         let same_doc = AccountRegistryDocument::new(
             my_mesh.clone(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
@@ -1168,7 +1230,7 @@ mod tests {
         let foreign_doc = AccountRegistryDocument::new(
             MeshIdentity::new("someone-else@github"),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
@@ -1231,7 +1293,7 @@ mod tests {
             AccountRegistryDocument::new(
                 mesh(),
                 2_000,
-                vec![room(1)],
+                vec![AccountRoom::new(room(1), Some("general".to_string()))],
                 vec![AccountPeerBeacon {
                     endpoints_advertised_at_ms: None,
                     endpoints_peer_id: None,
@@ -1374,7 +1436,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![
                 beacon_at(prod, "/machine/a/.airc", 1_000),
                 beacon_at(
@@ -1437,7 +1499,7 @@ mod tests {
         let old_doc = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![stale, beacon_at(only_in_old, "/machine/b/.airc", 900)],
         );
         let new_doc = AccountRegistryDocument::new(mesh(), 6_000, vec![], vec![fresh]);
@@ -1506,13 +1568,13 @@ mod tests {
         let daemon_doc = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![daemon_beacon],
         );
         let manual_doc = AccountRegistryDocument::new(
             mesh(),
             6_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![manual_sync_beacon],
         );
 
@@ -1653,7 +1715,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![room(1)],
+            vec![AccountRoom::new(room(1), Some("general".to_string()))],
             vec![
                 beacon(scope_peer, Some(machine_peer)),
                 beacon(self_hosted_peer, Some(self_hosted_peer)),
@@ -1718,7 +1780,7 @@ mod tests {
             AccountRegistryDocument::new(
                 mesh(),
                 hb,
-                vec![room(1)],
+                vec![AccountRoom::new(room(1), Some("general".to_string()))],
                 vec![AccountPeerBeacon {
                     presence: crate::coordinator::beacon_now(
                         peer_id,
@@ -1986,9 +2048,15 @@ mod tests {
             "stamped self-beacon rooms must come from self.subscriptions()"
         );
         for room_id in &subscribed {
+            let entry = document
+                .rooms
+                .iter()
+                .find(|r| r.room_id == *room_id)
+                .expect("document rooms must include the local subscriptions");
             assert!(
-                document.rooms.contains(room_id),
-                "document rooms must include the local subscriptions"
+                entry.label.is_some(),
+                "a subscribed room must publish its LABEL — that is what lets a peer \
+                 find this room by name instead of minting a second one"
             );
         }
     }

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -22,19 +22,19 @@ use crate::coordinator::{CoordinatorSnapshot, PresenceBeacon};
 use crate::error::AircError;
 use crate::registry::PeerSpec;
 use crate::route::{InviteBeacon, RouteEndpoint};
-use crate::subscriptions::{MeshIdentity};
+use crate::subscriptions::MeshIdentity;
 use crate::time;
 use crate::Airc;
 
 pub const ACCOUNT_REGISTRY_SCHEMA_VERSION: u16 = 1;
 
+pub use airc_core::scope_home_is_temp_rooted;
 /// Temp-rooted scope-home detection (#1150). The definition moved to
 /// [`airc_core::temp_home`] (card f122b5b5) so `airc-daemon`'s idle
 /// self-exit watchdog consults the SAME check without depending on
 /// this crate; re-exported here so existing callers keep their
 /// import path.
 pub use airc_core::RoomId;
-pub use airc_core::scope_home_is_temp_rooted;
 
 /// Outcome of [`merge_registry_documents`]: the merged view plus the
 /// hygiene counters the caller must surface (count, not full dump).
@@ -644,8 +644,7 @@ impl Airc {
             // and endpoints already follow the publisher-is-alive
             // doctrine and the room list must too.
             let subscriptions = self.subscriptions().await?;
-            let subscribed_rooms: Vec<RoomId> =
-                subscriptions.iter().map(|s| s.room_id).collect();
+            let subscribed_rooms: Vec<RoomId> = subscriptions.iter().map(|s| s.room_id).collect();
             for subscription in &subscriptions {
                 let label = (!subscription.name.as_str().is_empty())
                     .then(|| subscription.name.as_str().to_string());

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -873,8 +873,10 @@ mod tests {
         MeshIdentity::new("joelteply")
     }
 
-    fn channel(name: &str) -> ChannelName {
-        ChannelName::new(name).unwrap()
+    /// A stable test room id. Production ids are minted; these are
+    /// hand-picked so assertions can name the room they mean.
+    fn room(n: u128) -> RoomId {
+        RoomId::from_u128(n)
     }
 
     fn peer_spec(peer_id: PeerId) -> PeerSpec {
@@ -909,14 +911,14 @@ mod tests {
         let presence = crate::coordinator::beacon_now(
             peer_id,
             "/machine/a/.airc".into(),
-            vec![channel("general")],
+            vec![room(1)],
             123,
             1_000,
         );
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
@@ -945,14 +947,14 @@ mod tests {
         let with_spec = crate::coordinator::beacon_now(
             peer_with_spec,
             "/machine/a/.airc".into(),
-            vec![channel("general")],
+            vec![room(1)],
             123,
             1_000,
         );
         let without_spec = crate::coordinator::beacon_now(
             peer_without_spec,
             "/machine/b/.airc".into(),
-            vec![channel("cambriantech")],
+            vec![room(2)],
             456,
             1_000,
         );
@@ -984,14 +986,14 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
                 presence: crate::coordinator::beacon_now(
                     presence_peer,
                     "/machine/a/.airc".into(),
-                    vec![channel("general")],
+                    vec![room(1)],
                     123,
                     1_000,
                 ),
@@ -1022,14 +1024,14 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
                 presence: crate::coordinator::beacon_now(
                     peer_id,
                     "/machine/a/.airc".into(),
-                    vec![channel("general")],
+                    vec![room(1)],
                     123,
                     1_000,
                 ),
@@ -1057,14 +1059,14 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
                 presence: crate::coordinator::beacon_now(
                     peer_id,
                     machine_a.clone(),
-                    vec![channel("general")],
+                    vec![room(1)],
                     123,
                     1_000,
                 ),
@@ -1126,14 +1128,14 @@ mod tests {
         let same_doc = AccountRegistryDocument::new(
             my_mesh.clone(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
                 presence: crate::coordinator::beacon_now(
                     same_account_peer,
                     home.clone(),
-                    vec![channel("general")],
+                    vec![room(1)],
                     123,
                     1_000,
                 ),
@@ -1166,14 +1168,14 @@ mod tests {
         let foreign_doc = AccountRegistryDocument::new(
             MeshIdentity::new("someone-else@github"),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![AccountPeerBeacon {
                 endpoints_advertised_at_ms: None,
                 endpoints_peer_id: None,
                 presence: crate::coordinator::beacon_now(
                     foreign_peer,
                     home.clone(),
-                    vec![channel("general")],
+                    vec![room(1)],
                     123,
                     1_000,
                 ),
@@ -1229,14 +1231,14 @@ mod tests {
             AccountRegistryDocument::new(
                 mesh(),
                 2_000,
-                vec![channel("general")],
+                vec![room(1)],
                 vec![AccountPeerBeacon {
                     endpoints_advertised_at_ms: None,
                     endpoints_peer_id: None,
                     presence: crate::coordinator::beacon_now(
                         peer_id,
                         machine_b.clone(),
-                        vec![channel("general")],
+                        vec![room(1)],
                         123,
                         hb,
                     ),
@@ -1318,7 +1320,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 peer_id,
                 scope_home.into(),
-                vec![channel("general")],
+                vec![room(1)],
                 123,
                 heartbeat_ms,
             ),
@@ -1372,7 +1374,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![
                 beacon_at(prod, "/machine/a/.airc", 1_000),
                 beacon_at(
@@ -1408,7 +1410,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 shared,
                 "/machine/a/.airc".into(),
-                vec![channel("general")],
+                vec![room(1)],
                 123,
                 1_000,
             ),
@@ -1423,7 +1425,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 shared,
                 "/machine/a/.airc".into(),
-                vec![channel("general")],
+                vec![room(1)],
                 123,
                 5_000,
             ),
@@ -1435,7 +1437,7 @@ mod tests {
         let old_doc = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![stale, beacon_at(only_in_old, "/machine/b/.airc", 900)],
         );
         let new_doc = AccountRegistryDocument::new(mesh(), 6_000, vec![], vec![fresh]);
@@ -1479,7 +1481,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 peer,
                 "/machine/a/.airc".into(),
-                vec![channel("general")],
+                vec![room(1)],
                 123,
                 1_000,
             ),
@@ -1494,7 +1496,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 peer,
                 "/machine/a/.airc".into(),
-                vec![channel("general")],
+                vec![room(1)],
                 456,
                 5_000,
             ),
@@ -1504,13 +1506,13 @@ mod tests {
         let daemon_doc = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![daemon_beacon],
         );
         let manual_doc = AccountRegistryDocument::new(
             mesh(),
             6_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![manual_sync_beacon],
         );
 
@@ -1561,7 +1563,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 peer,
                 "/machine/a/.airc".into(),
-                vec![channel("general")],
+                vec![room(1)],
                 123,
                 1_000,
             ),
@@ -1576,7 +1578,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 peer,
                 "/machine/a/.airc".into(),
-                vec![channel("general")],
+                vec![room(1)],
                 456,
                 5_000,
             ),
@@ -1639,7 +1641,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 peer_id,
                 "/machine/a/.airc".into(),
-                vec![channel("general")],
+                vec![room(1)],
                 123,
                 1_000,
             ),
@@ -1651,7 +1653,7 @@ mod tests {
         let document = AccountRegistryDocument::new(
             mesh(),
             2_000,
-            vec![channel("general")],
+            vec![room(1)],
             vec![
                 beacon(scope_peer, Some(machine_peer)),
                 beacon(self_hosted_peer, Some(self_hosted_peer)),
@@ -1716,12 +1718,12 @@ mod tests {
             AccountRegistryDocument::new(
                 mesh(),
                 hb,
-                vec![channel("general")],
+                vec![room(1)],
                 vec![AccountPeerBeacon {
                     presence: crate::coordinator::beacon_now(
                         peer_id,
                         home.clone(),
-                        vec![channel("general")],
+                        vec![room(1)],
                         123,
                         hb,
                     ),
@@ -1920,7 +1922,7 @@ mod tests {
         let stale_self = crate::coordinator::beacon_now(
             airc.peer_id(),
             machine.clone(),
-            vec![channel("general")],
+            vec![room(1)],
             std::process::id(),
             1_000,
         );
@@ -1969,17 +1971,25 @@ mod tests {
             self_beacon.endpoints, expected_endpoints,
             "self-beacon must carry route_endpoints()"
         );
-        // Card cbbcf18d item 2: channels from the LOCAL SoT
-        // (self.subscriptions()), not presence-derived live_channels
+        // Card cbbcf18d item 2: rooms from the LOCAL SoT
+        // (self.subscriptions()), not presence-derived live_rooms
         // (empty in this exact scenario).
+        let subscribed: Vec<RoomId> = airc
+            .subscriptions()
+            .await
+            .expect("subscriptions")
+            .into_iter()
+            .map(|s| s.room_id)
+            .collect();
         assert_eq!(
-            self_beacon.presence.subscribed_channels,
-            vec![channel("general")],
-            "stamped self-beacon channels must come from self.subscriptions()"
+            self_beacon.presence.subscribed_rooms, subscribed,
+            "stamped self-beacon rooms must come from self.subscriptions()"
         );
-        assert!(
-            document.channels.contains(&channel("general")),
-            "document channels must include the local subscriptions"
-        );
+        for room_id in &subscribed {
+            assert!(
+                document.rooms.contains(room_id),
+                "document rooms must include the local subscriptions"
+            );
+        }
     }
 }

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -22,7 +22,7 @@ use crate::coordinator::{CoordinatorSnapshot, PresenceBeacon};
 use crate::error::AircError;
 use crate::registry::PeerSpec;
 use crate::route::{InviteBeacon, RouteEndpoint};
-use crate::subscriptions::{ChannelName, MeshIdentity};
+use crate::subscriptions::{MeshIdentity};
 use crate::time;
 use crate::Airc;
 
@@ -33,6 +33,7 @@ pub const ACCOUNT_REGISTRY_SCHEMA_VERSION: u16 = 1;
 /// self-exit watchdog consults the SAME check without depending on
 /// this crate; re-exported here so existing callers keep their
 /// import path.
+pub use airc_core::RoomId;
 pub use airc_core::scope_home_is_temp_rooted;
 
 /// Outcome of [`merge_registry_documents`]: the merged view plus the
@@ -76,7 +77,7 @@ pub fn merge_registry_documents(
 ) -> RegistryMergeOutcome {
     let mut ignored_temp_beacons = 0usize;
     let mut generated_at_ms = 0u64;
-    let mut channels: Vec<ChannelName> = Vec::new();
+    let mut rooms: Vec<RoomId> = Vec::new();
     // peer_id -> (heartbeat_at_ms, doc generated_at_ms, beacon)
     let mut freshest: HashMap<airc_core::PeerId, (u64, u64, AccountPeerBeacon)> = HashMap::new();
     // peer_id -> (heartbeat_at_ms, doc generated_at_ms, endpoints,
@@ -98,9 +99,9 @@ pub fn merge_registry_documents(
         }
         matched_any = true;
         generated_at_ms = generated_at_ms.max(document.generated_at_ms);
-        for channel in &document.channels {
-            if !channels.contains(channel) {
-                channels.push(channel.clone());
+        for room_id in &document.rooms {
+            if !rooms.contains(room_id) {
+                rooms.push(*room_id);
             }
         }
         for beacon in document.peers {
@@ -165,13 +166,13 @@ pub fn merge_registry_documents(
         }
     }
     peers.sort_by_key(|peer| peer.peer_id().to_string());
-    channels.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    rooms.sort();
 
     RegistryMergeOutcome {
         document: Some(AccountRegistryDocument::new(
             mesh_identity.clone(),
             generated_at_ms,
-            channels,
+            rooms,
             peers,
         )),
         ignored_temp_beacons,
@@ -216,7 +217,8 @@ pub struct AccountRegistryDocument {
     pub schema_version: u16,
     pub mesh_identity: MeshIdentity,
     pub generated_at_ms: u64,
-    pub channels: Vec<ChannelName>,
+    /// Every room the account knows, BY ID.
+    pub rooms: Vec<RoomId>,
     pub peers: Vec<AccountPeerBeacon>,
 }
 
@@ -224,14 +226,14 @@ impl AccountRegistryDocument {
     pub fn new(
         mesh_identity: MeshIdentity,
         generated_at_ms: u64,
-        channels: Vec<ChannelName>,
+        rooms: Vec<RoomId>,
         peers: Vec<AccountPeerBeacon>,
     ) -> Self {
         Self {
             schema_version: ACCOUNT_REGISTRY_SCHEMA_VERSION,
             mesh_identity,
             generated_at_ms,
-            channels,
+            rooms,
             peers,
         }
     }
@@ -281,7 +283,7 @@ impl AccountRegistryDocument {
         Self::new(
             snapshot.mesh_identity.clone(),
             generated_at_ms,
-            snapshot.live_channels.clone(),
+            snapshot.live_rooms.clone(),
             peers,
         )
     }
@@ -597,29 +599,29 @@ impl Airc {
         // are publishing right now) carrying our dialable endpoints.
         if !document.peers.iter().any(|peer| peer.peer_id() == self_id) {
             // Card cbbcf18d (post-#1146 audit): the stamped self-beacon's
-            // channel list comes from `self.subscriptions()` — the LOCAL
+            // room list comes from `self.subscriptions()` — the LOCAL
             // single source of truth — not from presence-derived
-            // `snapshot.live_channels`. In the exact stale-self scenario
-            // this branch exists for, `live` is empty, so live_channels
+            // `snapshot.live_rooms`. In the exact stale-self scenario
+            // this branch exists for, `live` is empty, so live_rooms
             // is [] even while this scope is subscribed; identity, key,
             // and endpoints already follow the publisher-is-alive
-            // doctrine and the channel list must too.
-            let subscribed_channels: Vec<ChannelName> = self
+            // doctrine and the room list must too.
+            let subscribed_rooms: Vec<RoomId> = self
                 .subscriptions()
                 .await?
                 .into_iter()
-                .map(|subscription| subscription.name)
+                .map(|subscription| subscription.room_id)
                 .collect();
-            for channel in &subscribed_channels {
-                if !document.channels.contains(channel) {
-                    document.channels.push(channel.clone());
+            for room_id in &subscribed_rooms {
+                if !document.rooms.contains(room_id) {
+                    document.rooms.push(*room_id);
                 }
             }
-            document.channels.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+            document.rooms.sort();
             let presence = crate::coordinator::beacon_now(
                 self_id,
                 self.inner.home.clone(),
-                subscribed_channels,
+                subscribed_rooms,
                 std::process::id(),
                 crate::time::now_ms()?,
             );

--- a/crates/airc-lib/src/account_registry_fs.rs
+++ b/crates/airc-lib/src/account_registry_fs.rs
@@ -206,13 +206,13 @@ mod tests {
     // zero GitHub. A regression that made publish clobber (single shared
     // file) or that skipped the merge would drop one machine's peer here.
     use super::*;
-    use crate::account_registry::AccountRoom;
-    use airc_core::RoomId;
     use crate::account_registry::AccountPeerBeacon;
+    use crate::account_registry::AccountRoom;
     use crate::route::RouteEndpoint;
-    use crate::subscriptions::{MeshIdentity};
+    use crate::subscriptions::MeshIdentity;
     use crate::PeerSpec;
     use airc_core::PeerId;
+    use airc_core::RoomId;
     use airc_protocol::PeerKeypair;
     use tempfile::TempDir;
 
@@ -227,7 +227,6 @@ mod tests {
     fn mesh() -> MeshIdentity {
         MeshIdentity::new("joelteply")
     }
-
 
     fn peer_spec(peer_id: PeerId) -> PeerSpec {
         PeerSpec {
@@ -260,7 +259,10 @@ mod tests {
         AccountRegistryDocument::new(
             mesh(),
             generated_at_ms,
-            vec![AccountRoom::new(RoomId::from_u128(1), Some("general".to_string()))],
+            vec![AccountRoom::new(
+                RoomId::from_u128(1),
+                Some("general".to_string()),
+            )],
             vec![peer.clone()],
         )
     }

--- a/crates/airc-lib/src/account_registry_fs.rs
+++ b/crates/airc-lib/src/account_registry_fs.rs
@@ -206,6 +206,7 @@ mod tests {
     // zero GitHub. A regression that made publish clobber (single shared
     // file) or that skipped the merge would drop one machine's peer here.
     use super::*;
+    use crate::account_registry::AccountRoom;
     use airc_core::RoomId;
     use crate::account_registry::AccountPeerBeacon;
     use crate::route::RouteEndpoint;
@@ -259,7 +260,7 @@ mod tests {
         AccountRegistryDocument::new(
             mesh(),
             generated_at_ms,
-            vec![RoomId::from_u128(1)],
+            vec![AccountRoom::new(RoomId::from_u128(1), Some("general".to_string()))],
             vec![peer.clone()],
         )
     }

--- a/crates/airc-lib/src/account_registry_fs.rs
+++ b/crates/airc-lib/src/account_registry_fs.rs
@@ -206,9 +206,10 @@ mod tests {
     // zero GitHub. A regression that made publish clobber (single shared
     // file) or that skipped the merge would drop one machine's peer here.
     use super::*;
+    use airc_core::RoomId;
     use crate::account_registry::AccountPeerBeacon;
     use crate::route::RouteEndpoint;
-    use crate::subscriptions::{ChannelName, MeshIdentity};
+    use crate::subscriptions::{MeshIdentity};
     use crate::PeerSpec;
     use airc_core::PeerId;
     use airc_protocol::PeerKeypair;
@@ -226,9 +227,6 @@ mod tests {
         MeshIdentity::new("joelteply")
     }
 
-    fn channel(name: &str) -> ChannelName {
-        ChannelName::new(name).unwrap()
-    }
 
     fn peer_spec(peer_id: PeerId) -> PeerSpec {
         PeerSpec {
@@ -246,7 +244,7 @@ mod tests {
             presence: crate::coordinator::beacon_now(
                 peer_id,
                 scope_home.into(),
-                vec![channel("general")],
+                vec![RoomId::from_u128(1)],
                 123,
                 FRESH_MS,
             ),
@@ -261,7 +259,7 @@ mod tests {
         AccountRegistryDocument::new(
             mesh(),
             generated_at_ms,
-            vec![channel("general")],
+            vec![RoomId::from_u128(1)],
             vec![peer.clone()],
         )
     }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1865,26 +1865,18 @@ impl Airc {
                     }
                 });
             }
-            subscriptions::RoomIdResolution::Ambiguous(subs) => {
-                return Err(AircError::JoinIdAmbiguous {
-                    token: token.trim().to_string(),
-                    candidates: subs
-                        .iter()
-                        .map(|s| format!("{} ({})", s.name.as_str(), s.room_id))
-                        .collect(),
-                });
-            }
             subscriptions::RoomIdResolution::NotAnId => {}
         }
         let name = ChannelName::new(token)?;
         let labelled: Vec<Subscription> = set.all().filter(|s| s.name == name).cloned().collect();
         if labelled.len() > 1 {
+            // The candidates are IDS. Rendering them into "name (id)"
+            // here would make the caller parse text back apart to get
+            // the one thing it needs — and the one thing it needs is
+            // the id it should have passed instead of the label.
             return Err(AircError::JoinIdAmbiguous {
                 token: token.trim().to_string(),
-                candidates: labelled
-                    .iter()
-                    .map(|s| format!("{} ({})", s.name.as_str(), s.room_id))
-                    .collect(),
+                candidates: labelled.iter().map(|s| s.room_id).collect(),
             });
         }
         if let Some(found) = labelled.into_iter().next() {

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use airc_core::{ClientId, PeerId, ScopeRef, ScopedStateEntry, TranscriptEvent};
+use airc_core::{ClientId, PeerId, RoomId, ScopeRef, ScopedStateEntry, TranscriptEvent};
 use airc_identity::{IdentityError, LocalIdentity};
 use airc_ipc::DaemonClient;
 use airc_protocol::{IdentityAssertion, PeerKeyRegistry, VerificationPolicy};
@@ -1868,19 +1868,39 @@ impl Airc {
             subscriptions::RoomIdResolution::NotAnId => {}
         }
         let name = ChannelName::new(token)?;
-        let labelled: Vec<Subscription> = set.all().filter(|s| s.name == name).cloned().collect();
-        if labelled.len() > 1 {
+        // Collect the IDS, not the subscriptions. `RoomId` is `Copy`, so
+        // this ends the borrow on `set` — which is the whole reason the
+        // collect exists — without copying a `String` + `PathBuf` per
+        // match. The previous shape cloned every candidate and then read
+        // one field off each: N heap allocations to answer "how many, and
+        // which ids", both of which the ids alone already say.
+        let labelled: Vec<RoomId> = set
+            .all()
+            .filter(|s| s.name == name)
+            .map(|s| s.room_id)
+            .collect();
+        match labelled.as_slice() {
             // The candidates are IDS. Rendering them into "name (id)"
             // here would make the caller parse text back apart to get
             // the one thing it needs — and the one thing it needs is
             // the id it should have passed instead of the label.
-            return Err(AircError::JoinIdAmbiguous {
-                token: token.trim().to_string(),
-                candidates: labelled.iter().map(|s| s.room_id).collect(),
-            });
-        }
-        if let Some(found) = labelled.into_iter().next() {
-            return Ok(found);
+            [_, _, ..] => {
+                return Err(AircError::JoinIdAmbiguous {
+                    token: token.trim().to_string(),
+                    candidates: labelled,
+                })
+            }
+            // ONE clone, and only here: the return type is owned, and a
+            // borrow cannot escape a `&mut set` the caller goes on to
+            // mutate. That is the "unless absolutely necessary" case.
+            [only] => {
+                let only = *only;
+                return set
+                    .get(only)
+                    .cloned()
+                    .ok_or_else(|| subscriptions::SubscriptionError::UnknownRoom(only).into());
+            }
+            [] => {}
         }
         // Not in THIS scope — ask the ACCOUNT. Every scope on this
         // machine shares one room directory, so the label resolves to

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1877,8 +1877,7 @@ impl Airc {
             subscriptions::RoomIdResolution::NotAnId => {}
         }
         let name = ChannelName::new(token)?;
-        let labelled: Vec<Subscription> =
-            set.all().filter(|s| s.name == name).cloned().collect();
+        let labelled: Vec<Subscription> = set.all().filter(|s| s.name == name).cloned().collect();
         if labelled.len() > 1 {
             return Err(AircError::JoinIdAmbiguous {
                 token: token.trim().to_string(),
@@ -2229,8 +2228,11 @@ impl Airc {
 
         let identity = self.mesh_identity().await?;
         let subscription = self.resolve_or_mint(&mut set, landing).await?;
-        let subscription =
-            set.join(&self.inner.wire_root, subscription.room_id, subscription.name)?;
+        let subscription = set.join(
+            &self.inner.wire_root,
+            subscription.room_id,
+            subscription.name,
+        )?;
         set.set_default(subscription.room_id)?;
         subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set).await?;

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -2451,6 +2451,14 @@ mod trust_tier_wire_str {
     }
 }
 
+/// How much room history a wall projection folds in.
+///
+/// Generous because a busy room accumulates pinned posts over time, and a
+/// wall post that scrolls out of the window silently stops being true —
+/// which is worse than a slow read. Declared once so `wall_posts` and
+/// `wall_posts_in` can never disagree about what "the wall" means.
+pub const WALL_PROJECTION_PAGE_SIZE: usize = 500;
+
 /// Pure discriminator: recover the `WallPostPublished` carried by a
 /// transcript event's self-describing body, or `None` if the event is
 /// not a wall post.
@@ -2463,15 +2471,6 @@ mod trust_tier_wire_str {
 /// deserializes to this variant for an actual wall post, so it is the
 /// authoritative identity; doctrine / identity / chat bodies fall through
 /// to `None` (heterogeneous-stream projection, not error-swallowing).
-
-/// How much room history a wall projection folds in.
-///
-/// Generous because a busy room accumulates pinned posts over time, and a
-/// wall post that scrolls out of the window silently stops being true —
-/// which is worse than a slow read. Declared once so `wall_posts` and
-/// `wall_posts_in` can never disagree about what "the wall" means.
-pub const WALL_PROJECTION_PAGE_SIZE: usize = 500;
-
 fn wall_post_from_event(
     event: airc_core::TranscriptEvent,
 ) -> Option<airc_core::doctrine::WallPostPublished> {

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -43,7 +43,7 @@ use crate::room::Room;
 use crate::route::health::TransportHealthTable;
 use crate::route::invite::{ImportedInviteTable, RouteEndpointTable};
 use crate::route::TransportHealthSample;
-use crate::subscriptions::{self, ChannelName, MeshIdentity};
+use crate::subscriptions::{self, ChannelName, MeshIdentity, Subscription};
 use crate::transport::FrameSubscriber;
 use crate::webrtc_media::{IncomingTrack, IncomingTrackHandler, IncomingTrackRegistry};
 use crate::{coordinator, time};
@@ -1783,11 +1783,11 @@ impl Airc {
         identity: &MeshIdentity,
         set: &subscriptions::SubscriptionSet,
     ) -> Result<(), AircError> {
-        let channels = set.channel_names().cloned().collect();
+        let rooms = set.room_ids().copied().collect();
         let beacon = coordinator::beacon_now(
             self.inner.identity.peer_id,
             self.inner.home.clone(),
-            channels,
+            rooms,
             std::process::id(),
             time::now_ms()?,
         );
@@ -1839,62 +1839,75 @@ impl Airc {
         self.join_channel(name, Focus::Keep).await
     }
 
-    async fn join_channel(&self, name: &str, focus: Focus) -> Result<Room, AircError> {
-        let identity = self.mesh_identity().await?;
-        let mut set = subscriptions::load_or_init(self.event_store()).await?;
-        // Self-healing join: `mesh_identity()` above may have HEALED
-        // (re-resolved) since these subscriptions were stored — re-bind
-        // any room UUID that no longer derives from its stored name, or
-        // this scope keeps reading (and attaching to) a dead diverged
-        // room while inbound frames land in the converged one. Saved +
-        // re-beaconed by the save/publish_presence below.
-        warn_subscription_rebinds(&set.rebind_diverged(&identity));
-        // Card c409eaf5, both octaves: an id-shaped token must RESOLVE
-        // against the channels this scope already knows, never reach
-        // `ChannelName::new` (which would hash it into a brand-new
-        // channel). Octave 1 (2026-06-01, continuum demo): a FULL uuid
-        // string minted a diverged channel — refused since. Octave 2
-        // (2026-08-11): the 8-hex SHORT id walked past that guard and
-        // minted ghost room 7d1a76de from academy's prefix "3be59578" —
-        // this scope then wrote and read a room nobody else was in, and
-        // every store read looked like a monologue. Resolution wins
-        // over refusal: a token matching exactly one subscribed channel
-        // binds to THAT room; no match or several is a loud error.
-        let channel = match set.resolve_id_token(name) {
-            subscriptions::IdTokenResolution::Match(sub) => sub.name.clone(),
-            subscriptions::IdTokenResolution::NotAnId => ChannelName::new(name)?,
-            subscriptions::IdTokenResolution::Unknown => {
-                // Preserve the documented c409eaf5 error for full-uuid
-                // tokens; the short-id form gets its own guidance.
-                return Err(if uuid::Uuid::parse_str(name.trim()).is_ok() {
+    /// Resolve `token` to a room this scope can join, MINTING one only
+    /// when the token names no room already known here.
+    ///
+    /// An id-shaped token is an id: it resolves against the rooms this
+    /// scope holds, and a token that matches none — or several — is a
+    /// loud error, never a new room. A label matches at most one room
+    /// (labels key nothing, so several sharing one is the caller's
+    /// answer to give by id).
+    fn resolve_or_mint(
+        &self,
+        set: &mut subscriptions::SubscriptionSet,
+        token: &str,
+    ) -> Result<Subscription, AircError> {
+        match set.resolve_room_id(token) {
+            subscriptions::RoomIdResolution::Match(sub) => return Ok(sub.clone()),
+            subscriptions::RoomIdResolution::Unknown => {
+                return Err(if uuid::Uuid::parse_str(token.trim()).is_ok() {
                     AircError::JoinUuidString {
-                        string: name.to_string(),
+                        string: token.to_string(),
                     }
                 } else {
                     AircError::JoinIdUnknown {
-                        token: name.trim().to_string(),
+                        token: token.trim().to_string(),
                     }
                 });
             }
-            subscriptions::IdTokenResolution::Ambiguous(subs) => {
+            subscriptions::RoomIdResolution::Ambiguous(subs) => {
                 return Err(AircError::JoinIdAmbiguous {
-                    token: name.trim().to_string(),
+                    token: token.trim().to_string(),
                     candidates: subs
                         .iter()
                         .map(|s| format!("{} ({})", s.name.as_str(), s.room_id))
                         .collect(),
                 });
             }
-        };
-        let subscription =
-            set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
+            subscriptions::RoomIdResolution::NotAnId => {}
+        }
+        let name = ChannelName::new(token)?;
+        let labelled: Vec<Subscription> =
+            set.all().filter(|s| s.name == name).cloned().collect();
+        if labelled.len() > 1 {
+            return Err(AircError::JoinIdAmbiguous {
+                token: token.trim().to_string(),
+                candidates: labelled
+                    .iter()
+                    .map(|s| format!("{} ({})", s.name.as_str(), s.room_id))
+                    .collect(),
+            });
+        }
+        if let Some(found) = labelled.into_iter().next() {
+            return Ok(found);
+        }
+        Ok(set.create(&self.inner.wire_root, name)?)
+    }
+
+    async fn join_channel(&self, name: &str, focus: Focus) -> Result<Room, AircError> {
+        let identity = self.mesh_identity().await?;
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
+        let subscription = self.resolve_or_mint(&mut set, name)?;
+        let room_id = subscription.room_id;
+        let channel = subscription.name.clone();
+        set.join(&self.inner.wire_root, room_id, channel.clone())?;
         if focus == Focus::MakeDefault {
-            set.set_default(channel.clone())?;
+            set.set_default(room_id)?;
         }
         // Whether this room ended up default is now a FACT to read, not a
-        // constant to assert: `subscribe_with_wire_root` seeds the default when
-        // the scope had none, so a first room is default under either focus.
-        let is_default = set.default_subscription().map(|s| &s.name) == Some(&channel);
+        // constant to assert: `join` seeds the default when the scope had
+        // none, so a first room is default under either focus.
+        let is_default = set.default == Some(room_id);
         subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set).await?;
         let room = subscription.as_room();
@@ -2053,12 +2066,6 @@ impl Airc {
     pub async fn ensure_join_context(&self, context: JoinContext) -> Result<Vec<Room>, AircError> {
         let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
-        // Self-healing join: this method re-runs constantly (bare
-        // `airc join`, init re-runs, daemon-bounce recovery, monitor
-        // resume) — it is the join-shaped touchpoint where a healed
-        // mesh identity re-binds stale subscriptions to their converged
-        // room UUIDs. See `SubscriptionSet::rebind_diverged`.
-        warn_subscription_rebinds(&set.rebind_diverged(&identity));
         let mut rooms = Vec::new();
 
         // Card 1eae6f3e: the default room is DURABLE scope state. This
@@ -2071,26 +2078,44 @@ impl Airc {
         // BEFORE this run so the context default is promoted only when
         // it is genuinely new to this scope (first entry into a project
         // context) — never to overwrite an established default.
-        let previous_default = set.default.clone();
-        let context_default_was_subscribed = set.subscribed.contains_key(&context.default);
+        let previous_default = set.default;
 
+        let mut context_default_room: Option<airc_core::RoomId> = None;
+        let mut context_default_was_subscribed = false;
         for channel in context.channels {
-            if set.parted.contains(&channel) {
+            let is_context_default = channel == context.default;
+            let existing = set
+                .all()
+                .find(|s| s.name == channel)
+                .map(|s| (s.room_id, true));
+            let (room_id, was_subscribed) = match existing {
+                Some(found) => found,
+                None => (
+                    set.create(&self.inner.wire_root, channel.clone())?.room_id,
+                    false,
+                ),
+            };
+            if is_context_default {
+                context_default_room = Some(room_id);
+                context_default_was_subscribed = was_subscribed;
+            }
+            if set.parted.contains(&room_id) {
                 continue;
             }
-            let subscription =
-                set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel)?;
+            let subscription = set.join(&self.inner.wire_root, room_id, channel)?;
             rooms.push(subscription.as_room());
         }
 
         let default_missing_or_dangling = match &set.default {
             None => true,
-            Some(name) => !set.subscribed.contains_key(name),
+            Some(room_id) => !set.subscribed.contains_key(room_id),
         };
-        if set.subscribed.contains_key(&context.default)
-            && (default_missing_or_dangling || !context_default_was_subscribed)
-        {
-            set.set_default(context.default)?;
+        if let Some(room_id) = context_default_room {
+            if set.subscribed.contains_key(&room_id)
+                && (default_missing_or_dangling || !context_default_was_subscribed)
+            {
+                set.set_default(room_id)?;
+            }
         }
         if let (Some(old), Some(new)) = (&previous_default, &set.default) {
             if old != new {
@@ -2099,8 +2124,8 @@ impl Airc {
                 // `airc msg` in this scope. Never let it happen
                 // silently.
                 tracing::warn!(
-                    old = %old.display_with_hash(),
-                    new = %new.display_with_hash(),
+                    old = %old,
+                    new = %new,
                     "default room CHANGED by join context — short-shape sends now target the new room"
                 );
             }
@@ -2129,13 +2154,14 @@ impl Airc {
     pub async fn part_channel(&self, name: Option<&str>) -> Result<Room, AircError> {
         let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
-        let channel = match name {
-            Some(name) => ChannelName::new(name)?,
-            None => set.default.clone().ok_or(AircError::NoCurrentRoom)?,
+        let room_id = match name {
+            Some(name) => self.resolve_or_mint(&mut set, name)?.room_id,
+            None => set.default.ok_or(AircError::NoCurrentRoom)?,
         };
         let removed = set
-            .unsubscribe(&channel)
-            .ok_or_else(|| AircError::NotSubscribed(channel.display_with_hash()))?;
+            .unsubscribe(&room_id)
+            .ok_or_else(|| AircError::NotSubscribed(room_id.to_string()))?;
+        let channel = removed.name.clone();
         subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set).await?;
 
@@ -2181,10 +2207,10 @@ impl Airc {
         }
 
         let identity = self.mesh_identity().await?;
-        let channel = ChannelName::new(landing)?;
+        let subscription = self.resolve_or_mint(&mut set, landing)?;
         let subscription =
-            set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
-        set.set_default(channel)?;
+            set.join(&self.inner.wire_root, subscription.room_id, subscription.name)?;
+        set.set_default(subscription.room_id)?;
         subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set).await?;
         // Same publish-on-subscribe semantics as Airc::join /
@@ -2414,24 +2440,6 @@ mod trust_tier_wire_str {
 /// deserializes to this variant for an actual wall post, so it is the
 /// authoritative identity; doctrine / identity / chat bodies fall through
 /// to `None` (heterogeneous-stream projection, not error-swallowing).
-/// Self-healing join — receive-binding re-derive on identity heal: be
-/// LOUD about every subscription whose stored room UUID was re-bound to
-/// the current derivation of its stored name. A silent rebind would hide
-/// a mesh-identity change that re-targets what this scope reads; the
-/// old UUID stays reachable via the router bridge's per-frame name
-/// reconvergence, so naming old→new here is the operator's only signal.
-fn warn_subscription_rebinds(rebinds: &[subscriptions::SubscriptionRebind]) {
-    for rebind in rebinds {
-        tracing::warn!(
-            channel = %rebind.name.display_with_hash(),
-            old_room_id = %rebind.old_room_id,
-            new_room_id = %rebind.new_room_id,
-            "subscription REBOUND: stored room UUID no longer derives from this \
-             scope's mesh identity (identity healed since join) — re-bound to the \
-             converged room so inbound frames and reads converge again"
-        );
-    }
-}
 
 /// How much room history a wall projection folds in.
 ///

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -2919,10 +2919,7 @@ mod publish_identity_tests {
         );
 
         let set = airc.subscription_set().await.expect("subscription set");
-        let names: Vec<String> = set
-            .channel_names()
-            .map(|c| c.as_str().to_string())
-            .collect();
+        let names: Vec<String> = set.all().map(|s| s.name.as_str().to_string()).collect();
         assert!(
             names.iter().any(|n| n == "academy") && names.iter().any(|n| n == "cambriantech"),
             "she is a member of BOTH rooms, not just the focused one: {names:?}"

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1922,11 +1922,57 @@ impl Airc {
     }
 
     async fn join_channel(&self, name: &str, focus: Focus) -> Result<Room, AircError> {
-        let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let subscription = self.resolve_or_mint(&mut set, name).await?;
+        self.commit_join(set, subscription, focus).await
+    }
+
+    /// Join the room `room_id` NAMES, labelling it `label` locally.
+    ///
+    /// This is the rendezvous verb, and the only honest way for two
+    /// scopes that have never met to end up in the SAME room. `join`
+    /// takes a token a human typed, so across two machines it mints
+    /// two rooms that merely share a label — the label keys nothing.
+    /// Here the caller already holds the id (from an
+    /// [`InviteBeacon`](crate::InviteBeacon), a peer's presence, a
+    /// link someone pasted), so there is nothing to resolve and
+    /// nothing to mint: the id IS the room.
+    ///
+    /// The label is local display only. Two scopes in one room may
+    /// call it different things and still be in one room, because
+    /// membership is keyed by the id and never by what either of them
+    /// wrote on the door.
+    ///
+    /// Focus moves, exactly as in [`Self::join`] — this is that same
+    /// verb with the room named by id instead of by token, so it
+    /// carries the same meaning for the caller. The membership-without
+    /// -focus half of the pair ([`Self::subscribe_room`]) has no by-id
+    /// twin yet because nothing needs one; `commit_join` already takes
+    /// the focus, so adding `subscribe_room_id` is a three-line
+    /// wrapper on the day a citizen wants it.
+    pub async fn join_room_id(&self, room_id: RoomId, label: &str) -> Result<Room, AircError> {
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
+        let subscription = set.join(&self.inner.wire_root, room_id, ChannelName::new(label)?)?;
+        self.commit_join(set, subscription, Focus::MakeDefault)
+            .await
+    }
+
+    /// Make a resolved subscription durable and announce it: save,
+    /// re-beacon presence, emit `RoomJoined`, publish the identity
+    /// card. Every join lands here regardless of how the room was
+    /// named, so a by-id join is observable on exactly the same terms
+    /// as a by-label one — no second lifecycle to drift.
+    async fn commit_join(
+        &self,
+        mut set: subscriptions::SubscriptionSet,
+        subscription: Subscription,
+        focus: Focus,
+    ) -> Result<Room, AircError> {
+        let identity = self.mesh_identity().await?;
         let room_id = subscription.room_id;
         let channel = subscription.name.clone();
+        // Idempotent by contract (an existing subscription is returned
+        // as-is), so the by-id path re-stating its own join is free.
         set.join(&self.inner.wire_root, room_id, channel.clone())?;
         if focus == Focus::MakeDefault {
             set.set_default(room_id)?;

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1847,7 +1847,7 @@ impl Airc {
     /// loud error, never a new room. A label matches at most one room
     /// (labels key nothing, so several sharing one is the caller's
     /// answer to give by id).
-    fn resolve_or_mint(
+    async fn resolve_or_mint(
         &self,
         set: &mut subscriptions::SubscriptionSet,
         token: &str,
@@ -1891,13 +1891,29 @@ impl Airc {
         if let Some(found) = labelled.into_iter().next() {
             return Ok(found);
         }
-        Ok(set.create(&self.inner.wire_root, name)?)
+        // Not in THIS scope — ask the ACCOUNT. Every scope on this
+        // machine shares one room directory, so the label resolves to
+        // whatever id the first scope to use it minted, and this scope
+        // JOINS that room instead of minting a second one. Without this
+        // hop, `~/.airc` and `repo/.airc` would each hold their own
+        // private `#general` and never see each other.
+        let candidate = Subscription::minting(&self.inner.wire_root, name.clone())?;
+        let room_id = self
+            .coordinator_store()
+            .claim_room_label(name.as_str(), candidate.room_id, time::now_ms()?)
+            .await
+            .map_err(subscriptions::SubscriptionError::from)?;
+        if room_id == candidate.room_id {
+            set.insert_subscription(candidate.clone());
+            return Ok(candidate);
+        }
+        Ok(set.join(&self.inner.wire_root, room_id, name)?)
     }
 
     async fn join_channel(&self, name: &str, focus: Focus) -> Result<Room, AircError> {
         let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
-        let subscription = self.resolve_or_mint(&mut set, name)?;
+        let subscription = self.resolve_or_mint(&mut set, name).await?;
         let room_id = subscription.room_id;
         let channel = subscription.name.clone();
         set.join(&self.inner.wire_root, room_id, channel.clone())?;
@@ -2090,8 +2106,13 @@ impl Airc {
                 .map(|s| (s.room_id, true));
             let (room_id, was_subscribed) = match existing {
                 Some(found) => found,
+                // Same account hop as `resolve_or_mint`: the context's
+                // rooms must be the ones the account already has, or
+                // every scope infers its own private `#general`.
                 None => (
-                    set.create(&self.inner.wire_root, channel.clone())?.room_id,
+                    self.resolve_or_mint(&mut set, channel.as_str())
+                        .await?
+                        .room_id,
                     false,
                 ),
             };
@@ -2155,7 +2176,7 @@ impl Airc {
         let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let room_id = match name {
-            Some(name) => self.resolve_or_mint(&mut set, name)?.room_id,
+            Some(name) => self.resolve_or_mint(&mut set, name).await?.room_id,
             None => set.default.ok_or(AircError::NoCurrentRoom)?,
         };
         let removed = set
@@ -2207,7 +2228,7 @@ impl Airc {
         }
 
         let identity = self.mesh_identity().await?;
-        let subscription = self.resolve_or_mint(&mut set, landing)?;
+        let subscription = self.resolve_or_mint(&mut set, landing).await?;
         let subscription =
             set.join(&self.inner.wire_root, subscription.room_id, subscription.name)?;
         set.set_default(subscription.room_id)?;

--- a/crates/airc-lib/src/coordinator.rs
+++ b/crates/airc-lib/src/coordinator.rs
@@ -43,13 +43,14 @@
 //! were removed after the SeaORM cut so production callers cannot
 //! accidentally reintroduce split-brain JSON presence state.
 
-use std::collections::HashMap;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::subscriptions::{ChannelName, ChannelNameError, MeshIdentity};
-use airc_core::PeerId;
+use crate::subscriptions::{ChannelNameError, MeshIdentity};
+use airc_core::{PeerId, RoomId};
+use uuid::Uuid;
 use airc_store::{EventStore, StoreError, StoredBeacon, StoredRefreshLockOutcome};
 
 const BEACON_VERSION: u32 = 1;
@@ -96,7 +97,9 @@ pub struct PresenceBeacon {
     /// different dirs (e.g., a CLI tab in `~/.airc/` vs. a project
     /// agent in `~/Development/foo/.airc/`).
     pub scope_home: PathBuf,
-    pub subscribed_channels: Vec<ChannelName>,
+    /// The rooms this scope is in, BY ID — the address a peer
+    /// routes to. A label would tell a peer nothing it can deliver on.
+    pub subscribed_rooms: Vec<RoomId>,
     /// Process id at publish time. Inspectable but never load-bearing
     /// for the freshness decision (heartbeat_at_ms is the truth).
     /// PID collisions across reboots make pid-only liveness checks
@@ -126,9 +129,9 @@ pub struct CoordinatorSnapshot {
     pub root: PathBuf,
     pub live: Vec<PresenceBeacon>,
     pub stale: Vec<PresenceBeacon>,
-    /// Channels mentioned by at least one live beacon. Useful for
+    /// Rooms mentioned by at least one live beacon. Useful for
     /// "which rooms are active on this machine right now" status.
-    pub live_channels: Vec<ChannelName>,
+    pub live_rooms: Vec<RoomId>,
     pub fetched_at_ms: u64,
 }
 
@@ -262,13 +265,13 @@ pub async fn snapshot_store(
     }
     live.sort_by_key(|b| b.peer_id.to_string());
     stale.sort_by_key(|b| b.peer_id.to_string());
-    let live_channels = unique_channels_in(&live);
+    let live_rooms = unique_rooms_in(&live);
     Ok(CoordinatorSnapshot {
         mesh_identity: identity.clone(),
         root: PathBuf::from("airc-store://beacons"),
         live,
         stale,
-        live_channels,
+        live_rooms,
         fetched_at_ms: now_ms,
     })
 }
@@ -349,18 +352,12 @@ pub async fn release_refresh_lock(
     Ok(())
 }
 
-fn unique_channels_in(beacons: &[PresenceBeacon]) -> Vec<ChannelName> {
-    let mut by_name: HashMap<String, ChannelName> = HashMap::new();
+fn unique_rooms_in(beacons: &[PresenceBeacon]) -> Vec<RoomId> {
+    let mut seen: BTreeSet<RoomId> = BTreeSet::new();
     for beacon in beacons {
-        for channel in &beacon.subscribed_channels {
-            by_name
-                .entry(channel.as_str().to_string())
-                .or_insert_with(|| channel.clone());
-        }
+        seen.extend(beacon.subscribed_rooms.iter().copied());
     }
-    let mut out: Vec<ChannelName> = by_name.into_values().collect();
-    out.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-    out
+    seen.into_iter().collect()
 }
 
 fn to_stored_beacon(identity: &MeshIdentity, beacon: &PresenceBeacon) -> StoredBeacon {
@@ -369,9 +366,9 @@ fn to_stored_beacon(identity: &MeshIdentity, beacon: &PresenceBeacon) -> StoredB
         peer_id: beacon.peer_id,
         scope_home: beacon.scope_home.to_string_lossy().to_string(),
         subscribed_channels: beacon
-            .subscribed_channels
+            .subscribed_rooms
             .iter()
-            .map(|channel| channel.as_str().to_string())
+            .map(RoomId::to_string)
             .collect(),
         pid: beacon.pid,
         published_at_ms: beacon.published_at_ms,
@@ -380,16 +377,19 @@ fn to_stored_beacon(identity: &MeshIdentity, beacon: &PresenceBeacon) -> StoredB
 }
 
 fn from_stored_beacon(beacon: StoredBeacon) -> Result<PresenceBeacon, CoordinatorError> {
-    let subscribed_channels = beacon
+    // Rows are room IDS. A row that doesn't parse as one predates the
+    // id key and addresses nothing routable, so it is dropped rather
+    // than guessed at.
+    let subscribed_rooms = beacon
         .subscribed_channels
         .into_iter()
-        .map(ChannelName::new)
-        .collect::<Result<Vec<_>, _>>()?;
+        .filter_map(|raw| raw.parse::<Uuid>().ok().map(RoomId::from_uuid))
+        .collect();
     Ok(PresenceBeacon {
         version: BEACON_VERSION,
         peer_id: beacon.peer_id,
         scope_home: PathBuf::from(beacon.scope_home),
-        subscribed_channels,
+        subscribed_rooms,
         pid: beacon.pid,
         published_at_ms: beacon.published_at_ms,
         heartbeat_at_ms: beacon.heartbeat_at_ms,
@@ -402,7 +402,7 @@ fn from_stored_beacon(beacon: StoredBeacon) -> Result<PresenceBeacon, Coordinato
 pub fn beacon_now(
     peer_id: PeerId,
     scope_home: PathBuf,
-    subscribed_channels: Vec<ChannelName>,
+    subscribed_rooms: Vec<RoomId>,
     pid: u32,
     now_ms: u64,
 ) -> PresenceBeacon {
@@ -410,7 +410,7 @@ pub fn beacon_now(
         version: BEACON_VERSION,
         peer_id,
         scope_home,
-        subscribed_channels,
+        subscribed_rooms,
         pid,
         published_at_ms: now_ms,
         heartbeat_at_ms: now_ms,

--- a/crates/airc-lib/src/coordinator.rs
+++ b/crates/airc-lib/src/coordinator.rs
@@ -435,15 +435,17 @@ mod tests {
         PeerId::from_uuid(Uuid::new_v4())
     }
 
-    fn channel(name: &str) -> ChannelName {
-        ChannelName::new(name).unwrap()
+    /// A stable test room id. Production ids are minted; these are
+    /// hand-picked so assertions can name the room they mean.
+    fn room(n: u128) -> RoomId {
+        RoomId::from_u128(n)
     }
 
-    fn make_beacon(now_ms: u64, channels: Vec<&str>) -> PresenceBeacon {
+    fn make_beacon(now_ms: u64, rooms: Vec<RoomId>) -> PresenceBeacon {
         beacon_now(
             peer(),
             PathBuf::from("/tmp/x/.airc"),
-            channels.into_iter().map(channel).collect(),
+            rooms,
             12345,
             now_ms,
         )
@@ -476,8 +478,8 @@ mod tests {
             heartbeat_ttl_ms: 1_000,
             refresh_interval_ms: 100,
         };
-        let fresh = make_beacon(950, vec!["general", "cambriantech"]);
-        let stale = make_beacon(0, vec!["ideem"]);
+        let fresh = make_beacon(950, vec![room(1), room(2)]);
+        let stale = make_beacon(0, vec![room(3)]);
 
         publish_store(&store, &mesh, &fresh).await.unwrap();
         publish_store(&store, &mesh, &stale).await.unwrap();
@@ -491,14 +493,7 @@ mod tests {
         let snapshot = snapshot_store(&store, &mesh, &cfg, 1_000).await.unwrap();
         assert_eq!(snapshot.live.len(), 1);
         assert_eq!(snapshot.stale.len(), 1);
-        assert_eq!(
-            snapshot
-                .live_channels
-                .iter()
-                .map(ChannelName::as_str)
-                .collect::<Vec<_>>(),
-            vec!["cambriantech", "general"]
-        );
+        assert_eq!(snapshot.live_rooms, vec![room(1), room(2)]);
 
         assert_eq!(
             drain_stale_store(&store, &mesh, &snapshot).await.unwrap(),
@@ -525,8 +520,8 @@ mod tests {
             refresh_interval_ms: 100,
         };
 
-        let fresh = make_beacon(950, vec!["general"]);
-        let stale = make_beacon(0, vec!["cambriantech"]);
+        let fresh = make_beacon(950, vec![room(1)]);
+        let stale = make_beacon(0, vec![room(2)]);
         publish_store(&store, &mesh, &fresh).await.unwrap();
         publish_store(&store, &mesh, &stale).await.unwrap();
 
@@ -543,14 +538,17 @@ mod tests {
         let mesh = id();
         let cfg = CoordinatorConfig::default();
 
-        let a = make_beacon(1_000, vec!["general", "cambriantech"]);
-        let b = make_beacon(1_000, vec!["general", "ideem"]);
+        let a = make_beacon(1_000, vec![room(1), room(2)]);
+        let b = make_beacon(1_000, vec![room(1), room(3)]);
         publish_store(&store, &mesh, &a).await.unwrap();
         publish_store(&store, &mesh, &b).await.unwrap();
 
         let snap = snapshot_store(&store, &mesh, &cfg, 1_000).await.unwrap();
-        let names: Vec<&str> = snap.live_channels.iter().map(ChannelName::as_str).collect();
-        assert_eq!(names, vec!["cambriantech", "general", "ideem"]);
+        assert_eq!(
+            snap.live_rooms,
+            vec![room(1), room(2), room(3)],
+            "deduplicated and sorted by id"
+        );
     }
 
     #[tokio::test]
@@ -561,15 +559,15 @@ mod tests {
             .unwrap();
         assert!(snap.live.is_empty());
         assert!(snap.stale.is_empty());
-        assert!(snap.live_channels.is_empty());
+        assert!(snap.live_rooms.is_empty());
     }
 
     #[tokio::test]
     async fn snapshot_isolates_identities() {
         let store = airc_store::InMemoryEventStore::new();
         let cfg = CoordinatorConfig::default();
-        let mine = make_beacon(1_000, vec!["general"]);
-        let theirs = make_beacon(1_000, vec!["general"]);
+        let mine = make_beacon(1_000, vec![room(1)]);
+        let theirs = make_beacon(1_000, vec![room(1)]);
         publish_store(&store, &id(), &mine).await.unwrap();
         publish_store(&store, &other_id(), &theirs).await.unwrap();
 
@@ -591,8 +589,8 @@ mod tests {
             heartbeat_ttl_ms: 1_000,
             refresh_interval_ms: 100,
         };
-        let fresh = make_beacon(950, vec!["general"]);
-        let stale = make_beacon(0, vec!["general"]);
+        let fresh = make_beacon(950, vec![room(1)]);
+        let stale = make_beacon(0, vec![room(1)]);
         publish_store(&store, &mesh, &fresh).await.unwrap();
         publish_store(&store, &mesh, &stale).await.unwrap();
 
@@ -616,7 +614,7 @@ mod tests {
             ..beacon_now(
                 peer_id,
                 PathBuf::from("/tmp/x/.airc"),
-                vec![channel("general")],
+                vec![room(1)],
                 100,
                 1_000,
             )
@@ -804,7 +802,7 @@ mod tests {
 
     #[test]
     fn beacon_is_fresh_uses_saturating_sub_for_clock_skew() {
-        let beacon = make_beacon(2_000, vec!["general"]);
+        let beacon = make_beacon(2_000, vec![room(1)]);
         // now_ms < heartbeat_at_ms — saturating yields 0, < ttl, so fresh.
         assert!(beacon.is_fresh(1_000, 500));
     }

--- a/crates/airc-lib/src/coordinator.rs
+++ b/crates/airc-lib/src/coordinator.rs
@@ -50,8 +50,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::subscriptions::{ChannelNameError, MeshIdentity};
 use airc_core::{PeerId, RoomId};
-use uuid::Uuid;
 use airc_store::{EventStore, StoreError, StoredBeacon, StoredRefreshLockOutcome};
+use uuid::Uuid;
 
 const BEACON_VERSION: u32 = 1;
 const ACCOUNTS_DIR: &str = "accounts";
@@ -442,13 +442,7 @@ mod tests {
     }
 
     fn make_beacon(now_ms: u64, rooms: Vec<RoomId>) -> PresenceBeacon {
-        beacon_now(
-            peer(),
-            PathBuf::from("/tmp/x/.airc"),
-            rooms,
-            12345,
-            now_ms,
-        )
+        beacon_now(peer(), PathBuf::from("/tmp/x/.airc"), rooms, 12345, now_ms)
     }
 
     #[test]

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -128,7 +128,11 @@ pub enum AircError {
     )]
     JoinIdAmbiguous {
         token: String,
-        candidates: Vec<String>,
+        /// The rooms carrying that label, BY ID — the answer the caller
+        /// re-issues its join with. Not pre-rendered text: a caller that
+        /// wants a display name reads it off the room, and one that just
+        /// wants to retry needs the id and nothing else.
+        candidates: Vec<airc_core::RoomId>,
     },
 
     /// Caller attempted to mutate a work card from a room whose work

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -85,7 +85,7 @@ pub mod work_subscription;
 
 pub use account_registry::{
     merge_registry_documents, prune_stale_peers, scope_home_is_temp_rooted, AccountPeerBeacon,
-    AccountRegistryDocument, AccountRegistryError, AccountRegistryStore, RegistryMergeOutcome,
+    AccountRegistryDocument, AccountRegistryError, AccountRoom, AccountRegistryStore, RegistryMergeOutcome,
     SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION, DEFAULT_PEER_FRESHNESS_TTL_MS,
 };
 pub use account_registry_fs::FsAccountRegistryStore;

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -189,8 +189,8 @@ pub use route_forwarder::{RoutedForwarder, RoutedForwarderConfig};
 pub use router_bridge::{InboundDeliveryVerdict, InboundFrameSink, RouterInboundBridge};
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use subscriptions::{
-    derive_room_id, ChannelName, ChannelNameError, MeshIdentity, Subscription, SubscriptionError,
-    SubscriptionSet,
+    ChannelName, ChannelNameError, MeshIdentity, RoomIdResolution, Subscription,
+    SubscriptionError, SubscriptionSet,
 };
 pub use task_negotiation::{
     HEADER_AIRC_TASK_ACCEPTED, HEADER_AIRC_TASK_OFFER, HEADER_AIRC_TASK_REQUEST,

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -85,8 +85,9 @@ pub mod work_subscription;
 
 pub use account_registry::{
     merge_registry_documents, prune_stale_peers, scope_home_is_temp_rooted, AccountPeerBeacon,
-    AccountRegistryDocument, AccountRegistryError, AccountRoom, AccountRegistryStore, RegistryMergeOutcome,
-    SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION, DEFAULT_PEER_FRESHNESS_TTL_MS,
+    AccountRegistryDocument, AccountRegistryError, AccountRegistryStore, AccountRoom,
+    RegistryMergeOutcome, SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION,
+    DEFAULT_PEER_FRESHNESS_TTL_MS,
 };
 pub use account_registry_fs::FsAccountRegistryStore;
 pub use agent_heartbeat::{
@@ -189,8 +190,8 @@ pub use route_forwarder::{RoutedForwarder, RoutedForwarderConfig};
 pub use router_bridge::{InboundDeliveryVerdict, InboundFrameSink, RouterInboundBridge};
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use subscriptions::{
-    ChannelName, ChannelNameError, MeshIdentity, RoomIdResolution, Subscription,
-    SubscriptionError, SubscriptionSet,
+    ChannelName, ChannelNameError, MeshIdentity, RoomIdResolution, Subscription, SubscriptionError,
+    SubscriptionSet,
 };
 pub use task_negotiation::{
     HEADER_AIRC_TASK_ACCEPTED, HEADER_AIRC_TASK_OFFER, HEADER_AIRC_TASK_REQUEST,

--- a/crates/airc-lib/src/publish.rs
+++ b/crates/airc-lib/src/publish.rs
@@ -150,15 +150,26 @@ impl Airc {
         let channel_name = subscriptions::ChannelName::new(name_or_channel).map_err(|error| {
             AircError::Route(format!("channel name {name_or_channel:?}: {error}"))
         })?;
-        set.subscribed
-            .get(&channel_name)
-            .map(|subscription| subscription.as_room())
-            .ok_or_else(|| {
-                AircError::Route(format!(
-                    "refusing to {verb} {name_or_channel:?}: this scope is not subscribed to that \
-                     channel. join the room first (this does not auto-join)."
-                ))
-            })
+        // A LABEL lookup, scanning the display names of rooms this scope
+        // is in. Labels key nothing, so two rooms may legitimately carry
+        // the same one — that is the caller's answer to resolve by id,
+        // never ours to pick for them.
+        let mut matches = set.all().filter(|s| s.name == channel_name);
+        let Some(subscription) = matches.next() else {
+            return Err(AircError::Route(format!(
+                "refusing to {verb} {name_or_channel:?}: this scope is not subscribed to a room \
+                 with that name. join the room first (this does not auto-join)."
+            )));
+        };
+        if let Some(second) = matches.next() {
+            return Err(AircError::Route(format!(
+                "refusing to {verb} {name_or_channel:?}: that name is carried by more than one \
+                 room this scope is in ({} and {}). a name is a label, not an address — pass the \
+                 room id.",
+                subscription.room_id, second.room_id
+            )));
+        }
+        Ok(subscription.as_room())
     }
 }
 

--- a/crates/airc-lib/src/room.rs
+++ b/crates/airc-lib/src/room.rs
@@ -64,17 +64,69 @@ pub struct Room {
     pub name: String,
     /// Wire directory for this room.
     pub wire: PathBuf,
-    /// Channel UUID, derived deterministically from `name` so peers
-    /// joining the same name land in the same channel.
+    /// Channel UUID — the room's ADDRESS. Minted, never derived from
+    /// the name (see `mint`). The name is a label hanging off this id;
+    /// this id is what every caller passes.
     pub channel: RoomId,
     pub joined_at_ms: u64,
 }
 
 impl Room {
-    /// Derive a `Room` from a name + home dir. Deterministic — same
-    /// (home, name) always produces the same `Room`. Doesn't read
-    /// or write disk.
-    pub fn from_name(home: &Path, name: &str) -> Result<Self, RoomError> {
+    /// Mint a NEW room. The id is generated and out of the caller's
+    /// control; the name is a display label with no addressing role.
+    ///
+    /// ## Why the id is minted and not derived
+    ///
+    /// This used to be `from_name`, deriving BOTH the identity
+    /// (`new_v5(ROOM_NAMESPACE, name)`) and the storage location
+    /// (`wires/sanitise_name(name)`) from a human string. One
+    /// derivation, and text became identity — which is the root of
+    /// every room defect this crate carries:
+    ///
+    /// - a name that is *id-shaped* hashes into a brand-new channel,
+    ///   so a scope writes and reads a room nobody else is in. Twice
+    ///   in production (card c409eaf5): a full uuid, then the 8-hex
+    ///   short id minting ghost room `7d1a76de` off academy's prefix.
+    ///   `resolve_id_token` and the `JoinUuidString` / `JoinIdUnknown`
+    ///   / `JoinIdAmbiguous` errors exist ONLY to referee that.
+    /// - an id can *diverge* from its stored name, so join carries
+    ///   self-healing (`rebind_diverged`) to re-bind rooms whose uuid
+    ///   no longer derives from the name it was saved under.
+    /// - the name charset (`ChannelName`) becomes load-bearing on
+    ///   identity, so a room cannot be called anything a hash-input
+    ///   validator dislikes.
+    ///
+    /// A minted id makes all of that unrepresentable: nothing derives,
+    /// so nothing can diverge; the id IS an id, so nothing can be
+    /// merely id-SHAPED; the label is free text because no one hashes
+    /// it. Renaming a room is now a label edit, and two rooms may
+    /// share a label without colliding.
+    ///
+    /// Rendezvous — the one thing derivation genuinely bought (two
+    /// machines independently landing on `#general` with no registry)
+    /// — is a discovery concern, not an identity one: peers exchange
+    /// the id. Named lookup for humans lives at the CLI edge.
+    pub fn mint(home: &Path, name: &str) -> Result<Self, RoomError> {
+        let channel = RoomId::from_uuid(Uuid::new_v4());
+        // Wire dir keyed by the ID: always a valid path component, so
+        // `sanitise_name` has no say in where a room's bytes live.
+        let wire = home.join("wires").join(channel.to_string());
+        Ok(Self {
+            version: ROOM_VERSION,
+            name: name.to_string(),
+            wire,
+            channel,
+            joined_at_ms: now_ms()?,
+        })
+    }
+
+    /// Re-derive the legacy name-hashed room. RETAINED FOR MIGRATION
+    /// ONLY: every room created before ids were minted has an id that
+    /// IS `v5(name)` and a wire dir at `wires/<sanitised-name>`, so
+    /// existing installs (and peers still on the old build) must be
+    /// able to reconstruct it to find their bytes. Never call this for
+    /// a NEW room — `mint` is the constructor.
+    pub fn legacy_from_name(home: &Path, name: &str) -> Result<Self, RoomError> {
         let wire = home.join("wires").join(sanitise_name(name));
         let channel = RoomId::from_uuid(Uuid::new_v5(&ROOM_NAMESPACE, name.as_bytes()));
         Ok(Self {
@@ -86,10 +138,15 @@ impl Room {
         })
     }
 
-    /// Default room — auto-created on `airc init`. Name "default",
-    /// derived per `from_name`.
+    /// Default room — auto-created on `airc init`.
+    ///
+    /// LEGACY-DERIVED on purpose: every install that already ran `init`
+    /// has this room at `v5("default")` with its bytes under
+    /// `wires/default`. Minting a fresh id here would strand those
+    /// bytes and split existing scopes from their own default room, so
+    /// this one keeps the derived id until a migration moves it.
     pub fn default_for(home: &Path) -> Result<Self, RoomError> {
-        Self::from_name(home, DEFAULT_ROOM_NAME)
+        Self::legacy_from_name(home, DEFAULT_ROOM_NAME)
     }
 
     /// Stamp this room's human NAME onto outbound headers

--- a/crates/airc-lib/src/room.rs
+++ b/crates/airc-lib/src/room.rs
@@ -1,14 +1,15 @@
-//! Room value type — the substrate expansion of a channel name into
-//! a wire path and channel id.
+//! Room value type — a room's concrete substrate location.
 //!
-//! A "room" is a name. The substrate primitives it expands to are
-//! deterministic:
-//!   - wire    = `<home>/wires/<name>/`
-//!   - channel = UUIDv5(namespace=oid, name)
+//! A room IS its `RoomId`. The id is minted by airc when the room is
+//! created, is read-only to every caller, and is the only thing that
+//! addresses the room:
+//!   - wire = `<home>/wires/<room-id>/`
+//!   - name = a display label hanging off the id, addressing nothing
 //!
-//! Same name → same channel UUID across machines, so two peers who
-//! both `airc join project-x` land in the same room without
-//! exchanging the channel UUID.
+//! Peers exchange the id. Named lookup for humans lives at the CLI
+//! edge, where a label is resolved against rooms this scope is already
+//! in — and refuses when the label is ambiguous, because a label is not
+//! an address.
 
 use std::path::{Path, PathBuf};
 
@@ -18,14 +19,6 @@ use uuid::Uuid;
 use airc_core::RoomId;
 
 const ROOM_VERSION: u32 = 1;
-const DEFAULT_ROOM_NAME: &str = "default";
-
-/// Namespace UUID for deriving channel UUIDs from room names.
-/// Stable across all airc installs so `airc join project-x`
-/// on different machines produces the same channel.
-const ROOM_NAMESPACE: Uuid = Uuid::from_bytes([
-    0xa1, 0xc2, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-]);
 
 /// What can go wrong constructing a room value.
 #[derive(Debug)]
@@ -55,61 +48,32 @@ impl From<std::time::SystemTimeError> for RoomError {
     }
 }
 
-/// A channel's concrete substrate location.
+/// A room's concrete substrate location.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Room {
     /// Schema version.
     pub version: u32,
-    /// Human-readable room name.
+    /// Display label. Carries no addressing role; two rooms may share
+    /// one, and a room may have none.
     pub name: String,
-    /// Wire directory for this room.
+    /// Wire directory for this room, keyed by its id.
     pub wire: PathBuf,
-    /// Channel UUID — the room's ADDRESS. Minted, never derived from
-    /// the name (see `mint`). The name is a label hanging off this id;
-    /// this id is what every caller passes.
+    /// The room's ADDRESS. Minted by airc, read-only to callers.
     pub channel: RoomId,
     pub joined_at_ms: u64,
 }
 
 impl Room {
-    /// Mint a NEW room. The id is generated and out of the caller's
-    /// control; the name is a display label with no addressing role.
+    /// Mint a NEW room. The id is generated here and is out of the
+    /// caller's control; the name is a display label.
     ///
-    /// ## Why the id is minted and not derived
-    ///
-    /// This used to be `from_name`, deriving BOTH the identity
-    /// (`new_v5(ROOM_NAMESPACE, name)`) and the storage location
-    /// (`wires/sanitise_name(name)`) from a human string. One
-    /// derivation, and text became identity — which is the root of
-    /// every room defect this crate carries:
-    ///
-    /// - a name that is *id-shaped* hashes into a brand-new channel,
-    ///   so a scope writes and reads a room nobody else is in. Twice
-    ///   in production (card c409eaf5): a full uuid, then the 8-hex
-    ///   short id minting ghost room `7d1a76de` off academy's prefix.
-    ///   `resolve_id_token` and the `JoinUuidString` / `JoinIdUnknown`
-    ///   / `JoinIdAmbiguous` errors exist ONLY to referee that.
-    /// - an id can *diverge* from its stored name, so join carries
-    ///   self-healing (`rebind_diverged`) to re-bind rooms whose uuid
-    ///   no longer derives from the name it was saved under.
-    /// - the name charset (`ChannelName`) becomes load-bearing on
-    ///   identity, so a room cannot be called anything a hash-input
-    ///   validator dislikes.
-    ///
-    /// A minted id makes all of that unrepresentable: nothing derives,
-    /// so nothing can diverge; the id IS an id, so nothing can be
-    /// merely id-SHAPED; the label is free text because no one hashes
-    /// it. Renaming a room is now a label edit, and two rooms may
-    /// share a label without colliding.
-    ///
-    /// Rendezvous — the one thing derivation genuinely bought (two
-    /// machines independently landing on `#general` with no registry)
-    /// — is a discovery concern, not an identity one: peers exchange
-    /// the id. Named lookup for humans lives at the CLI edge.
+    /// Nothing derives the id, so nothing can diverge from it, no
+    /// id-SHAPED text can collide with it, and the label is free text
+    /// because no one hashes it. Renaming is a label edit.
     pub fn mint(home: &Path, name: &str) -> Result<Self, RoomError> {
         let channel = RoomId::from_uuid(Uuid::new_v4());
         // Wire dir keyed by the ID: always a valid path component, so
-        // `sanitise_name` has no say in where a room's bytes live.
+        // no name-sanitiser has a say in where a room's bytes live.
         let wire = home.join("wires").join(channel.to_string());
         Ok(Self {
             version: ROOM_VERSION,
@@ -120,41 +84,11 @@ impl Room {
         })
     }
 
-    /// Re-derive the legacy name-hashed room. RETAINED FOR MIGRATION
-    /// ONLY: every room created before ids were minted has an id that
-    /// IS `v5(name)` and a wire dir at `wires/<sanitised-name>`, so
-    /// existing installs (and peers still on the old build) must be
-    /// able to reconstruct it to find their bytes. Never call this for
-    /// a NEW room — `mint` is the constructor.
-    pub fn legacy_from_name(home: &Path, name: &str) -> Result<Self, RoomError> {
-        let wire = home.join("wires").join(sanitise_name(name));
-        let channel = RoomId::from_uuid(Uuid::new_v5(&ROOM_NAMESPACE, name.as_bytes()));
-        Ok(Self {
-            version: ROOM_VERSION,
-            name: name.to_string(),
-            wire,
-            channel,
-            joined_at_ms: now_ms()?,
-        })
-    }
-
-    /// Default room — auto-created on `airc init`.
-    ///
-    /// LEGACY-DERIVED on purpose: every install that already ran `init`
-    /// has this room at `v5("default")` with its bytes under
-    /// `wires/default`. Minting a fresh id here would strand those
-    /// bytes and split existing scopes from their own default room, so
-    /// this one keeps the derived id until a migration moves it.
-    pub fn default_for(home: &Path) -> Result<Self, RoomError> {
-        Self::legacy_from_name(home, DEFAULT_ROOM_NAME)
-    }
-
-    /// Stamp this room's human NAME onto outbound headers
-    /// ([`airc_protocol::HEADER_AIRC_CHANNEL_NAME`]) — the convergence
-    /// key that lets a receiving machine whose identity-scoped channel
-    /// derivation diverged from ours (the M5↔bigmama blind-room bug)
-    /// re-derive the room under its own identity and still deliver.
-    /// Never overwrites a caller-supplied value; skips unnamed rooms.
+    /// Stamp this room's display NAME onto outbound headers
+    /// ([`airc_protocol::HEADER_AIRC_CHANNEL_NAME`]) so a receiving
+    /// surface can render a label next to the id. Never overwrites a
+    /// caller-supplied value; skips unnamed rooms. Delivery routes on
+    /// the id — this header is for humans reading the wire.
     pub fn stamp_name_header(&self, headers: &mut airc_core::Headers) {
         if self.name.is_empty() {
             return;
@@ -163,22 +97,6 @@ impl Room {
             .entry(airc_protocol::HEADER_AIRC_CHANNEL_NAME.to_string())
             .or_insert_with(|| self.name.clone());
     }
-}
-
-/// Sanitise a room name into a path-safe directory component. ASCII
-/// alphanumerics + `-` + `_` survive; everything else becomes `-`.
-/// Multiple names can collide post-sanitisation (`foo/bar` and
-/// `foo-bar` → same dir); avoid weird names.
-fn sanitise_name(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect()
 }
 
 fn now_ms() -> Result<u64, std::time::SystemTimeError> {

--- a/crates/airc-lib/src/room/tests.rs
+++ b/crates/airc-lib/src/room/tests.rs
@@ -2,26 +2,53 @@ use super::*;
 use tempfile::TempDir;
 
 #[test]
-fn from_name_is_deterministic_across_homes() {
-    let home_a = TempDir::new().unwrap();
-    let home_b = TempDir::new().unwrap();
-    let a = Room::from_name(home_a.path(), "project-x").unwrap();
-    let b = Room::from_name(home_b.path(), "project-x").unwrap();
-    assert_eq!(a.channel, b.channel);
-    assert_ne!(a.wire, b.wire);
-}
-
-#[test]
-fn from_name_differs_per_name() {
+fn mint_gives_every_room_its_own_id() {
+    // what this catches: an id derived from the name. Two rooms carrying
+    // the SAME label are two rooms — the label is not the identity, and
+    // minting the same id for both is the ghost-room collision that a
+    // v5(name) derivation made unavoidable.
     let home = TempDir::new().unwrap();
-    let a = Room::from_name(home.path(), "general").unwrap();
-    let b = Room::from_name(home.path(), "private").unwrap();
-    assert_ne!(a.channel, b.channel);
-    assert_ne!(a.wire, b.wire);
+    let a = Room::mint(home.path(), "project-x").unwrap();
+    let b = Room::mint(home.path(), "project-x").unwrap();
+    assert_ne!(a.channel, b.channel, "each mint is its own room");
+    assert_ne!(a.wire, b.wire, "and its own bytes");
+    assert_eq!(a.name, b.name, "sharing a label is legal");
 }
 
 #[test]
-fn sanitise_replaces_path_separators() {
-    assert_eq!(sanitise_name("../etc/passwd"), "---etc-passwd");
-    assert_eq!(sanitise_name("normal-name_42"), "normal-name_42");
+fn mint_ids_are_v4_out_of_the_callers_control() {
+    // what this catches: any reintroduction of a derived id. A v5 uuid
+    // here means something hashed an input, and whatever it hashed just
+    // became the room's identity.
+    let home = TempDir::new().unwrap();
+    let room = Room::mint(home.path(), "general").unwrap();
+    assert_eq!(
+        room.channel.as_uuid().get_version(),
+        Some(uuid::Version::Random)
+    );
+}
+
+#[test]
+fn wire_dir_is_keyed_by_id_so_no_name_can_reach_the_filesystem() {
+    // what this catches: `wires/<sanitised-name>`. A path-traversal name
+    // used to decide where a room's bytes live, which is why a sanitiser
+    // existed at all. The id is always a valid single path component.
+    let home = TempDir::new().unwrap();
+    let room = Room::mint(home.path(), "../etc/passwd").unwrap();
+    assert_eq!(
+        room.wire,
+        home.path().join("wires").join(room.channel.to_string())
+    );
+}
+
+#[test]
+fn name_is_a_label_that_addresses_nothing() {
+    // what this catches: re-coupling the label to the address. Renaming
+    // must be an edit to one field and nothing else.
+    let home = TempDir::new().unwrap();
+    let mut room = Room::mint(home.path(), "general").unwrap();
+    let (id, wire) = (room.channel, room.wire.clone());
+    room.name = "renamed".to_string();
+    assert_eq!(room.channel, id);
+    assert_eq!(room.wire, wire);
 }

--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -7,7 +7,7 @@
 
 use std::net::SocketAddr;
 
-use airc_core::PeerId;
+use airc_core::{PeerId, RoomId};
 use airc_transport::GhGistInviteStore;
 use serde::{Deserialize, Serialize};
 
@@ -122,6 +122,26 @@ pub struct InviteBeacon {
     pub peer_id: PeerId,
     pub peer_spec: PeerSpec,
     pub endpoints: Vec<RouteEndpoint>,
+    /// The rooms the publisher is in. IDs, and nothing else.
+    ///
+    /// An invite used to carry a peer and no rooms at all, and rooms
+    /// converged anyway because a room id was `v5(account, name)` —
+    /// two machines typing `join general` derived the same id without
+    /// ever exchanging one. That derivation WAS the cross-machine room
+    /// rendezvous, and minting the id removed it: both sides mint their
+    /// own and address rooms the other has never heard of. So the ids
+    /// travel explicitly now.
+    ///
+    /// No labels ride along. A label is per-scope display text; putting
+    /// one on the wire next to its id would make the pair the unit of
+    /// exchange and re-import naming into the rendezvous this branch
+    /// exists to remove. A recipient that wants to show a name for one
+    /// of these rooms looks it up BY the id.
+    ///
+    /// Serde-default: a beacon from a pre-rooms binary deserializes
+    /// empty and still pairs the peer.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rooms: Vec<RoomId>,
 }
 
 impl InviteBeacon {
@@ -131,7 +151,14 @@ impl InviteBeacon {
             peer_id,
             peer_spec,
             endpoints,
+            rooms: Vec::new(),
         }
+    }
+
+    /// Advertise the rooms this beacon's publisher is in.
+    pub fn with_rooms(mut self, rooms: Vec<RoomId>) -> Self {
+        self.rooms = rooms;
+        self
     }
 }
 
@@ -174,6 +201,8 @@ impl RouteEndpointTable {
 pub struct ImportedInvite {
     pub peer_id: PeerId,
     pub endpoints: Vec<RouteEndpoint>,
+    /// Rooms this peer advertised, by id.
+    pub rooms: Vec<RoomId>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -186,6 +215,7 @@ impl ImportedInviteTable {
         let imported = ImportedInvite {
             peer_id: beacon.peer_id,
             endpoints: beacon.endpoints,
+            rooms: beacon.rooms,
         };
         self.invites.insert(imported.peer_id, imported);
     }
@@ -217,11 +247,41 @@ impl Airc {
         ))
     }
 
+    /// [`Self::invite_beacon`] plus the ids of the rooms this scope is
+    /// in, so a recipient can join one by id instead of guessing.
+    ///
+    /// Async because the subscription set is durable state; the
+    /// synchronous form stays for callers that only want reachability.
+    pub async fn invite_beacon_with_rooms(&self) -> Result<InviteBeacon, AircError> {
+        let set = crate::subscriptions::load_or_init(self.event_store()).await?;
+        let rooms = set.room_ids().copied().collect();
+        Ok(self.invite_beacon()?.with_rooms(rooms))
+    }
+
     pub async fn import_invite_beacon(&self, beacon: InviteBeacon) -> Result<(), AircError> {
         let peer_spec = beacon.peer_spec.clone();
         self.add_peer_via(peer_spec, "invite").await?;
         self.inner.imported_invites.import(beacon);
         Ok(())
+    }
+
+    /// The room ids advertised by peers this scope has imported an
+    /// invite from — what is joinable BY ID as a result of pairing.
+    ///
+    /// The caller passes one of these to `join_room_id`. Nothing here
+    /// is resolved by name, because a peer's label for a room is its
+    /// own business.
+    pub fn peer_room_ids(&self) -> Result<Vec<RoomId>, AircError> {
+        let mut ids = self
+            .inner
+            .imported_invites
+            .invites()
+            .into_iter()
+            .flat_map(|invite| invite.rooms)
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids.dedup();
+        Ok(ids)
     }
 
     pub fn imported_invites(&self) -> Result<Vec<ImportedInvite>, AircError> {
@@ -416,7 +476,8 @@ mod tests {
                 peer_id,
                 endpoints: vec![RouteEndpoint::Relay {
                     url: "https://relay.example".to_string()
-                }]
+                }],
+                rooms: Vec::new(),
             }]
         );
     }

--- a/crates/airc-lib/src/router_bridge.rs
+++ b/crates/airc-lib/src/router_bridge.rs
@@ -64,7 +64,6 @@ use airc_store::EventStore;
 use async_trait::async_trait;
 
 use crate::coordinator::{self, CoordinatorConfig};
-use crate::subscriptions::derive_room_id;
 use crate::time;
 
 /// Verdict of an [`InboundFrameSink::deliver`] call. This is the
@@ -179,8 +178,8 @@ impl RouterInboundBridge {
             .live
             .iter()
             .chain(snapshot.stale.iter())
-            .flat_map(|beacon| beacon.subscribed_channels.iter())
-            .any(|name| derive_room_id(&identity, name) == channel))
+            .flat_map(|beacon| beacon.subscribed_rooms.iter())
+            .any(|room_id| *room_id == channel))
     }
 
     /// Self-healing join — the "blind room" heal (M5↔bigmama decay
@@ -227,29 +226,22 @@ impl RouterInboundBridge {
                 return false;
             }
         };
-        // Does the account know this channel? Check the document's
-        // channel union AND every beacon's subscription list (belt and
-        // braces — older documents may carry one but not the other).
-        let Some(name) = document
-            .channels
+        // Does the account know this room? The beacons carry room
+        // IDS, so this is an equality check on the key — nothing is
+        // re-derived and nothing can be merely id-SHAPED.
+        if !document
+            .peers
             .iter()
-            .chain(
-                document
-                    .peers
-                    .iter()
-                    .flat_map(|peer| peer.presence.subscribed_channels.iter()),
-            )
-            .find(|name| derive_room_id(&identity, name) == channel)
-            .cloned()
-        else {
+            .any(|peer| peer.presence.subscribed_rooms.contains(&channel))
+        {
             return false;
-        };
+        }
         // Re-bind: republish every registry beacon that subscribes the
         // channel into the coordinator store (idempotent upsert — the
         // exact write `join`'s publish_presence does).
         let mut rebound = 0usize;
         for peer in &document.peers {
-            if !peer.presence.subscribed_channels.contains(&name) {
+            if !peer.presence.subscribed_rooms.contains(&channel) {
                 continue;
             }
             match coordinator::publish_store(
@@ -287,7 +279,6 @@ impl RouterInboundBridge {
                  longer blind",
             )
             .with_field("channel", channel)
-            .with_field("channel_name", name.as_str())
             .with_field("rebound_beacons", rebound),
         );
         // The verdict must stay honest: only claim Delivered if the
@@ -295,63 +286,6 @@ impl RouterInboundBridge {
         matches!(self.channel_has_subscribed_scope(channel).await, Ok(true))
     }
 
-    /// Self-healing join — cross-machine NAME reconvergence (the
-    /// M5↔bigmama blind-room root cause). Channel UUIDs derive from
-    /// `(mesh_identity, name)`; when the sender's identity resolution
-    /// forked (gh unreachable → `local:<host>:<user>` fallback), its
-    /// room UUID diverges from ours and every frame it sends dies here
-    /// as unknown_channel — while the SAME room, by name, is bound by
-    /// local scopes. When the addressed channel binds no local scope
-    /// but the frame carries [`airc_protocol::HEADER_AIRC_CHANNEL_NAME`],
-    /// re-derive the room under THIS machine's identity; if that local
-    /// channel is bound (directly, or after the registry rebind heal),
-    /// deliver there — LOUDLY ([`DiagnosticCode::ChannelNameReconverged`]).
-    ///
-    /// Trust posture: the name is a heal HINT from an already
-    /// authenticated, enrolled-account peer, consulted ONLY when the
-    /// addressed UUID binds nothing — a bound channel is never
-    /// re-routed.
-    ///
-    /// Returns the local `RoomId` to deliver under, or `None` when no
-    /// honest reconvergence exists.
-    async fn reconverge_by_name(&self, frame: &Frame, addressed: RoomId) -> Option<RoomId> {
-        let raw = frame
-            .envelope
-            .headers
-            .get(airc_protocol::HEADER_AIRC_CHANNEL_NAME)?;
-        let name = crate::subscriptions::ChannelName::new(raw.clone()).ok()?;
-        let cached = crate::mesh_identity::resolve(self.coordinator_store.as_ref())
-            .await
-            .ok()?;
-        let identity = cached.as_mesh_identity();
-        let local = derive_room_id(&identity, &name);
-        if local == addressed {
-            // Same derivation — the channel is genuinely unbound here,
-            // not diverged; the registry rebind path owns that case.
-            return None;
-        }
-        let bound = matches!(self.channel_has_subscribed_scope(local).await, Ok(true))
-            || self.try_rebind_known_channel(local).await;
-        if !bound {
-            return None;
-        }
-        self.diag_sink.emit(
-            DiagnosticEvent::warn(
-                DiagnosticComponent::Subscriber,
-                DiagnosticCode::ChannelNameReconverged,
-                "inbound frame's channel UUID binds NO local scope, but its channel \
-                 NAME derives — under this machine's identity — to a bound room; \
-                 delivered there. The SENDING machine's mesh identity has diverged \
-                 from the account identity (likely gh unreachable there) and should \
-                 be fixed",
-            )
-            .with_field("addressed_channel", addressed)
-            .with_field("local_channel", local)
-            .with_field("channel_name", name.as_str())
-            .with_field("sender", frame.envelope.sender),
-        );
-        Some(local)
-    }
 }
 
 /// Local binding state of an inbound frame's channel, resolved BEFORE
@@ -368,30 +302,17 @@ enum ChannelBinding {
 impl InboundFrameSink for RouterInboundBridge {
     async fn deliver(&self, frame: &Frame) -> InboundDeliveryVerdict {
         let event_id = frame.envelope.event_id;
+        // The frame's room id IS where it goes. There is no remap:
+        // an id is not derived from anything, so there is nothing for
+        // a sender-supplied label to disagree with, and a peer never
+        // gets to redirect a frame by sending different text.
         let addressed = frame.envelope.channel;
-        // Resolve the local binding BEFORE publish so a name-
-        // reconverged frame lands in the transcript of the room a
-        // local scope actually reads — never in a ghost channel.
         let binding = match self.channel_has_subscribed_scope(addressed).await {
             Ok(true) => ChannelBinding::Bound,
             Ok(false) => ChannelBinding::Unbound,
             Err(error) => ChannelBinding::Unknown(error),
         };
-        let remapped = match binding {
-            // A bound channel is never re-routed — the name header is
-            // a heal hint, not addressing authority.
-            ChannelBinding::Unbound => self.reconverge_by_name(frame, addressed).await,
-            ChannelBinding::Bound | ChannelBinding::Unknown(_) => None,
-        };
-        let mut env = bus_envelope_for_inbound(frame);
-        if let Some(local) = remapped {
-            env.channel = local;
-            // Keep a room mention coherent with the delivery channel
-            // (room mentions round-trip as `room:<uuid>` endpoints).
-            if frame.envelope.target == MentionTarget::Room(addressed) {
-                env.target = Target::Endpoint(format!("room:{}", local.as_uuid()));
-            }
-        }
+        let env = bus_envelope_for_inbound(frame);
         // Card 1998f6cb: attach the verified link origin so the
         // router's outbound forward sink (when installed) never
         // echoes this frame back over the link it arrived on.
@@ -403,12 +324,7 @@ impl InboundFrameSink for RouterInboundBridge {
             Ok(PublishIfNew::Published(_)) | Ok(PublishIfNew::Duplicate) => match binding {
                 ChannelBinding::Bound => InboundDeliveryVerdict::Delivered,
                 ChannelBinding::Unbound => {
-                    if let Some(local) = remapped {
-                        // Name reconvergence already proved (and, when
-                        // needed, rebound) the local binding — and the
-                        // frame was PUBLISHED under it.
-                        InboundDeliveryVerdict::DeliveredRemapped(local)
-                    } else if self.try_rebind_known_channel(addressed).await {
+                    if self.try_rebind_known_channel(addressed).await {
                         // Self-healing join: before concluding "stored
                         // but blind", try re-binding from the account
                         // registry's known channels (decay mode #5).

--- a/crates/airc-lib/src/router_bridge.rs
+++ b/crates/airc-lib/src/router_bridge.rs
@@ -285,7 +285,6 @@ impl RouterInboundBridge {
         // re-published beacons actually bind the channel now.
         matches!(self.channel_has_subscribed_scope(channel).await, Ok(true))
     }
-
 }
 
 /// Local binding state of an inbound frame's channel, resolved BEFORE

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -99,6 +99,18 @@ impl From<ChannelNameError> for SubscriptionError {
 pub struct ChannelName(String);
 
 impl ChannelName {
+    /// The empty display label, for a room that has no name — one
+    /// addressed purely by id (dispatched into, handed over by a peer)
+    /// or one whose stored label no longer parses.
+    ///
+    /// This is a LABEL being absent, never an identity being absent: the
+    /// room is fully identified by its `RoomId`. Before ids keyed
+    /// membership, an unparseable name meant the whole subscription was
+    /// dropped on load — a display string could evict a real room.
+    pub(crate) fn unnamed() -> Self {
+        Self(String::new())
+    }
+
     pub(crate) fn general() -> Self {
         Self("general".to_string())
     }
@@ -325,14 +337,24 @@ pub struct SubscriptionRebind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubscriptionSet {
     pub version: u32,
-    pub subscribed: BTreeMap<ChannelName, Subscription>,
-    /// Default channel for `airc msg "..."` etc. `None` means no
+    /// Keyed by ROOM ID — the address. The name rides along inside each
+    /// `Subscription` as a display label and keys nothing.
+    ///
+    /// This was keyed by `ChannelName`, which made a display string the
+    /// lookup key for durable membership: a room could only be
+    /// remembered if it had a name, a renamed room became a different
+    /// room, and a room you were HANDED (dispatched into, told about by
+    /// a peer) had an id and no name and so could not be represented at
+    /// all. No migration is needed for the switch — `StoredSubscription`
+    /// has always persisted `room_id` alongside the name, so the id was
+    /// on disk the whole time; only the in-memory key was wrong.
+    pub subscribed: BTreeMap<RoomId, Subscription>,
+    /// Default room for `airc msg "..."` etc. `None` means no
     /// subscriptions yet (fresh-init scope).
-    pub default: Option<ChannelName>,
-    /// Channels the user explicitly parted. Never auto-rejoined by
-    /// `join_default_context`. Re-subscribing via `subscribe` clears
-    /// the entry from this set.
-    pub parted: BTreeSet<ChannelName>,
+    pub default: Option<RoomId>,
+    /// Rooms the user explicitly parted. Never auto-rejoined by
+    /// `join_default_context`. Re-subscribing clears the entry.
+    pub parted: BTreeSet<RoomId>,
 }
 
 impl SubscriptionSet {
@@ -525,28 +547,30 @@ impl SubscriptionSet {
 pub async fn load_or_init(store: &dyn EventStore) -> Result<SubscriptionSet, SubscriptionError> {
     let mut set = SubscriptionSet::empty();
     for row in store.load_subscriptions().await? {
-        let name = ChannelName::new(&row.channel_name)?;
+        // Key off the ROOM ID the row already carries. The stored name is
+        // read as a display label only, and a row whose label no longer
+        // parses (or never had one — an id-addressed room) is still a
+        // perfectly good membership: the id is what identifies it.
         if row.parted {
-            set.parted.insert(name);
+            set.parted.insert(row.room_id);
             continue;
         }
         let subscription = Subscription {
-            name: name.clone(),
+            name: ChannelName::new(&row.channel_name).unwrap_or_else(|_| ChannelName::unnamed()),
             room_id: row.room_id,
             wire: PathBuf::from(row.wire),
             joined_at_ms: row.joined_at_ms,
         };
         if row.is_default {
-            set.default = Some(name.clone());
+            set.default = Some(row.room_id);
         }
-        set.subscribed.insert(name, subscription);
+        set.subscribed.insert(row.room_id, subscription);
     }
     if set
         .default
-        .as_ref()
-        .is_some_and(|name| !set.subscribed.contains_key(name))
+        .is_some_and(|room| !set.subscribed.contains_key(&room))
     {
-        set.default = set.subscribed.keys().next().cloned();
+        set.default = set.subscribed.keys().next().copied();
     }
     Ok(set)
 }
@@ -561,15 +585,21 @@ pub async fn save(store: &dyn EventStore, set: &SubscriptionSet) -> Result<(), S
             room_id: subscription.room_id,
             wire: subscription.wire.to_string_lossy().into_owned(),
             joined_at_ms: subscription.joined_at_ms,
-            is_default: set.default.as_ref() == Some(&subscription.name),
+            is_default: set.default == Some(subscription.room_id),
             parted: false,
         });
     }
-    for channel in &set.parted {
-        if !set.subscribed.contains_key(channel) {
+    for room in &set.parted {
+        if !set.subscribed.contains_key(room) {
             rows.push(StoredSubscription {
-                channel_name: channel.as_str().to_string(),
-                room_id: derive_room_id(&MeshIdentity::unset(), channel),
+                // The parted row used to re-DERIVE its room id from the
+                // name against an `unset` identity — a fabricated id that
+                // matched the real room only by luck of the derivation.
+                // The parted set holds the actual id now, so the row
+                // carries it and the label is left empty: nothing keys on
+                // a name any more.
+                channel_name: String::new(),
+                room_id: *room,
                 wire: String::new(),
                 joined_at_ms: 0,
                 is_default: false,

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -247,7 +247,11 @@ impl Subscription {
     /// Membership in a room whose id you already hold — the normal
     /// path. A peer hands you an id, a board row carries one, a
     /// dispatch names one; you join THAT room.
-    pub fn joining(home: &Path, room_id: RoomId, name: ChannelName) -> Result<Self, SubscriptionError> {
+    pub fn joining(
+        home: &Path,
+        room_id: RoomId,
+        name: ChannelName,
+    ) -> Result<Self, SubscriptionError> {
         Self::with_wire_root(home, room_id, name)
     }
 
@@ -295,7 +299,6 @@ impl Subscription {
         }
     }
 }
-
 
 /// All channels this scope is subscribed to, plus the default-channel
 /// pointer for short-shape commands and the parted set so re-running
@@ -491,7 +494,6 @@ impl SubscriptionSet {
     pub fn room_ids(&self) -> impl Iterator<Item = &RoomId> {
         self.subscribed.keys()
     }
-
 }
 
 /// Load the subscription set from the durable store. If no rows exist
@@ -708,7 +710,6 @@ mod tests {
         assert_eq!(c.display_with_hash(), "#general");
     }
 
-
     #[test]
     fn resolve_id_token_binds_id_shaped_tokens_to_existing_channels() {
         // what this catches: the ghost-room mint (card c409eaf5 octave 2,
@@ -808,10 +809,18 @@ mod tests {
         let mut b = SubscriptionSet::empty();
 
         let a_sub = a
-            .join_with_wire_root(machine_home.path(), room_id, ChannelName::new("general").unwrap())
+            .join_with_wire_root(
+                machine_home.path(),
+                room_id,
+                ChannelName::new("general").unwrap(),
+            )
             .unwrap();
         let b_sub = b
-            .join_with_wire_root(machine_home.path(), room_id, ChannelName::new("general").unwrap())
+            .join_with_wire_root(
+                machine_home.path(),
+                room_id,
+                ChannelName::new("general").unwrap(),
+            )
             .unwrap();
 
         assert_eq!(a_sub.room_id, b_sub.room_id);
@@ -869,7 +878,8 @@ mod tests {
         set.unsubscribe(&general.room_id);
         assert!(set.parted.contains(&general.room_id));
 
-        set.join(home, general.room_id, general.name.clone()).unwrap();
+        set.join(home, general.room_id, general.name.clone())
+            .unwrap();
         assert!(!set.parted.contains(&general.room_id));
         assert_eq!(set.default, Some(general.room_id));
     }

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -218,20 +218,19 @@ impl MeshIdentity {
     }
 }
 
-/// Resolution of an id-shaped token against this scope's rooms.
+/// Resolution of a caller-supplied token against this scope's rooms.
 ///
-/// Every id surface in the system accepts a short form, so a caller
-/// holding `3be59578` must land on the room whose id starts with it.
+/// A token is either a room id or it is not. There is no third thing:
+/// an id parses to 128 bits and looks up, or the token is a name and a
+/// different surface deals with it.
 #[derive(Debug)]
 pub enum RoomIdResolution<'a> {
-    /// Not id-shaped.
+    /// Does not parse as a room id.
     NotAnId,
-    /// Identifies exactly this subscribed room.
+    /// Parsed to the id of exactly this subscribed room.
     Match(&'a Subscription),
-    /// Id-shaped but no subscribed room matches.
+    /// A valid room id this scope is not subscribed to.
     Unknown,
-    /// Id-shaped and a prefix of MORE than one subscribed room.
-    Ambiguous(Vec<&'a Subscription>),
 }
 
 /// One channel this scope is subscribed to.
@@ -244,28 +243,25 @@ pub struct Subscription {
 }
 
 impl Subscription {
+    /// Membership in a NEWLY MINTED room. The id is generated here and
+    /// is out of the caller's control.
+    pub fn minting(wire_root: &Path, name: ChannelName) -> Result<Self, SubscriptionError> {
+        Self::joining(wire_root, RoomId::new(), name)
+    }
+
     /// Membership in a room whose id you already hold — the normal
     /// path. A peer hands you an id, a board row carries one, a
     /// dispatch names one; you join THAT room.
+    ///
+    /// `wire_root` is the account-wide machine home, not the caller's
+    /// scope home: that is what makes `~/.airc`, `repo/.airc`, and every
+    /// other scope on one OS account share a data plane.
+    ///
+    /// (This and `minting` are the only two ways to build one. There was
+    /// a third, `with_wire_root`, that `joining` delegated to with an
+    /// identical signature — two spellings of one constructor, so the
+    /// choice between them carried no information.)
     pub fn joining(
-        home: &Path,
-        room_id: RoomId,
-        name: ChannelName,
-    ) -> Result<Self, SubscriptionError> {
-        Self::with_wire_root(home, room_id, name)
-    }
-
-    /// Membership in a NEWLY MINTED room. The id is generated here and
-    /// is out of the caller's control.
-    pub fn minting(home: &Path, name: ChannelName) -> Result<Self, SubscriptionError> {
-        Self::with_wire_root(home, RoomId::new(), name)
-    }
-
-    /// As [`Self::with_wire_root`], for the account-wide machine home
-    /// rather than the caller's scope home. This is what makes
-    /// `~/.airc`, `repo/.airc`, and other scopes on the same OS account
-    /// converge on one local data plane.
-    pub fn with_wire_root(
         wire_root: &Path,
         room_id: RoomId,
         name: ChannelName,
@@ -399,7 +395,7 @@ impl SubscriptionSet {
         if let Some(existing) = self.subscribed.get(&room_id) {
             return Ok(existing.clone());
         }
-        let sub = Subscription::with_wire_root(wire_root, room_id, name)?;
+        let sub = Subscription::joining(wire_root, room_id, name)?;
         self.insert(sub.clone());
         Ok(sub)
     }
@@ -462,28 +458,15 @@ impl SubscriptionSet {
     /// binds to that existing room; zero or several is the caller's
     /// answer, never a mint. Anything else is a plain name.
     pub fn resolve_room_id(&self, token: &str) -> RoomIdResolution<'_> {
-        let compact: String = token.trim().chars().filter(|c| *c != '-').collect();
-        let id_shaped =
-            (8..=32).contains(&compact.len()) && compact.chars().all(|c| c.is_ascii_hexdigit());
-        if !id_shaped {
+        // Parse to the id TYPE, then look up. The map is keyed by the
+        // 16-byte id, so this is one comparison against a key — never a
+        // scan, never a rendered uuid, never a substring of one.
+        let Ok(uuid) = uuid::Uuid::parse_str(token.trim()) else {
             return RoomIdResolution::NotAnId;
-        }
-        let needle = compact.to_ascii_lowercase();
-        let matches: Vec<&Subscription> = self
-            .subscribed
-            .values()
-            .filter(|s| {
-                s.room_id
-                    .as_uuid()
-                    .as_simple()
-                    .to_string()
-                    .starts_with(&needle)
-            })
-            .collect();
-        match matches.len() {
-            0 => RoomIdResolution::Unknown,
-            1 => RoomIdResolution::Match(matches[0]),
-            _ => RoomIdResolution::Ambiguous(matches),
+        };
+        match self.subscribed.get(&RoomId::from_uuid(uuid)) {
+            Some(subscription) => RoomIdResolution::Match(subscription),
+            None => RoomIdResolution::Unknown,
         }
     }
 
@@ -724,22 +707,29 @@ mod tests {
             .create(home, ChannelName::new("academy").unwrap())
             .unwrap();
 
-        let simple = academy.room_id.as_uuid().as_simple().to_string();
-
-        // 8-hex short id → binds to academy.
-        match set.resolve_room_id(&simple[..8]) {
-            RoomIdResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
-            other => panic!("short id must Match, got {other:?}"),
-        }
-        // Full dashed uuid → binds too (resolution wins over the old refusal).
+        // A room id → binds to academy.
         match set.resolve_room_id(&academy.room_id.to_string()) {
             RoomIdResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
             other => panic!("full uuid must Match, got {other:?}"),
         }
-        // Id-shaped, no such channel → Unknown (join refuses; no mint).
+        // A REAL id naming no subscribed room → Unknown (join refuses; no mint).
+        assert!(matches!(
+            set.resolve_room_id(&RoomId::new().to_string()),
+            RoomIdResolution::Unknown
+        ));
+        // A TRUNCATION of a real id is not an id. It was accepted once, by
+        // rendering every room's uuid to text and prefix-matching it — which
+        // made 32 hex characters mean 128 bits only when they happened not to
+        // collide, and needed an `Ambiguous` arm to paper over when they did.
+        // A key is passed whole or it is not passed.
+        let simple = academy.room_id.as_uuid().as_simple().to_string();
+        assert!(matches!(
+            set.resolve_room_id(&simple[..8]),
+            RoomIdResolution::NotAnId
+        ));
         assert!(matches!(
             set.resolve_room_id("deadbeef"),
-            RoomIdResolution::Unknown
+            RoomIdResolution::NotAnId
         ));
         // Plain names — including hexy-but-short and dashed ones — stay names.
         assert!(matches!(
@@ -932,10 +922,15 @@ mod tests {
         airc.join("cambriantech").await.unwrap();
 
         let subscriptions = airc.subscriptions().await.unwrap();
-        let names = subscriptions
+        // Set, not sequence. The old assertion read alphabetically only
+        // because the map was keyed by the NAME; keyed by id, iteration
+        // order follows v4 ids and carries no meaning. A caller that
+        // wants rooms in a particular order sorts by the field it means.
+        let mut names = subscriptions
             .iter()
             .map(|subscription| subscription.name.as_str())
             .collect::<Vec<_>>();
+        names.sort();
         assert_eq!(names, vec!["cambriantech", "general"]);
 
         // Membership is asked BY ID — the labels above are only how the

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -716,101 +716,105 @@ mod tests {
         let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
         let academy = set
-            .subscribe(home, &id, ChannelName::new("academy").unwrap())
+            .create(home, ChannelName::new("academy").unwrap())
             .unwrap();
 
         let simple = academy.room_id.as_uuid().as_simple().to_string();
 
         // 8-hex short id → binds to academy.
-        match set.resolve_id_token(&simple[..8]) {
+        match set.resolve_room_id(&simple[..8]) {
             RoomIdResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
             other => panic!("short id must Match, got {other:?}"),
         }
         // Full dashed uuid → binds too (resolution wins over the old refusal).
-        match set.resolve_id_token(&academy.room_id.to_string()) {
+        match set.resolve_room_id(&academy.room_id.to_string()) {
             RoomIdResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
             other => panic!("full uuid must Match, got {other:?}"),
         }
         // Id-shaped, no such channel → Unknown (join refuses; no mint).
         assert!(matches!(
-            set.resolve_id_token("deadbeef"),
+            set.resolve_room_id("deadbeef"),
             RoomIdResolution::Unknown
         ));
         // Plain names — including hexy-but-short and dashed ones — stay names.
         assert!(matches!(
-            set.resolve_id_token("academy"),
+            set.resolve_room_id("academy"),
             RoomIdResolution::NotAnId
         ));
         assert!(matches!(
-            set.resolve_id_token("bench-swe-run-1"),
+            set.resolve_room_id("bench-swe-run-1"),
             RoomIdResolution::NotAnId
         ));
         assert!(matches!(
-            set.resolve_id_token("cafe"),
+            set.resolve_room_id("cafe"),
             RoomIdResolution::NotAnId
         ));
     }
 
     #[test]
-    fn subscribe_is_idempotent_and_seeds_default() {
+    fn create_mints_a_distinct_room_each_time_and_seeds_default() {
+        // what this catches: create keyed by NAME. Two rooms with the same
+        // label are two rooms; collapsing them was the v5(name) collision.
         let dir = tempdir().unwrap();
         let home = dir.path();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
         assert!(set.default.is_none());
 
-        let sub1 = set
-            .subscribe(home, &id, ChannelName::new("general").unwrap())
+        let first = set
+            .create(home, ChannelName::new("general").unwrap())
             .unwrap();
-        assert_eq!(set.default.as_ref().unwrap().as_str(), "general");
-        assert_eq!(set.subscribed.len(), 1);
+        assert_eq!(set.default, Some(first.room_id), "first room seeds default");
 
-        // Idempotent: second subscribe returns the same entry.
-        let sub2 = set
-            .subscribe(home, &id, ChannelName::new("general").unwrap())
+        let second = set
+            .create(home, ChannelName::new("general").unwrap())
             .unwrap();
-        assert_eq!(sub1, sub2);
-        assert_eq!(set.subscribed.len(), 1);
-        assert_eq!(set.default.as_ref().unwrap().as_str(), "general");
+        assert_ne!(first.room_id, second.room_id);
+        assert_eq!(set.subscribed.len(), 2);
+        assert_eq!(set.default, Some(first.room_id), "default is not stolen");
     }
 
     #[test]
-    fn subscribe_adds_without_changing_default() {
+    fn join_is_idempotent_on_the_id_and_keeps_the_stored_label() {
+        // what this catches: re-joining a room you are already in must be a
+        // no-op for observers (joined_at_ms preserved), and a caller's label
+        // must never overwrite the one already stored.
         let dir = tempdir().unwrap();
         let home = dir.path();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
-        set.subscribe(home, &id, ChannelName::new("general").unwrap())
+        let room = set
+            .create(home, ChannelName::new("general").unwrap())
             .unwrap();
-        set.subscribe(home, &id, ChannelName::new("cambriantech").unwrap())
+
+        let again = set
+            .join(home, room.room_id, ChannelName::new("renamed").unwrap())
             .unwrap();
-        // First subscription stays as default.
-        assert_eq!(set.default.as_ref().unwrap().as_str(), "general");
-        assert_eq!(set.subscribed.len(), 2);
+        assert_eq!(again, room);
+        assert_eq!(set.subscribed.len(), 1);
     }
 
     #[test]
-    fn subscribe_with_wire_root_uses_machine_account_wire() {
+    fn join_with_wire_root_uses_the_machine_account_wire_keyed_by_id() {
+        // what this catches: a per-scope wire root (which split one machine's
+        // data plane per project dir) and a name-keyed wire dir.
         let scope_a = tempdir().unwrap();
         let scope_b = tempdir().unwrap();
         let machine_home = tempdir().unwrap();
-        let id = MeshIdentity::new("joelteply");
-        let channel = ChannelName::new("general").unwrap();
+        let room_id = RoomId::new();
         let mut a = SubscriptionSet::empty();
         let mut b = SubscriptionSet::empty();
 
         let a_sub = a
-            .subscribe_with_wire_root(machine_home.path(), &id, channel.clone())
+            .join_with_wire_root(machine_home.path(), room_id, ChannelName::new("general").unwrap())
             .unwrap();
         let b_sub = b
-            .subscribe_with_wire_root(machine_home.path(), &id, channel)
+            .join_with_wire_root(machine_home.path(), room_id, ChannelName::new("general").unwrap())
             .unwrap();
 
         assert_eq!(a_sub.room_id, b_sub.room_id);
         assert_eq!(a_sub.wire, b_sub.wire);
         assert_eq!(
             a_sub.wire,
-            machine_home.path().join("wires").join("general")
+            machine_home.path().join("wires").join(room_id.to_string())
         );
         assert!(
             !a_sub.wire.starts_with(scope_a.path()) && !b_sub.wire.starts_with(scope_b.path()),
@@ -819,82 +823,66 @@ mod tests {
     }
 
     #[test]
-    fn subscribe_accepts_arbitrary_user_and_domain_channels() {
+    fn a_room_with_no_label_is_still_a_membership() {
+        // what this catches: dropping a room because its label is absent or
+        // unparseable. The id identifies it; the label is decoration.
         let dir = tempdir().unwrap();
-        let home = dir.path();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
-
-        for name in [
-            "continuum-activity-7",
-            "openclaw-workspace_alpha",
-            "useideem",
-            "friend-general",
-            "forge-lora-slots",
-        ] {
-            set.subscribe(home, &id, ChannelName::new(name).unwrap())
-                .unwrap();
-        }
-
-        let names = set
-            .channel_names()
-            .map(ChannelName::as_str)
-            .collect::<Vec<_>>();
-        assert!(names.contains(&"continuum-activity-7"));
-        assert!(names.contains(&"openclaw-workspace_alpha"));
-        assert!(names.contains(&"useideem"));
-        assert!(names.contains(&"friend-general"));
-        assert!(names.contains(&"forge-lora-slots"));
+        let room = set.create(dir.path(), ChannelName::unnamed()).unwrap();
+        assert!(set.subscribed.contains_key(&room.room_id));
+        assert_eq!(set.default, Some(room.room_id));
     }
 
     #[test]
-    fn unsubscribe_marks_parted_and_falls_back_default() {
+    fn unsubscribe_marks_parted_by_id_and_falls_back_default() {
         let dir = tempdir().unwrap();
         let home = dir.path();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
-        let general = ChannelName::new("general").unwrap();
-        let cambriantech = ChannelName::new("cambriantech").unwrap();
-        set.subscribe(home, &id, general.clone()).unwrap();
-        set.subscribe(home, &id, cambriantech.clone()).unwrap();
+        let general = set
+            .create(home, ChannelName::new("general").unwrap())
+            .unwrap();
+        let cambriantech = set
+            .create(home, ChannelName::new("cambriantech").unwrap())
+            .unwrap();
 
-        let removed = set.unsubscribe(&general).expect("general was subscribed");
-        assert_eq!(removed.name, general);
-        assert!(set.parted.contains(&general));
-        // Default falls back to remaining (cambriantech).
-        assert_eq!(set.default, Some(cambriantech.clone()));
+        let removed = set
+            .unsubscribe(&general.room_id)
+            .expect("general was subscribed");
+        assert_eq!(removed.room_id, general.room_id);
+        assert!(set.parted.contains(&general.room_id));
+        assert_eq!(set.default, Some(cambriantech.room_id));
         assert_eq!(set.subscribed.len(), 1);
     }
 
     #[test]
-    fn unsubscribe_then_resubscribe_clears_parted() {
+    fn rejoining_a_parted_room_clears_the_tombstone() {
         let dir = tempdir().unwrap();
         let home = dir.path();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
-        let general = ChannelName::new("general").unwrap();
-        set.subscribe(home, &id, general.clone()).unwrap();
-        set.unsubscribe(&general);
-        assert!(set.parted.contains(&general));
+        let general = set
+            .create(home, ChannelName::new("general").unwrap())
+            .unwrap();
+        set.unsubscribe(&general.room_id);
+        assert!(set.parted.contains(&general.room_id));
 
-        set.subscribe(home, &id, general.clone()).unwrap();
-        assert!(!set.parted.contains(&general));
-        assert_eq!(set.default, Some(general));
+        set.join(home, general.room_id, general.name.clone()).unwrap();
+        assert!(!set.parted.contains(&general.room_id));
+        assert_eq!(set.default, Some(general.room_id));
     }
 
     #[test]
-    fn set_default_requires_subscription() {
+    fn set_default_requires_membership_and_names_the_id_it_refused() {
         let dir = tempdir().unwrap();
-        let home = dir.path();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
-        set.subscribe(home, &id, ChannelName::new("general").unwrap())
+        set.create(dir.path(), ChannelName::new("general").unwrap())
             .unwrap();
-        // Setting a non-subscribed channel as default must error.
-        let result = set.set_default(ChannelName::new("nowhere").unwrap());
-        assert!(result.is_err());
-    }
 
+        let stranger = RoomId::new();
+        match set.set_default(stranger) {
+            Err(SubscriptionError::UnknownRoom(id)) => assert_eq!(id, stranger),
+            other => panic!("must refuse a non-subscribed room by id, got {other:?}"),
+        }
+    }
 
     #[tokio::test]
     async fn save_load_round_trip_preserves_set() {
@@ -903,9 +891,9 @@ mod tests {
         let store = InMemoryEventStore::new();
         let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
-        set.subscribe(home, &id, ChannelName::new("general").unwrap())
+        set.create(home, ChannelName::new("general").unwrap())
             .unwrap();
-        set.subscribe(home, &id, ChannelName::new("cambriantech").unwrap())
+        set.create(home, ChannelName::new("cambriantech").unwrap())
             .unwrap();
         save(&store, &set).await.unwrap();
 

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -713,7 +713,6 @@ mod tests {
         // v5 mint that splits the room's readers from its writers.
         let dir = tempdir().unwrap();
         let home = dir.path();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
         let academy = set
             .create(home, ChannelName::new("academy").unwrap())
@@ -889,7 +888,6 @@ mod tests {
         let dir = tempdir().unwrap();
         let home = dir.path();
         let store = InMemoryEventStore::new();
-        let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
         set.create(home, ChannelName::new("general").unwrap())
             .unwrap();
@@ -925,9 +923,18 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["cambriantech", "general"]);
 
-        let cambriantech = ChannelName::new("cambriantech").unwrap();
-        let general = ChannelName::new("general").unwrap();
-        let missing = ChannelName::new("not-joined").unwrap();
+        // Membership is asked BY ID — the labels above are only how the
+        // rooms were created; they answer no question about membership.
+        let by_label = |label: &str| {
+            subscriptions
+                .iter()
+                .find(|s| s.name.as_str() == label)
+                .expect("created above")
+                .room_id
+        };
+        let cambriantech = by_label("cambriantech");
+        let general = by_label("general");
+        let missing = RoomId::new();
 
         assert!(airc.is_subscribed(&cambriantech).await.unwrap());
         assert!(airc.is_subscribed(&general).await.unwrap());

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -383,23 +383,6 @@ impl SubscriptionSet {
         }
     }
 
-    /// [`Self::join`] against an account-wide local wire root. See
-    /// [`Subscription::with_wire_root`].
-    pub fn join_with_wire_root(
-        &mut self,
-        wire_root: &Path,
-        room_id: RoomId,
-        name: ChannelName,
-    ) -> Result<Subscription, SubscriptionError> {
-        self.parted.remove(&room_id);
-        if let Some(existing) = self.subscribed.get(&room_id) {
-            return Ok(existing.clone());
-        }
-        let sub = Subscription::joining(wire_root, room_id, name)?;
-        self.insert(sub.clone());
-        Ok(sub)
-    }
-
     /// Remove a subscription and mark it parted so it's not
     /// auto-restored. If the removed room was the default, the
     /// default falls back to any remaining subscription
@@ -814,7 +797,7 @@ mod tests {
     }
 
     #[test]
-    fn join_with_wire_root_uses_the_machine_account_wire_keyed_by_id() {
+    fn join_uses_the_machine_account_wire_keyed_by_id() {
         // what this catches: a per-scope wire root (which split one machine's
         // data plane per project dir) and a name-keyed wire dir.
         let scope_a = tempdir().unwrap();
@@ -825,14 +808,14 @@ mod tests {
         let mut b = SubscriptionSet::empty();
 
         let a_sub = a
-            .join_with_wire_root(
+            .join(
                 machine_home.path(),
                 room_id,
                 ChannelName::new("general").unwrap(),
             )
             .unwrap();
         let b_sub = b
-            .join_with_wire_root(
+            .join(
                 machine_home.path(),
                 room_id,
                 ChannelName::new("general").unwrap(),

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -439,6 +439,13 @@ impl SubscriptionSet {
         self.subscribed.values()
     }
 
+    /// Consume the set and yield every subscription by VALUE — for the
+    /// caller that owns the set and is about to drop it. Pairs with
+    /// [`Self::all`], which borrows for everyone else.
+    pub fn into_all(self) -> impl Iterator<Item = Subscription> {
+        self.subscribed.into_values()
+    }
+
     /// The subscription for a room id — one comparison against the key
     /// this map is already keyed by.
     ///
@@ -568,11 +575,19 @@ impl Airc {
     /// Return all active channel subscriptions for this scope.
     ///
     /// Consumer integrations use this instead of parsing `airc status`
-    /// or reading the store directly. Ordering is deterministic by
-    /// channel name.
+    /// or reading the store directly. Ordering is deterministic by ROOM
+    /// ID — the map's key. It was by channel name until membership was
+    /// re-keyed onto the id; a caller that wants name order sorts by the
+    /// field it means, because a label carries no ordering any more than
+    /// it carries an address.
+    ///
+    /// MOVES out of the set rather than cloning: `set` is loaded fresh
+    /// here and dropped on the next line, so cloning every subscription
+    /// out of it copied a `String` + a `PathBuf` per room for values
+    /// nobody else could observe.
     pub async fn subscriptions(&self) -> Result<Vec<Subscription>, AircError> {
         let set = self.subscription_set().await?;
-        Ok(set.all().cloned().collect())
+        Ok(set.into_all().collect())
     }
 
     /// True when this scope is subscribed to `room_id`.

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -439,6 +439,17 @@ impl SubscriptionSet {
         self.subscribed.values()
     }
 
+    /// The subscription for a room id — one comparison against the key
+    /// this map is already keyed by.
+    ///
+    /// Borrowed, deliberately. A caller that only needs to READ a field
+    /// should not be handed an owned copy of a `String` + `PathBuf`;
+    /// clone at the boundary that genuinely requires ownership, and only
+    /// there.
+    pub fn get(&self, room_id: RoomId) -> Option<&Subscription> {
+        self.subscribed.get(&room_id)
+    }
+
     /// Resolve a join TOKEN that may be a channel ID rather than a
     /// name (card c409eaf5, octave 2 — glass-boxed 2026-08-11).
     ///

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -8,16 +8,12 @@
 //! [`Airc::join_default_context`](crate::Airc::join_default_context)
 //! re-infers context.
 //!
-//! ## RoomId derivation
+//! ## The room id IS the key
 //!
-//! Each subscribed channel is a typed [`ChannelName`] with a
-//! deterministic [`RoomId`] — see [`derive_room_id`]. The derivation
-//! is namespaced by an opaque [`MeshIdentity`] string (intended to be
-//! the user's authenticated Git/GitHub identity) so that two scopes on
-//! the same identity converge to the same `RoomId` for a given
-//! channel, and cross-identity channels do NOT collide. For v1, the
-//! identity is supplied by the caller; a follow-up wires it to
-//! `gh api user --jq .login` via the machine-global coordinator.
+//! Membership is keyed by [`RoomId`] — a v4 uuid minted by airc when
+//! the room is created, read-only to every caller. A [`ChannelName`]
+//! rides along as a display label and addresses nothing: two rooms may
+//! share a label, a room may have none, and renaming one moves nothing.
 //!
 //! ## Storage
 //!
@@ -29,7 +25,6 @@ use std::path::{Path, PathBuf};
 
 use airc_store::{EventStore, StoredSubscription};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use airc_core::RoomId;
 
@@ -40,18 +35,16 @@ use crate::Airc;
 
 const SUBSCRIPTIONS_VERSION: u32 = 1;
 
-/// Namespace UUID for deriving channel UUIDs from
-/// `(mesh_identity, channel_name)`.
-const SUBSCRIPTIONS_NAMESPACE: Uuid = Uuid::from_bytes([
-    0xa1, 0xc2, 0x00, 0x01, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-]);
-
 /// What can go wrong loading or saving the subscription set.
 #[derive(Debug)]
 pub enum SubscriptionError {
     Store(airc_store::StoreError),
     Clock(std::time::SystemTimeError),
     InvalidChannelName(ChannelNameError),
+    /// A room id was passed where membership is required, and this
+    /// scope is not subscribed to it. The id is reported verbatim —
+    /// there is no name to guess at.
+    UnknownRoom(RoomId),
 }
 
 impl std::fmt::Display for SubscriptionError {
@@ -60,6 +53,7 @@ impl std::fmt::Display for SubscriptionError {
             Self::Store(error) => write!(f, "subscriptions store: {error}"),
             Self::Clock(error) => write!(f, "subscriptions clock: {error}"),
             Self::InvalidChannelName(error) => write!(f, "invalid channel name: {error}"),
+            Self::UnknownRoom(room_id) => write!(f, "not subscribed to room {room_id}"),
         }
     }
 }
@@ -70,6 +64,7 @@ impl std::error::Error for SubscriptionError {
             Self::Store(error) => Some(error),
             Self::Clock(error) => Some(error),
             Self::InvalidChannelName(error) => Some(error),
+            Self::UnknownRoom(_) => None,
         }
     }
 }
@@ -201,13 +196,9 @@ pub enum ChannelNameError {
     InvalidChar(char),
 }
 
-/// Opaque mesh-identity string. v1 callers may pass any stable token;
-/// future revisions wire this to `gh api user --jq .login` via the
-/// machine-global coordinator so all scopes on one GitHub account
-/// converge to the same `RoomId` for a given channel.
-///
-/// Wrapper instead of bare String so misuse like
-/// `derive_room_id(name, name)` is impossible.
+/// Opaque mesh-identity string — WHO this scope is on the mesh.
+/// Wrapper instead of a bare String so it can never be confused with
+/// any other text the mesh passes around.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MeshIdentity(String);
 
@@ -227,33 +218,19 @@ impl MeshIdentity {
     }
 }
 
-/// Derive a `RoomId` from `(mesh_identity, channel_name)`. Same inputs
-/// produce the same `RoomId` on any machine, so two scopes on the same
-/// identity that both subscribe to `#general` see the same room.
-pub fn derive_room_id(identity: &MeshIdentity, channel: &ChannelName) -> RoomId {
-    let mut bytes = Vec::with_capacity(identity.as_str().len() + 1 + channel.as_str().len());
-    bytes.extend_from_slice(identity.as_str().as_bytes());
-    // NUL separator so e.g. ("alice", "bob-room") and ("alice-bob", "room")
-    // can never collide.
-    bytes.push(0);
-    bytes.extend_from_slice(channel.as_str().as_bytes());
-    RoomId::from_uuid(Uuid::new_v5(&SUBSCRIPTIONS_NAMESPACE, &bytes))
-}
-
-/// Outcome of [`SubscriptionSet::resolve_id_token`] — how a join
-/// token that might be a channel ID resolves against this scope's
-/// subscriptions.
+/// Resolution of an id-shaped token against this scope's rooms.
+///
+/// Every id surface in the system accepts a short form, so a caller
+/// holding `3be59578` must land on the room whose id starts with it.
 #[derive(Debug)]
-pub enum IdTokenResolution<'a> {
-    /// Not id-shaped — treat the token as a channel NAME.
+pub enum RoomIdResolution<'a> {
+    /// Not id-shaped.
     NotAnId,
-    /// Id-shaped and identifies exactly this subscribed channel.
+    /// Identifies exactly this subscribed room.
     Match(&'a Subscription),
-    /// Id-shaped but no subscribed channel matches — almost certainly
-    /// a mis-pasted id; minting a room named after it would split the
-    /// real room (the ghost-room trap).
+    /// Id-shaped but no subscribed room matches.
     Unknown,
-    /// Id-shaped and a prefix of MORE than one subscribed channel.
+    /// Id-shaped and a prefix of MORE than one subscribed room.
     Ambiguous(Vec<&'a Subscription>),
 }
 
@@ -267,37 +244,39 @@ pub struct Subscription {
 }
 
 impl Subscription {
-    /// Construct a subscription. Derives the `RoomId` from
-    /// `(identity, name)` and the wire path from
-    /// `<home>/wires/<name>/`.
-    pub fn new(
-        home: &Path,
-        identity: &MeshIdentity,
-        name: ChannelName,
-    ) -> Result<Self, SubscriptionError> {
-        let wire = home.join("wires").join(name.as_str());
-        Self::with_wire(identity, name, wire)
+    /// Membership in a room whose id you already hold — the normal
+    /// path. A peer hands you an id, a board row carries one, a
+    /// dispatch names one; you join THAT room.
+    pub fn joining(home: &Path, room_id: RoomId, name: ChannelName) -> Result<Self, SubscriptionError> {
+        Self::with_wire_root(home, room_id, name)
     }
 
-    /// Construct a subscription whose local-fs wire is rooted at the
-    /// account-wide machine home instead of the caller's scope home.
-    /// This is what makes `~/.airc`, `repo/.airc`, and other scopes on
-    /// the same OS account converge on one local data plane.
-    pub fn new_with_wire_root(
+    /// Membership in a NEWLY MINTED room. The id is generated here and
+    /// is out of the caller's control.
+    pub fn minting(home: &Path, name: ChannelName) -> Result<Self, SubscriptionError> {
+        Self::with_wire_root(home, RoomId::new(), name)
+    }
+
+    /// As [`Self::with_wire_root`], for the account-wide machine home
+    /// rather than the caller's scope home. This is what makes
+    /// `~/.airc`, `repo/.airc`, and other scopes on the same OS account
+    /// converge on one local data plane.
+    pub fn with_wire_root(
         wire_root: &Path,
-        identity: &MeshIdentity,
+        room_id: RoomId,
         name: ChannelName,
     ) -> Result<Self, SubscriptionError> {
-        let wire = wire_root.join("wires").join(name.as_str());
-        Self::with_wire(identity, name, wire)
+        // Wire dir keyed by the ID: always a valid path component, and
+        // renaming a room never moves its bytes.
+        let wire = wire_root.join("wires").join(room_id.to_string());
+        Self::with_wire(room_id, name, wire)
     }
 
     pub fn with_wire(
-        identity: &MeshIdentity,
+        room_id: RoomId,
         name: ChannelName,
         wire: PathBuf,
     ) -> Result<Self, SubscriptionError> {
-        let room_id = derive_room_id(identity, &name);
         Ok(Self {
             name,
             room_id,
@@ -317,18 +296,6 @@ impl Subscription {
     }
 }
 
-/// One healed subscription binding (self-healing join — receive-binding
-/// re-derive on identity heal): the stored room UUID no longer matched
-/// the current derivation of the stored channel NAME, so the
-/// subscription was re-bound to the converged UUID. Carried out of
-/// [`SubscriptionSet::rebind_diverged`] so callers can be LOUD about
-/// exactly which room moved where.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SubscriptionRebind {
-    pub name: ChannelName,
-    pub old_room_id: RoomId,
-    pub new_room_id: RoomId,
-}
 
 /// All channels this scope is subscribed to, plus the default-channel
 /// pointer for short-shape commands and the parted set so re-running
@@ -368,77 +335,90 @@ impl SubscriptionSet {
         }
     }
 
-    /// Add or replace a subscription for `name`. Idempotent: if the
-    /// channel is already subscribed, the existing
-    /// `joined_at_ms` is preserved (re-subscribe is a no-op for
-    /// observers). Clears the channel from `parted` if present so a
-    /// later default-context re-infer will keep it.
+    /// Join the room `room_id` identifies. Idempotent: if this scope is
+    /// already in that room the existing `joined_at_ms` is preserved
+    /// (re-joining is a no-op for observers) and its stored label wins.
+    /// Clears the room from `parted` so a later default-context
+    /// re-infer keeps it.
     ///
-    /// Sets the channel as `default` only if no default exists yet.
+    /// Sets the room as `default` only if no default exists yet.
     /// Explicit promotion is via [`Self::set_default`].
-    pub fn subscribe(
+    pub fn join(
         &mut self,
         home: &Path,
-        identity: &MeshIdentity,
+        room_id: RoomId,
         name: ChannelName,
     ) -> Result<Subscription, SubscriptionError> {
-        self.parted.remove(&name);
-        if let Some(existing) = self.subscribed.get(&name) {
+        self.parted.remove(&room_id);
+        if let Some(existing) = self.subscribed.get(&room_id) {
             return Ok(existing.clone());
         }
-        let sub = Subscription::new(home, identity, name.clone())?;
-        self.subscribed.insert(name.clone(), sub.clone());
-        if self.default.is_none() {
-            self.default = Some(name);
-        }
+        let sub = Subscription::joining(home, room_id, name)?;
+        self.insert(sub.clone());
         Ok(sub)
     }
 
-    /// Add or replace a subscription using an account-wide local wire
-    /// root. See [`Subscription::new_with_wire_root`].
-    pub fn subscribe_with_wire_root(
+    /// Mint a NEW room and join it. The id is generated by airc; the
+    /// caller supplies only a display label.
+    pub fn create(
         &mut self,
-        wire_root: &Path,
-        identity: &MeshIdentity,
+        home: &Path,
         name: ChannelName,
     ) -> Result<Subscription, SubscriptionError> {
-        self.parted.remove(&name);
-        if let Some(existing) = self.subscribed.get(&name) {
+        let sub = Subscription::minting(home, name)?;
+        self.insert(sub.clone());
+        Ok(sub)
+    }
+
+    fn insert(&mut self, sub: Subscription) {
+        self.parted.remove(&sub.room_id);
+        let room_id = sub.room_id;
+        self.subscribed.insert(room_id, sub);
+        if self.default.is_none() {
+            self.default = Some(room_id);
+        }
+    }
+
+    /// [`Self::join`] against an account-wide local wire root. See
+    /// [`Subscription::with_wire_root`].
+    pub fn join_with_wire_root(
+        &mut self,
+        wire_root: &Path,
+        room_id: RoomId,
+        name: ChannelName,
+    ) -> Result<Subscription, SubscriptionError> {
+        self.parted.remove(&room_id);
+        if let Some(existing) = self.subscribed.get(&room_id) {
             return Ok(existing.clone());
         }
-        let sub = Subscription::new_with_wire_root(wire_root, identity, name.clone())?;
-        self.subscribed.insert(name.clone(), sub.clone());
-        if self.default.is_none() {
-            self.default = Some(name);
-        }
+        let sub = Subscription::with_wire_root(wire_root, room_id, name)?;
+        self.insert(sub.clone());
         Ok(sub)
     }
 
     /// Remove a subscription and mark it parted so it's not
-    /// auto-restored. If the removed channel was the default, the
+    /// auto-restored. If the removed room was the default, the
     /// default falls back to any remaining subscription
-    /// (deterministically the lowest-sorted name) or `None`.
-    pub fn unsubscribe(&mut self, name: &ChannelName) -> Option<Subscription> {
-        let removed = self.subscribed.remove(name);
+    /// (deterministically the lowest-sorted id) or `None`.
+    pub fn unsubscribe(&mut self, room_id: &RoomId) -> Option<Subscription> {
+        let removed = self.subscribed.remove(room_id);
         if removed.is_some() {
-            self.parted.insert(name.clone());
-            if self.default.as_ref() == Some(name) {
-                self.default = self.subscribed.keys().next().cloned();
+            self.parted.insert(*room_id);
+            if self.default.as_ref() == Some(room_id) {
+                self.default = self.subscribed.keys().next().copied();
             }
         }
         removed
     }
 
-    /// Set the default channel. Only succeeds if the channel is
-    /// already subscribed; setting a non-subscribed channel as
-    /// default would lie about what `airc msg` will hit.
-    pub fn set_default(&mut self, name: ChannelName) -> Result<(), SubscriptionError> {
-        if !self.subscribed.contains_key(&name) {
-            return Err(SubscriptionError::InvalidChannelName(
-                ChannelNameError::Empty,
-            ));
+    /// Set the default room. Only succeeds if the room is already
+    /// subscribed; setting a non-subscribed room as default would lie
+    /// about what `airc msg` will hit.
+    pub fn set_default(&mut self, room_id: RoomId) -> Result<(), SubscriptionError> {
+        if !self.subscribed.contains_key(&room_id) {
+            return Err(SubscriptionError::UnknownRoom(room_id));
         }
-        self.default = Some(name);
+        self.default = Some(room_id);
         Ok(())
     }
 
@@ -473,12 +453,12 @@ impl SubscriptionSet {
     /// a prefix of a subscribed channel's UUID. Exactly one match
     /// binds to that existing room; zero or several is the caller's
     /// answer, never a mint. Anything else is a plain name.
-    pub fn resolve_id_token(&self, token: &str) -> IdTokenResolution<'_> {
+    pub fn resolve_room_id(&self, token: &str) -> RoomIdResolution<'_> {
         let compact: String = token.trim().chars().filter(|c| *c != '-').collect();
         let id_shaped =
             (8..=32).contains(&compact.len()) && compact.chars().all(|c| c.is_ascii_hexdigit());
         if !id_shaped {
-            return IdTokenResolution::NotAnId;
+            return RoomIdResolution::NotAnId;
         }
         let needle = compact.to_ascii_lowercase();
         let matches: Vec<&Subscription> = self
@@ -493,53 +473,20 @@ impl SubscriptionSet {
             })
             .collect();
         match matches.len() {
-            0 => IdTokenResolution::Unknown,
-            1 => IdTokenResolution::Match(matches[0]),
-            _ => IdTokenResolution::Ambiguous(matches),
+            0 => RoomIdResolution::Unknown,
+            1 => RoomIdResolution::Match(matches[0]),
+            _ => RoomIdResolution::Ambiguous(matches),
         }
     }
 
-    /// Just the names of subscribed channels — what Codex's
-    /// consumer-surface PR reads to know which RoomIds to drain.
-    pub fn channel_names(&self) -> impl Iterator<Item = &ChannelName> {
+    /// The ids of every subscribed room — what a consumer surface reads
+    /// to know which rooms to drain. The id is the address; a caller
+    /// that wants a label reads it off the `Subscription` via
+    /// [`Self::all`].
+    pub fn room_ids(&self) -> impl Iterator<Item = &RoomId> {
         self.subscribed.keys()
     }
 
-    /// Self-healing join — receive-binding re-derive on identity heal
-    /// (M5↔bigmama decay mode: after the Windows mesh identity healed,
-    /// SENDS derived converged channel UUIDs, but this scope's stored
-    /// subscriptions kept the OLD diverged UUIDs — so inbound frames
-    /// addressed to the converged room found no binding and the scope
-    /// read a dead room until a manual `airc stop && airc join`).
-    ///
-    /// A subscription's channel NAME is its durable identity; the room
-    /// UUID is a derivation of `(mesh_identity, name)` frozen at join
-    /// time. When the identity changes (heals), re-derive each
-    /// subscription's room UUID and re-bind any that diverged, keeping
-    /// name, wire, and `joined_at_ms`. Read cursors are unaffected:
-    /// runtime cursors are keyed per consumer id over the owner-core's
-    /// GLOBAL `(epoch, counter)` order, not per room UUID.
-    ///
-    /// Returns the rebinds performed (empty when the set is already
-    /// converged — the idempotent steady state) so callers can be loud
-    /// about each old→new move. Delivery to the OLD UUID keeps working
-    /// via the router bridge's per-frame name reconvergence; this heals
-    /// the READ side, which that per-frame remap cannot reach.
-    pub fn rebind_diverged(&mut self, identity: &MeshIdentity) -> Vec<SubscriptionRebind> {
-        let mut rebinds = Vec::new();
-        for (name, subscription) in self.subscribed.iter_mut() {
-            let derived = derive_room_id(identity, name);
-            if subscription.room_id != derived {
-                rebinds.push(SubscriptionRebind {
-                    name: name.clone(),
-                    old_room_id: subscription.room_id,
-                    new_room_id: derived,
-                });
-                subscription.room_id = derived;
-            }
-        }
-        rebinds
-    }
 }
 
 /// Load the subscription set from the durable store. If no rows exist
@@ -627,10 +574,10 @@ impl Airc {
         Ok(set.all().cloned().collect())
     }
 
-    /// True when this scope is subscribed to `channel`.
-    pub async fn is_subscribed(&self, channel: &ChannelName) -> Result<bool, AircError> {
+    /// True when this scope is subscribed to `room_id`.
+    pub async fn is_subscribed(&self, room_id: &RoomId) -> Result<bool, AircError> {
         let set = self.subscription_set().await?;
-        Ok(set.subscribed.contains_key(channel))
+        Ok(set.subscribed.contains_key(room_id))
     }
 
     /// Return the default room used by short-shape commands such as
@@ -644,15 +591,15 @@ impl Airc {
     /// can be empty/stale on an attached scope), the local store
     /// otherwise (card 8428ae8c).
     ///
-    /// `None` means either the channel has no events yet or this
-    /// scope is not subscribed to it. Use [`Self::is_subscribed`] when
-    /// callers need to distinguish those cases.
+    /// `None` means either the room has no events yet or this scope is
+    /// not subscribed to it. Use [`Self::is_subscribed`] when callers
+    /// need to distinguish those cases.
     pub async fn subscription_cursor(
         &self,
-        channel: &ChannelName,
+        room_id: &RoomId,
     ) -> Result<Option<airc_core::TranscriptCursor>, AircError> {
         let set = self.subscription_set().await?;
-        let Some(subscription) = set.subscribed.get(channel) else {
+        let Some(subscription) = set.subscribed.get(room_id) else {
             return Ok(None);
         };
         self.channel_latest_cursor(subscription.room_id).await
@@ -678,19 +625,10 @@ impl Airc {
                 room_ids.push(subscription.room_id);
             }
         }
-
-        if room_ids.is_empty() {
-            let identity = self.mesh_identity().await?;
-            let room_id = Subscription::new_with_wire_root(
-                &self.inner.wire_root,
-                &identity,
-                ChannelName::new("general").map_err(SubscriptionError::from)?,
-            )?
-            .room_id;
-            if seen.insert(room_id) {
-                room_ids.push(room_id);
-            }
-        }
+        // No conjured default. A scope with no subscriptions is in no
+        // rooms, and an empty filter says exactly that — inventing a
+        // room id here would have this scope draining a room nobody
+        // put it in.
         Ok(room_ids)
     }
 }
@@ -765,50 +703,6 @@ mod tests {
         assert_eq!(c.display_with_hash(), "#general");
     }
 
-    #[test]
-    fn derive_room_id_is_deterministic_per_identity_channel() {
-        let id = MeshIdentity::new("joelteply");
-        let c = ChannelName::new("general").unwrap();
-        let a = derive_room_id(&id, &c);
-        let b = derive_room_id(&id, &c);
-        assert_eq!(a, b);
-    }
-
-    #[test]
-    fn derive_room_id_differs_across_identities() {
-        let c = ChannelName::new("general").unwrap();
-        let a = derive_room_id(&MeshIdentity::new("joelteply"), &c);
-        let b = derive_room_id(&MeshIdentity::new("someone-else"), &c);
-        assert_ne!(
-            a, b,
-            "two users' #general channels MUST be different RoomIds — \
-             same-name cross-user bridging would be a privacy bug"
-        );
-    }
-
-    #[test]
-    fn derive_room_id_differs_across_channels() {
-        let id = MeshIdentity::new("joelteply");
-        let a = derive_room_id(&id, &ChannelName::new("general").unwrap());
-        let b = derive_room_id(&id, &ChannelName::new("cambriantech").unwrap());
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn derive_room_id_nul_separator_prevents_collisions() {
-        // Without the NUL separator, ("alice", "bob-c") and
-        // ("alice-bob", "c") would both produce the input "alicebob-c"
-        // (or "alicebobc") and collide.
-        let a = derive_room_id(
-            &MeshIdentity::new("alice"),
-            &ChannelName::new("bob-c").unwrap(),
-        );
-        let b = derive_room_id(
-            &MeshIdentity::new("alice-bob"),
-            &ChannelName::new("c").unwrap(),
-        );
-        assert_ne!(a, b);
-    }
 
     #[test]
     fn resolve_id_token_binds_id_shaped_tokens_to_existing_channels() {
@@ -829,31 +723,31 @@ mod tests {
 
         // 8-hex short id → binds to academy.
         match set.resolve_id_token(&simple[..8]) {
-            IdTokenResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
+            RoomIdResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
             other => panic!("short id must Match, got {other:?}"),
         }
         // Full dashed uuid → binds too (resolution wins over the old refusal).
         match set.resolve_id_token(&academy.room_id.to_string()) {
-            IdTokenResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
+            RoomIdResolution::Match(sub) => assert_eq!(sub.name.as_str(), "academy"),
             other => panic!("full uuid must Match, got {other:?}"),
         }
         // Id-shaped, no such channel → Unknown (join refuses; no mint).
         assert!(matches!(
             set.resolve_id_token("deadbeef"),
-            IdTokenResolution::Unknown
+            RoomIdResolution::Unknown
         ));
         // Plain names — including hexy-but-short and dashed ones — stay names.
         assert!(matches!(
             set.resolve_id_token("academy"),
-            IdTokenResolution::NotAnId
+            RoomIdResolution::NotAnId
         ));
         assert!(matches!(
             set.resolve_id_token("bench-swe-run-1"),
-            IdTokenResolution::NotAnId
+            RoomIdResolution::NotAnId
         ));
         assert!(matches!(
             set.resolve_id_token("cafe"),
-            IdTokenResolution::NotAnId
+            RoomIdResolution::NotAnId
         ));
     }
 
@@ -1001,58 +895,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // what this catches (self-healing join — receive-binding re-derive
-    // on identity heal): a subscription stored under a DIVERGED mesh
-    // identity keeps its stale room UUID forever (subscribe() is
-    // idempotent by NAME and never re-derives), so a healed identity
-    // leaves the scope reading a dead room. `rebind_diverged` must move
-    // every stale room UUID to the current derivation, preserve name /
-    // wire / joined_at_ms, report each old→new move, and be idempotent
-    // once converged.
-    #[test]
-    fn rebind_diverged_moves_room_ids_to_the_current_identity_derivation() {
-        let dir = tempdir().unwrap();
-        let home = dir.path();
-        let diverged = MeshIdentity::new("local-fallback-boot-identity");
-        let healed = MeshIdentity::new("joelteply");
-        let general = ChannelName::new("general").unwrap();
-        let project = ChannelName::new("cambriantech").unwrap();
-
-        let mut set = SubscriptionSet::empty();
-        set.subscribe(home, &diverged, general.clone()).unwrap();
-        set.subscribe(home, &diverged, project.clone()).unwrap();
-        let old_general = set.subscribed.get(&general).unwrap().clone();
-
-        let rebinds = set.rebind_diverged(&healed);
-        assert_eq!(rebinds.len(), 2, "both diverged rooms must be re-bound");
-        let general_rebind = rebinds
-            .iter()
-            .find(|rebind| rebind.name == general)
-            .expect("general rebind reported");
-        assert_eq!(general_rebind.old_room_id, old_general.room_id);
-        assert_eq!(
-            general_rebind.new_room_id,
-            derive_room_id(&healed, &general),
-            "the new binding must be the healed identity's derivation"
-        );
-
-        let rebound = set.subscribed.get(&general).unwrap();
-        assert_eq!(rebound.room_id, derive_room_id(&healed, &general));
-        assert_eq!(
-            rebound.wire, old_general.wire,
-            "the wire path is name-derived and must not move"
-        );
-        assert_eq!(
-            rebound.joined_at_ms, old_general.joined_at_ms,
-            "rebind is a heal, not a re-join"
-        );
-
-        // Idempotent once converged — a steady-state join must not spam.
-        assert!(
-            set.rebind_diverged(&healed).is_empty(),
-            "converged set must report no rebinds"
-        );
-    }
 
     #[tokio::test]
     async fn save_load_round_trip_preserves_set() {

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -370,6 +370,11 @@ impl SubscriptionSet {
         Ok(sub)
     }
 
+    /// Record a subscription this scope already constructed.
+    pub(crate) fn insert_subscription(&mut self, sub: Subscription) {
+        self.insert(sub);
+    }
+
     fn insert(&mut self, sub: Subscription) {
         self.parted.remove(&sub.room_id);
         let room_id = sub.room_id;

--- a/crates/airc-lib/tests/common/mod.rs
+++ b/crates/airc-lib/tests/common/mod.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use airc_core::PeerId;
+use airc_core::{PeerId, RoomId};
 use airc_daemon::{run, DaemonRuntimeInfo, DaemonState};
 use airc_lib::{Airc, PeerSpec};
 use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
@@ -280,4 +280,33 @@ pub async fn trust(a: &Airc, b: &Airc) {
     let b_spec: PeerSpec = b.peer_spec().parse().expect("b peer spec");
     a.add_peer(b_spec).await.expect("a trusts b");
     b.add_peer(a_spec).await.expect("b trusts a");
+}
+
+/// Put every scope in ONE room and return its id.
+///
+/// The first scope resolves `label` on its own account — minting the
+/// room if this account has never used the name — and every other
+/// scope joins THAT id.
+///
+/// Why this is a helper and not `scope.join(label)` per scope: a label
+/// keys a room only WITHIN one account. Two scopes on two simulated
+/// machines each joining `"room"` get two different rooms that merely
+/// share a name, and every frame between them comes back
+/// `Undeliverable { UnknownChannel }`. The id is the address, so a
+/// test that means "these scopes are together" has to say so by id —
+/// once, here, rather than correctly in each of a dozen call sites.
+pub async fn same_room(label: &str, scopes: &[&Airc]) -> RoomId {
+    let (first, rest) = scopes.split_first().expect("at least one scope");
+    let room_id = first
+        .join(label)
+        .await
+        .expect("first scope resolves the label on its own account")
+        .channel;
+    for scope in rest {
+        scope
+            .join_room_id(room_id, label)
+            .await
+            .expect("scope joins the SAME room by id");
+    }
+    room_id
 }

--- a/crates/airc-lib/tests/daemon_cursor_reads.rs
+++ b/crates/airc-lib/tests/daemon_cursor_reads.rs
@@ -15,7 +15,6 @@
 
 mod common;
 
-use airc_lib::ChannelName;
 use common::Machine;
 
 #[tokio::test]
@@ -57,9 +56,9 @@ async fn attached_subscription_cursor_is_the_daemon_tip() {
 
     let last = alice.say("newest").await.expect("say");
 
-    let channel = ChannelName::new("sub-cursor").expect("channel name");
+    let room = bob.current_room().await.expect("current room");
     let cursor = bob
-        .subscription_cursor(&channel)
+        .subscription_cursor(&room.channel)
         .await
         .expect("subscription_cursor")
         .expect("subscribed channel with daemon history has a cursor");
@@ -70,7 +69,7 @@ async fn attached_subscription_cursor_is_the_daemon_tip() {
 
     // A channel this scope is not subscribed to still answers None —
     // the subscription gate is unchanged by the daemon routing.
-    let unsubscribed = ChannelName::new("not-joined").expect("channel name");
+    let unsubscribed = airc_lib::RoomId::new();
     assert_eq!(
         bob.subscription_cursor(&unsubscribed)
             .await

--- a/crates/airc-lib/tests/daemon_lan_visibility.rs
+++ b/crates/airc-lib/tests/daemon_lan_visibility.rs
@@ -477,7 +477,7 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
     let document = airc_lib::AccountRegistryDocument::new(
         identity.clone(),
         now_ms,
-        vec![known_room],
+        vec![airc_lib::AccountRoom::new(known_room, Some("general".to_string()))],
         vec![airc_lib::AccountPeerBeacon {
             presence: airc_lib::beacon_now(
                 remote_peer,

--- a/crates/airc-lib/tests/daemon_lan_visibility.rs
+++ b/crates/airc-lib/tests/daemon_lan_visibility.rs
@@ -64,6 +64,22 @@ async fn machine_coordinator_store(machine: &Machine) -> Arc<dyn EventStore> {
     )
 }
 
+/// The id this machine's ACCOUNT gives `label`, claiming it if this
+/// is the first ask.
+///
+/// This is what any scope's `join(label)` resolves through, so a room
+/// claimed here is the same room a later `operator.join(label)` lands
+/// in — which is exactly what the late-joiner test needs: the room
+/// must have an ADDRESS before anyone on this machine SUBSCRIBES to
+/// it, and those are different things.
+async fn account_room_id(machine: &Machine, label: &str) -> RoomId {
+    machine_coordinator_store(machine)
+        .await
+        .claim_room_label(label, RoomId::new(), 1)
+        .await
+        .expect("claim the account's room label")
+}
+
 /// Build the production bridge against this machine's daemon router +
 /// coordinator store and install it on a LAN-gateway handle — the
 /// in-process equivalent of what `run_daemon` does for its listener
@@ -83,13 +99,25 @@ async fn lan_gateway_with_bridge(machine: &Machine) -> (Airc, Arc<RouterInboundB
     (gateway, bridge)
 }
 
-/// A remote peer on its own "machine" (isolated temp home), joined to
-/// `room`, mutually trusted and dialed into the gateway's listener.
-async fn dialed_remote(gateway: &Airc, remote_home: &TempDir, room: &str) -> Airc {
+/// A remote peer on its own "machine" (isolated temp home), in the
+/// SAME room as the gateway, mutually trusted and dialed into the
+/// gateway's listener.
+///
+/// `room_id` is the gateway's own room id, and the remote joins THAT
+/// — the rendezvous shape, and the only one that works across two
+/// machines. Joining by the label instead (`remote.join("name")`)
+/// mints a second room on the remote's own machine that merely SHARES
+/// a name, so every frame the remote sent came back `Undeliverable {
+/// UnknownChannel }`: two rooms, one label, no membership in common.
+/// A label keys nothing; the id is the address.
+async fn dialed_remote(gateway: &Airc, remote_home: &TempDir, room_id: RoomId) -> Airc {
     let remote = Airc::open(remote_home.path().join(".airc"))
         .await
         .expect("open remote");
-    remote.join(room).await.expect("remote joins room");
+    remote
+        .join_room_id(room_id, "gateway-room")
+        .await
+        .expect("remote joins the gateway's room BY ID");
     let remote_spec: PeerSpec = remote.peer_spec().parse().expect("remote spec");
     let gateway_spec: PeerSpec = gateway.peer_spec().parse().expect("gateway spec");
     gateway
@@ -178,7 +206,8 @@ async fn inbound_lan_frame_is_visible_in_subscribed_scope_transcript() {
 
     let (gateway, _bridge) = lan_gateway_with_bridge(&machine).await;
     let remote_home = TempDir::new().expect("remote home");
-    let remote = dialed_remote(&gateway, &remote_home, "store-split-room").await;
+    let room_id = account_room_id(&machine, "store-split-room").await;
+    let remote = dialed_remote(&gateway, &remote_home, room_id).await;
 
     let outcome = remote
         .send_with_delivery_ack(
@@ -234,7 +263,8 @@ async fn unsubscribed_scope_does_not_see_inbound_frame() {
 
     let (gateway, _bridge) = lan_gateway_with_bridge(&machine).await;
     let remote_home = TempDir::new().expect("remote home");
-    let remote = dialed_remote(&gateway, &remote_home, "store-split-room").await;
+    let room_id = account_room_id(&machine, "store-split-room").await;
+    let remote = dialed_remote(&gateway, &remote_home, room_id).await;
 
     let outcome = remote
         .send_with_delivery_ack(
@@ -372,7 +402,10 @@ async fn delivered_ack_means_visible_to_subscribed_scopes_not_just_durable() {
     gateway.set_diagnostic_sink(Arc::new(diag.clone()));
 
     let remote_home = TempDir::new().expect("remote home");
-    let remote = dialed_remote(&gateway, &remote_home, "store-split-room").await;
+    // The room gets an ADDRESS now; nobody on this machine SUBSCRIBES
+    // to it until the operator attaches below. That gap is the test.
+    let room_id = account_room_id(&machine, "store-split-room").await;
+    let remote = dialed_remote(&gateway, &remote_home, room_id).await;
 
     // Nobody on the receiving machine subscribes yet.
     let outcome = remote

--- a/crates/airc-lib/tests/daemon_lan_visibility.rs
+++ b/crates/airc-lib/tests/daemon_lan_visibility.rs
@@ -465,7 +465,9 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
     // Seed the LOCAL account-registry cache: the account knows
     // #general via a remote machine's beacon. No scope on THIS machine
     // has ever joined, so the coordinator store holds no binding.
-    let channel_name = airc_lib::subscriptions::ChannelName::new("general").expect("channel");
+    // The account knows this ROOM BY ID — that is what a beacon
+    // advertises and what a frame addresses.
+    let known_room = RoomId::new();
     let remote_peer = PeerId::new();
     let remote_keypair = airc_protocol::PeerKeypair::generate();
     let now_ms = std::time::SystemTime::now()
@@ -475,12 +477,12 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
     let document = airc_lib::AccountRegistryDocument::new(
         identity.clone(),
         now_ms,
-        vec![channel_name.clone()],
+        vec![known_room],
         vec![airc_lib::AccountPeerBeacon {
             presence: airc_lib::beacon_now(
                 remote_peer,
                 "/machine/remote/.airc".into(),
-                vec![channel_name.clone()],
+                vec![known_room],
                 123,
                 now_ms,
             ),
@@ -518,12 +520,11 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
         "an account-unknown channel must not fake a rebind"
     );
 
-    // The heal: the frame's channel derives from a registry-known name
+    // The heal: the frame addresses a room the registry KNOWS BY ID
     // → rebound from the registry beacon and DELIVERED.
-    let general = airc_lib::subscriptions::derive_room_id(&identity, &channel_name);
     assert_eq!(
         bridge
-            .deliver(&inbound_frame(general, EventId::new(), "hello blind room"))
+            .deliver(&inbound_frame(known_room, EventId::new(), "hello blind room"))
             .await,
         InboundDeliveryVerdict::Delivered,
         "a registry-known channel must re-bind and deliver, not store-and-drop"
@@ -544,7 +545,7 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
     // rebind — the heal restored durable state, not a per-frame patch.
     assert_eq!(
         bridge
-            .deliver(&inbound_frame(general, EventId::new(), "second frame"))
+            .deliver(&inbound_frame(known_room, EventId::new(), "second frame"))
             .await,
         InboundDeliveryVerdict::Delivered,
     );
@@ -555,295 +556,43 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
     );
 }
 
-/// what this catches (self-healing join, the M5↔bigmama blind-room
-/// ROOT CAUSE — live log: 24 unknown_channel frames on channel
-/// `eef18336-…` = derive_room_id("local:unknown-host:unknown-user",
-/// "general")): bigmama's Windows daemon fell to the degenerate
-/// mesh-identity fallback (gh unreachable; POSIX env probes don't
-/// exist on Windows), so its `#general` UUID diverged from this
-/// machine's — and every room frame between the two machines died as
-/// unknown_channel while the room was bound and readable on both
-/// sides the whole time. The bridge must re-derive the room from the
-/// frame's channel-NAME header under THIS machine's identity and
-/// deliver into the bound room (loudly); a frame with no header, or a
-/// name nobody binds, keeps the honest unknown-channel verdict; and a
-/// BOUND channel is never re-routed by the hint. Mutation checks:
-/// dropping `reconverge_by_name` fails the DeliveredRemapped assert;
-/// remapping before the bound-check would fail the never-re-route
-/// assert; publishing under the addressed UUID instead of the local
-/// one would fail the operator-visibility assert.
+/// A sender's channel-NAME header must NEVER redirect a frame.
+///
+/// what this catches: the deleted `reconverge_by_name`. It re-routed an
+/// unbound frame to whatever local room the sender's NAME header
+/// derived to — which meant a peer could redirect a frame into a room
+/// it was not addressing by sending different text. That existed only
+/// because room ids were `v5(identity, name)` and could DIVERGE between
+/// machines. Ids are minted now: nothing derives, so nothing diverges,
+/// and the header is decoration.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn diverged_channel_uuid_reconverges_by_name_header() {
+async fn a_name_header_never_redirects_a_frame() {
     let machine = Machine::boot().await;
     let store = machine_coordinator_store(&machine).await;
     pin_identity(store.as_ref(), "converged-account").await;
     let operator = machine.attach("operator").await;
-    let room = operator.join("general").await.expect("operator joins");
+    let room = operator.join("general").await.expect("join");
 
     let sink = MemoryDiagnosticSink::default();
     let bridge = RouterInboundBridge::new(machine.daemon.router(), store.clone())
         .with_diagnostic_sink(Arc::new(sink.clone()));
 
-    // The literal field fingerprint: the sender derived #general under
-    // the degenerate Windows fallback identity.
-    let diverged_identity =
-        airc_lib::subscriptions::MeshIdentity::new("local:unknown-host:unknown-user");
-    let name = airc_lib::subscriptions::ChannelName::new("general").expect("channel name");
-    let diverged = airc_lib::subscriptions::derive_room_id(&diverged_identity, &name);
-    assert_ne!(
-        diverged, room.channel,
-        "premise: the two identities must derive different room UUIDs"
-    );
-
-    // Control: no name header → honestly blind (durable + loud, as before).
-    assert_eq!(
-        bridge
-            .deliver(&inbound_frame(diverged, EventId::new(), "no hint"))
-            .await,
-        InboundDeliveryVerdict::UnknownChannel,
-        "without the name header there is no honest reconvergence"
-    );
-
-    // THE heal: the name header re-derives to the bound local room.
-    let healed_id = EventId::new();
+    // A frame addressed at a room NOBODY binds, carrying the name of a
+    // room this scope IS in. The old code delivered it into #general.
+    let stranger = RoomId::new();
     assert_eq!(
         bridge
             .deliver(&inbound_frame_with_headers(
-                diverged,
-                healed_id,
-                "hello from the diverged machine",
+                stranger,
+                EventId::new(),
+                "i claim to be #general",
                 &[(airc_protocol::HEADER_AIRC_CHANNEL_NAME, "general")],
             ))
             .await,
-        InboundDeliveryVerdict::DeliveredRemapped(room.channel),
-        "a name that derives to a bound local room must deliver there"
-    );
-    let recent = operator.page_recent(32).await.expect("page_recent");
-    assert!(
-        recent.iter().any(|event| event.event_id == healed_id),
-        "the reconverged frame must surface in the room the operator reads"
-    );
-    let reconvergences = |sink: &MemoryDiagnosticSink| {
-        sink.events()
-            .iter()
-            .filter(|event| event.code == DiagnosticCode::ChannelNameReconverged)
-            .count()
-    };
-    assert_eq!(reconvergences(&sink), 1, "the heal must be LOUD");
-
-    // A name nobody binds (and the account does not know) must not
-    // fake a delivery.
-    assert_eq!(
-        bridge
-            .deliver(&inbound_frame_with_headers(
-                diverged,
-                EventId::new(),
-                "nobody reads this",
-                &[(airc_protocol::HEADER_AIRC_CHANNEL_NAME, "nobody-binds-this")],
-            ))
-            .await,
         InboundDeliveryVerdict::UnknownChannel,
-        "an unbound name must keep the honest unknown-channel verdict"
+        "a name header must not buy delivery into a room the frame did not address"
     );
 
-    // A BOUND channel is never re-routed: the header is a heal hint,
-    // not addressing authority.
-    assert_eq!(
-        bridge
-            .deliver(&inbound_frame_with_headers(
-                room.channel,
-                EventId::new(),
-                "correctly addressed",
-                &[(airc_protocol::HEADER_AIRC_CHANNEL_NAME, "nobody-binds-this")],
-            ))
-            .await,
-        InboundDeliveryVerdict::Delivered,
-        "a bound channel must deliver as addressed, hint ignored"
-    );
-    assert_eq!(
-        reconvergences(&sink),
-        1,
-        "no reconvergence may fire for a bound or unhealable channel"
-    );
-}
-
-/// what this catches (the field scenario END-TO-END, over a real TLS
-/// LAN link): a remote machine pinned to the degenerate Windows
-/// fallback identity joins #general (deriving a diverged channel
-/// UUID), dials in, and sends with a delivery ack. Sender-side, the
-/// room name must ride `HEADER_AIRC_CHANNEL_NAME` (stamped by
-/// `send_frame_to_room`); receiver-side, the bridge must reconverge by
-/// name; the ack must say DELIVERED carrying the receiver's LOCAL
-/// channel; and the operator scope must actually see the message.
-/// This is the exact exchange that produced bigmama's unknown_channel
-/// receipts before the heal.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn diverged_remote_lan_send_reconverges_and_acks_delivered() {
-    let machine = Machine::boot().await;
-    let store = machine_coordinator_store(&machine).await;
-    pin_identity(store.as_ref(), "converged-account").await;
-    let operator = machine.attach("operator").await;
-    let room = operator.join("general").await.expect("operator joins");
-
-    let (gateway, _bridge) = lan_gateway_with_bridge(&machine).await;
-    let remote_home = TempDir::new().expect("remote home");
-    let remote = Airc::open(remote_home.path().join(".airc"))
-        .await
-        .expect("open remote");
-    // Pin BEFORE join so the diverged identity shapes the remote's
-    // room derivation — the bigmama boot order.
-    pin_identity(
-        remote.coordinator_store_for_test(),
-        "local:unknown-host:unknown-user",
-    )
-    .await;
-    let remote_room = remote.join("general").await.expect("remote joins");
-    assert_ne!(
-        remote_room.channel, room.channel,
-        "premise: the remote must derive a DIVERGED channel UUID"
-    );
-    let remote_spec: PeerSpec = remote.peer_spec().parse().expect("remote spec");
-    let gateway_spec: PeerSpec = gateway.peer_spec().parse().expect("gateway spec");
-    gateway.add_peer(remote_spec).await.expect("gateway trusts");
-    remote.add_peer(gateway_spec).await.expect("remote trusts");
-    let addr: SocketAddr = gateway
-        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .await
-        .expect("gateway listens");
-    remote
-        .connect_lan(addr, gateway.peer_id())
-        .await
-        .expect("remote dials");
-
-    let outcome = remote
-        .send_with_delivery_ack(
-            "marker across the diverged channel",
-            Headers::new(),
-            Duration::from_secs(5),
-        )
-        .await
-        .expect("send succeeds");
-    let event_id = match outcome {
-        DeliverySendOutcome::Delivered { event_id, ack } => {
-            match ack.outcome {
-                DeliveryOutcome::Delivered { channel, .. } => assert_eq!(
-                    channel, room.channel,
-                    "the ack must carry the receiver's LOCAL room, not the diverged UUID"
-                ),
-                DeliveryOutcome::Undeliverable { .. } => {
-                    panic!("delivered outcome must not be undeliverable")
-                }
-            }
-            event_id
-        }
-        DeliverySendOutcome::Undeliverable { .. } | DeliverySendOutcome::NoAck { .. } => {
-            panic!("expected Delivered after name reconvergence, got {outcome:?}")
-        }
-    };
-
-    let recent = operator.page_recent(32).await.expect("page_recent");
-    let seen = recent
-        .iter()
-        .find(|event| event.event_id == event_id)
-        .expect("the diverged remote's message must surface in the operator's room");
-    assert_eq!(
-        seen.headers
-            .get(airc_protocol::HEADER_AIRC_CHANNEL_NAME)
-            .map(String::as_str),
-        Some("general"),
-        "the sender must stamp the channel name on the wire — the convergence key"
-    );
-}
-
-/// what this catches (self-healing join item 2 — receive-binding
-/// re-derive on identity heal; the live sequel to the d79843c heal):
-/// a scope that joined WHILE its machine's mesh identity was diverged
-/// stores its subscription under the diverged room UUID. After the
-/// identity heals, inbound frames arrive addressed to the CONVERGED
-/// UUID — the per-frame name reconvergence heals delivery TO a bound
-/// room, but a room bound under a stale UUID must be REBOUND or the
-/// scope keeps reading the dead room (live evidence: it took a manual
-/// `airc stop && airc join`). The join-shaped touchpoint must re-derive
-/// and re-bind; after that, a frame addressed to the converged UUID is
-/// delivered AND visible to the scope, while the old diverged UUID
-/// keeps working via the existing name reconvergence remap. Mutation
-/// checks: dropping `rebind_diverged` (or not calling it from `join`)
-/// fails the room-UUID assert and the operator-visibility assert.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn healed_identity_rebinds_stale_subscription_to_the_converged_room() {
-    let machine = Machine::boot().await;
-    let store = machine_coordinator_store(&machine).await;
-    let name = airc_lib::subscriptions::ChannelName::new("general").expect("channel name");
-
-    // Boot diverged (the Windows-fallback shape), join #general.
-    pin_identity(store.as_ref(), "diverged-boot-identity").await;
-    let operator = machine.attach("operator").await;
-    let stale_room = operator.join("general").await.expect("diverged join");
-
-    let diverged_id = airc_lib::subscriptions::derive_room_id(
-        &airc_lib::subscriptions::MeshIdentity::new("diverged-boot-identity"),
-        &name,
-    );
-    let converged_id = airc_lib::subscriptions::derive_room_id(
-        &airc_lib::subscriptions::MeshIdentity::new("converged-account"),
-        &name,
-    );
-    assert_eq!(stale_room.channel, diverged_id, "premise: joined diverged");
-    assert_ne!(diverged_id, converged_id, "premise: identities diverge");
-
-    // The identity HEALS (gh reachable again / operator re-pin).
-    pin_identity(store.as_ref(), "converged-account").await;
-
-    // The join-shaped touchpoint re-binds the stored subscription.
-    let healed_room = operator.join("general").await.expect("healed join");
-    assert_eq!(
-        healed_room.channel, converged_id,
-        "join after the identity heal must re-bind the stored subscription \
-         to the converged room UUID, not keep returning the stale one"
-    );
-
-    // An inbound frame addressed to the CONVERGED UUID now delivers…
-    let sink = MemoryDiagnosticSink::default();
-    let bridge = RouterInboundBridge::new(machine.daemon.router(), store.clone())
-        .with_diagnostic_sink(Arc::new(sink.clone()));
-    let converged_event = EventId::new();
-    assert_eq!(
-        bridge
-            .deliver(&inbound_frame(
-                converged_id,
-                converged_event,
-                "addressed to the converged room"
-            ))
-            .await,
-        InboundDeliveryVerdict::Delivered,
-        "the healed binding must make the converged room deliverable"
-    );
-    // …and the SCOPE actually reads it (the read side is what the
-    // per-frame remap could never heal).
-    let recent = operator.page_recent(32).await.expect("page_recent");
-    assert!(
-        recent.iter().any(|event| event.event_id == converged_event),
-        "the rebound scope must see frames addressed to the converged room"
-    );
-
-    // The OLD diverged UUID keeps working via the existing name
-    // reconvergence remap (a not-yet-healed sender still converges).
-    let stale_addressed = EventId::new();
-    assert_eq!(
-        bridge
-            .deliver(&inbound_frame_with_headers(
-                diverged_id,
-                stale_addressed,
-                "addressed to the old diverged room",
-                &[(airc_protocol::HEADER_AIRC_CHANNEL_NAME, "general")],
-            ))
-            .await,
-        InboundDeliveryVerdict::DeliveredRemapped(converged_id),
-        "the old UUID must keep delivering via the per-frame name remap"
-    );
-    let recent = operator.page_recent(32).await.expect("page_recent");
-    assert!(
-        recent.iter().any(|event| event.event_id == stale_addressed),
-        "frames remapped from the old UUID must surface in the rebound room"
-    );
+    // And the room it named is untouched — the frame did not land there.
+    assert_ne!(stranger, room.channel);
 }

--- a/crates/airc-lib/tests/daemon_lan_visibility.rs
+++ b/crates/airc-lib/tests/daemon_lan_visibility.rs
@@ -477,7 +477,10 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
     let document = airc_lib::AccountRegistryDocument::new(
         identity.clone(),
         now_ms,
-        vec![airc_lib::AccountRoom::new(known_room, Some("general".to_string()))],
+        vec![airc_lib::AccountRoom::new(
+            known_room,
+            Some("general".to_string()),
+        )],
         vec![airc_lib::AccountPeerBeacon {
             presence: airc_lib::beacon_now(
                 remote_peer,
@@ -524,7 +527,11 @@ async fn unknown_channel_auto_rebinds_from_account_registry_cache() {
     // → rebound from the registry beacon and DELIVERED.
     assert_eq!(
         bridge
-            .deliver(&inbound_frame(known_room, EventId::new(), "hello blind room"))
+            .deliver(&inbound_frame(
+                known_room,
+                EventId::new(),
+                "hello blind room"
+            ))
             .await,
         InboundDeliveryVerdict::Delivered,
         "a registry-known channel must re-bind and deliver, not store-and-drop"

--- a/crates/airc-lib/tests/daemon_routed_forward.rs
+++ b/crates/airc-lib/tests/daemon_routed_forward.rs
@@ -49,7 +49,7 @@ use airc_relay::{RelayServer, RelayServerConfig};
 use airc_store::{EventStore, SqliteEventStore};
 use airc_transport::LanTcpAdapter;
 use async_trait::async_trait;
-use common::Machine;
+use common::{same_room, Machine};
 
 const ROOM: &str = "routed-forward-room";
 
@@ -172,9 +172,8 @@ async fn routed_room_send_traverses_lan_both_directions() {
     link(&a.gateway, &b.gateway).await;
 
     let op_a = a.machine.attach("op-a").await;
-    op_a.join(ROOM).await.expect("op-a joins");
     let op_b = b.machine.attach("op-b").await;
-    op_b.join(ROOM).await.expect("op-b joins");
+    same_room(ROOM, &[&op_a, &op_b]).await;
 
     // A → B: the leg that was dead (daemon-originated ROUTED sends).
     let id_ab = op_a
@@ -233,9 +232,8 @@ async fn frame_received_from_a_peer_is_not_forwarded_back_to_it() {
     link(&a.gateway, &b.gateway).await;
 
     let op_a = a.machine.attach("op-a").await;
-    op_a.join(ROOM).await.expect("op-a joins");
     let op_b = b.machine.attach("op-b").await;
-    op_b.join(ROOM).await.expect("op-b joins");
+    same_room(ROOM, &[&op_a, &op_b]).await;
 
     // Quiesce, then snapshot B's wire-flush counter.
     tokio::time::sleep(Duration::from_millis(300)).await;
@@ -274,11 +272,9 @@ async fn transitive_forward_reaches_third_machine_exactly_once() {
     link(&b.gateway, &c.gateway).await;
 
     let op_a = a.machine.attach("op-a").await;
-    op_a.join(ROOM).await.expect("op-a joins");
     let op_b = b.machine.attach("op-b").await;
-    op_b.join(ROOM).await.expect("op-b joins");
     let op_c = c.machine.attach("op-c").await;
-    op_c.join(ROOM).await.expect("op-c joins");
+    same_room(ROOM, &[&op_a, &op_b, &op_c]).await;
 
     let event_id = op_a
         .say("one hop, two hops — exactly once everywhere")
@@ -374,9 +370,8 @@ async fn remote_persist_failure_then_retry_is_exactly_once_visible() {
     link(&a.gateway, &b_gateway).await;
 
     let op_a = a.machine.attach("op-a").await;
-    op_a.join(ROOM).await.expect("op-a joins");
     let op_b = b_machine.attach("op-b").await;
-    op_b.join(ROOM).await.expect("op-b joins");
+    same_room(ROOM, &[&op_a, &op_b]).await;
 
     let event_id = op_a.say(MARKER).await.expect("op-a says");
 
@@ -527,9 +522,8 @@ async fn delivery_ledger_records_measured_acks_for_a_live_peer() {
     link(&a.gateway, &b.gateway).await;
 
     let op_a = a.machine.attach("op-a").await;
-    op_a.join(ROOM).await.expect("op-a joins");
     let op_b = b.machine.attach("op-b").await;
-    op_b.join(ROOM).await.expect("op-b joins");
+    same_room(ROOM, &[&op_a, &op_b]).await;
 
     let id = op_a.say("ledger proof").await.expect("op-a says");
     assert_eq!(wait_for_copies(&op_b, id).await, 1);
@@ -658,9 +652,8 @@ async fn routed_room_send_traverses_relay() {
     }
 
     let op_a = a.machine.attach("op-a").await;
-    op_a.join(ROOM).await.expect("op-a joins");
     let op_b = b.machine.attach("op-b").await;
-    op_b.join(ROOM).await.expect("op-b joins");
+    same_room(ROOM, &[&op_a, &op_b]).await;
 
     let id = op_a
         .say("room message A→B over the relay")

--- a/crates/airc-lib/tests/default_room_durability.rs
+++ b/crates/airc-lib/tests/default_room_durability.rs
@@ -53,9 +53,12 @@ async fn open_scope(home: &Path, wire_root: &Path) -> Airc {
         .expect("open scope")
 }
 
+/// The default room's LABEL, read off the subscription the default id
+/// points at. The pointer is the id; this is only for readable asserts.
 async fn default_channel(airc: &Airc) -> Option<String> {
     let set = airc.subscription_set().await.expect("load subscriptions");
-    set.default.map(|name| name.as_str().to_string())
+    set.default_subscription()
+        .map(|s| s.name.as_str().to_string())
 }
 
 /// THE BUG: bare `airc join` re-run from a cwd outside any git

--- a/crates/airc-lib/tests/invite_room_rendezvous.rs
+++ b/crates/airc-lib/tests/invite_room_rendezvous.rs
@@ -1,0 +1,118 @@
+//! Rendezvous: how two scopes that have never met end up in ONE room.
+//!
+//! A room label keys a room only WITHIN one account. Across two
+//! accounts it keys nothing — so "we both joined #project" is not a
+//! shared room, it is two rooms wearing the same word, and every
+//! frame between them comes back `Undeliverable { UnknownChannel }`.
+//!
+//! The only thing that crosses an account boundary intact is the id.
+//! An `InviteBeacon` carries the ids of the rooms its publisher is in
+//! (`rooms: Vec<RoomId>` — ids, never `(id, label)` pairs, because a
+//! pair makes the pair the unit of exchange and re-imports naming
+//! into the rendezvous). The recipient imports the beacon, reads the
+//! ids, and joins one by id.
+//!
+//! This file pins that chain end to end, and pins the negative half
+//! too: joining by the LABEL instead gets you a different room. That
+//! second assertion is the whole reason the by-id verb exists.
+
+use airc_lib::Airc;
+use tempfile::TempDir;
+
+/// The rendezvous keystone: beacon → import → id → join, and both
+/// scopes land in the SAME room.
+///
+/// what this catches: a beacon that advertises reachability but not
+/// rooms (the shape before `rooms` existed), leaving a freshly-paired
+/// peer able to reach its partner and with no way to name anywhere to
+/// speak; and any regression where `join_room_id` resolves through
+/// the label instead of taking the id it was handed.
+#[tokio::test]
+async fn a_peer_joins_the_publishers_room_by_id_from_its_invite_beacon() {
+    let tmp_a = TempDir::new().expect("alice tempdir");
+    let tmp_b = TempDir::new().expect("bob tempdir");
+    let alice = Airc::open(tmp_a.path().join(".airc"))
+        .await
+        .expect("alice open");
+    let bob = Airc::open(tmp_b.path().join(".airc"))
+        .await
+        .expect("bob open");
+
+    // Alice is in a room. Her account minted the id; the label is
+    // hers, and stays hers.
+    let alice_room = alice.join("design-review").await.expect("alice joins");
+
+    // The beacon carries the ids of the rooms she is in.
+    let beacon = alice
+        .invite_beacon_with_rooms()
+        .await
+        .expect("alice builds a beacon carrying her rooms");
+    assert!(
+        beacon.rooms.contains(&alice_room.channel),
+        "the beacon must advertise the room its publisher is in; \
+         without it a paired peer has reachability and nowhere to go. \
+         advertised: {:?}, alice is in: {}",
+        beacon.rooms,
+        alice_room.channel
+    );
+
+    bob.import_invite_beacon(beacon)
+        .await
+        .expect("bob imports alice's invite");
+
+    // What bob can now join, BY ID. Nothing here is resolved by name.
+    let joinable = bob.peer_room_ids().expect("bob reads peer room ids");
+    assert!(
+        joinable.contains(&alice_room.channel),
+        "an imported invite's rooms must surface as joinable ids; \
+         joinable: {joinable:?}, expected to contain {}",
+        alice_room.channel
+    );
+
+    // Bob joins by id, labelling it whatever he likes — the label is
+    // local display and deliberately NOT alice's word for the room.
+    let bob_room = bob
+        .join_room_id(alice_room.channel, "the-thing-alice-invited-me-to")
+        .await
+        .expect("bob joins by id");
+
+    assert_eq!(
+        bob_room.channel, alice_room.channel,
+        "both scopes must be in ONE room — the id is the room"
+    );
+    assert_ne!(
+        bob_room.name, alice_room.name,
+        "and they may call it different things: a label is per-scope \
+         display, so a matching id with differing labels is the \
+         contract working, not a bug"
+    );
+}
+
+/// The negative half, and the reason the by-id verb had to exist.
+///
+/// what this catches: any return of name-derived room identity. If a
+/// label ever keys a room across accounts again, these two ids
+/// collide and this test fails — which is exactly the silent
+/// `UnknownChannel` bug, caught at build time instead of on the wire.
+#[tokio::test]
+async fn joining_the_same_label_on_another_account_is_a_different_room() {
+    let tmp_a = TempDir::new().expect("alice tempdir");
+    let tmp_b = TempDir::new().expect("bob tempdir");
+    let alice = Airc::open(tmp_a.path().join(".airc"))
+        .await
+        .expect("alice open");
+    let bob = Airc::open(tmp_b.path().join(".airc"))
+        .await
+        .expect("bob open");
+
+    let alice_room = alice.join("design-review").await.expect("alice joins");
+    let bob_room = bob.join("design-review").await.expect("bob joins");
+
+    assert_ne!(
+        alice_room.channel, bob_room.channel,
+        "two accounts typing the same word must get two DIFFERENT \
+         rooms — a label keys nothing across an account boundary. If \
+         these are equal, name-as-identity is back and every \
+         cross-account send is about to fail as UnknownChannel."
+    );
+}

--- a/crates/airc-lib/tests/lan_delivery_ack.rs
+++ b/crates/airc-lib/tests/lan_delivery_ack.rs
@@ -51,11 +51,15 @@ async fn lan_send_yields_delivered_ack_only_after_receiver_persistence() {
     let tmp_b = TempDir::new().expect("bob tempdir");
     let (alice, bob) = paired_handles(&tmp_a, &tmp_b).await;
 
-    // Both scopes bind the same channel name; same-machine mesh
-    // identity resolution makes the derived RoomId identical, which
-    // is the cross-machine production shape for a shared room.
+    // Alice's account resolves the label; bob joins THAT id. Two
+    // homes are two accounts, and a label keys a room only within
+    // one — so binding the same name on each would give them two
+    // different rooms wearing the same word, which is precisely the
+    // cross-machine shape this test must NOT accidentally exercise.
     let alice_room = alice.join("delivery-ack-room").await.expect("alice joins");
-    bob.join("delivery-ack-room").await.expect("bob joins");
+    bob.join_room_id(alice_room.channel, "delivery-ack-room")
+        .await
+        .expect("bob joins alice's room BY ID");
 
     let alice_addr: SocketAddr = alice
         .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -290,7 +290,7 @@ async fn part_channel_emits_room_parted_lifecycle_event() {
     assert_eq!(parted.channel, room.channel);
     assert!(
         !airc
-            .is_subscribed(&airc_lib::ChannelName::new("part-me").unwrap())
+            .is_subscribed(&room.channel)
             .await
             .expect("subscription query"),
         "parted channel must no longer be subscribed"

--- a/crates/airc-lib/tests/sibling_scope_intra_machine_msg.rs
+++ b/crates/airc-lib/tests/sibling_scope_intra_machine_msg.rs
@@ -39,7 +39,7 @@ mod common;
 use std::time::Duration;
 
 use airc_lib::Airc;
-use common::{trust, DaemonFixture, Machine};
+use common::{same_room, trust, DaemonFixture, Machine};
 use tempfile::TempDir;
 
 /// Baseline: with the shared-mesh-root convergence path (the test fixture's
@@ -102,9 +102,13 @@ async fn independent_wire_roots_two_scopes_share_one_daemon() {
 
     trust(&alice, &bob).await;
 
+    // Independent wire roots are independent ACCOUNTS, so the label
+    // keys nothing across them: joining it on each side would mint two
+    // rooms sharing a word. The room is the id alice's side resolves,
+    // and bob joins THAT — which is the shape the card describes and
+    // the only one that can route.
     let room = "sibling-scope-routing-independent";
-    alice.join(room).await.expect("alice joins");
-    bob.join(room).await.expect("bob joins");
+    same_room(room, &[&alice, &bob]).await;
 
     let body = "sibling-scope-routing-326000a5-independent";
     alice.say(body).await.expect("alice sends");

--- a/crates/airc-lib/tests/stored_endpoint_dial.rs
+++ b/crates/airc-lib/tests/stored_endpoint_dial.rs
@@ -623,7 +623,7 @@ async fn peer_dials_lan_rung_and_skips_tailscale() {
 #[tokio::test]
 async fn split_store_import_still_dials_no_silent_shadow() {
     use airc_lib::{
-        beacon_now, AccountPeerBeacon, AccountRegistryDocument, ChannelName, MeshIdentity,
+        beacon_now, AccountPeerBeacon, AccountRegistryDocument, MeshIdentity,
     };
 
     let tmp_a = TempDir::new().expect("alice tempdir");
@@ -650,18 +650,18 @@ async fn split_store_import_still_dials_no_silent_shadow() {
         .await
         .expect("alice listens");
 
-    let channel = ChannelName::new("general").expect("channel");
+    let room = alice.current_room().await.expect("alice current room");
     let document = AccountRegistryDocument::new(
         MeshIdentity::new("test-account"),
         2_000,
-        vec![channel.clone()],
+        vec![room.channel],
         vec![AccountPeerBeacon {
             endpoints_advertised_at_ms: None,
             endpoints_peer_id: None,
             presence: beacon_now(
                 alice.peer_id(),
                 tmp_a.path().join(".airc"),
-                vec![channel],
+                vec![room.channel],
                 123,
                 1_000,
             ),

--- a/crates/airc-lib/tests/stored_endpoint_dial.rs
+++ b/crates/airc-lib/tests/stored_endpoint_dial.rs
@@ -654,7 +654,7 @@ async fn split_store_import_still_dials_no_silent_shadow() {
     let document = AccountRegistryDocument::new(
         MeshIdentity::new("test-account"),
         2_000,
-        vec![room.channel],
+        vec![airc_lib::AccountRoom::new(room.channel, Some(room.name.clone()))],
         vec![AccountPeerBeacon {
             endpoints_advertised_at_ms: None,
             endpoints_peer_id: None,

--- a/crates/airc-lib/tests/stored_endpoint_dial.rs
+++ b/crates/airc-lib/tests/stored_endpoint_dial.rs
@@ -622,9 +622,7 @@ async fn peer_dials_lan_rung_and_skips_tailscale() {
 /// and demands the dial happens.
 #[tokio::test]
 async fn split_store_import_still_dials_no_silent_shadow() {
-    use airc_lib::{
-        beacon_now, AccountPeerBeacon, AccountRegistryDocument, MeshIdentity,
-    };
+    use airc_lib::{beacon_now, AccountPeerBeacon, AccountRegistryDocument, MeshIdentity};
 
     let tmp_a = TempDir::new().expect("alice tempdir");
     let tmp_b = TempDir::new().expect("bob tempdir");
@@ -654,7 +652,10 @@ async fn split_store_import_still_dials_no_silent_shadow() {
     let document = AccountRegistryDocument::new(
         MeshIdentity::new("test-account"),
         2_000,
-        vec![airc_lib::AccountRoom::new(room.channel, Some(room.name.clone()))],
+        vec![airc_lib::AccountRoom::new(
+            room.channel,
+            Some(room.name.clone()),
+        )],
         vec![AccountPeerBeacon {
             endpoints_advertised_at_ms: None,
             endpoints_peer_id: None,

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -41,6 +41,7 @@ pub mod mesh_identity;
 pub mod peer_rotation_audit;
 pub mod peer_trust;
 pub mod refresh_lock;
+pub mod room_directory;
 pub mod runtime_cursor;
 pub mod scoped_state;
 pub mod subscription;

--- a/crates/airc-store/src/entities/room_directory.rs
+++ b/crates/airc-store/src/entities/room_directory.rs
@@ -1,0 +1,20 @@
+//! `room_directory` table — the account's `label → RoomId` index.
+//!
+//! The ONLY place a room label is a key. Everywhere else the label is a
+//! display string and the `RoomId` is the address.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "room_directory")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub label: String,
+    pub room_id: Uuid,
+    pub claimed_at_ms: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/error.rs
+++ b/crates/airc-store/src/error.rs
@@ -33,6 +33,12 @@ pub enum StoreError {
     #[error("unknown transcript kind: {0}")]
     UnknownTranscriptKind(String),
 
+    /// A row this store just wrote inside a transaction was not there
+    /// when the same transaction read it back. Never expected; refuse
+    /// rather than guess a value the caller would treat as durable.
+    #[error("store invariant broken: {0}")]
+    InvariantBroken(String),
+
     /// Stored numeric value is outside the domain accepted by the
     /// Rust contract. Refuse silent wraparound at the DB boundary.
     #[error("invalid stored value for {field}: {value}")]

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -23,6 +23,7 @@ pub struct InMemoryEventStore {
     events: Mutex<Vec<TranscriptEvent>>,
     runtime_cursors: Mutex<BTreeMap<String, TranscriptCursor>>,
     subscriptions: Mutex<Vec<StoredSubscription>>,
+    room_directory: Mutex<std::collections::BTreeMap<String, RoomId>>,
     mesh_identities: Mutex<BTreeMap<String, StoredMeshIdentity>>,
     beacons: Mutex<BTreeMap<(String, Uuid), StoredBeacon>>,
     refresh_locks: Mutex<BTreeMap<String, StoredRefreshLock>>,
@@ -36,6 +37,7 @@ impl InMemoryEventStore {
             events: Mutex::new(Vec::new()),
             runtime_cursors: Mutex::new(BTreeMap::new()),
             subscriptions: Mutex::new(Vec::new()),
+            room_directory: Mutex::new(std::collections::BTreeMap::new()),
             mesh_identities: Mutex::new(BTreeMap::new()),
             beacons: Mutex::new(BTreeMap::new()),
             refresh_locks: Mutex::new(BTreeMap::new()),
@@ -176,6 +178,27 @@ impl EventStore for InMemoryEventStore {
             .map_err(|_| StoreError::LockPoisoned)?;
         cursors.insert(consumer_id.to_string(), cursor.clone());
         Ok(())
+    }
+
+    async fn claim_room_label(
+        &self,
+        label: &str,
+        candidate: RoomId,
+        _claimed_at_ms: u64,
+    ) -> Result<RoomId, StoreError> {
+        // Held across the read AND the write: the whole point is that
+        // two concurrent claims cannot both mint.
+        let mut directory = self.room_directory.lock().expect("room_directory lock");
+        Ok(*directory.entry(label.to_string()).or_insert(candidate))
+    }
+
+    async fn resolve_room_label(&self, label: &str) -> Result<Option<RoomId>, StoreError> {
+        Ok(self
+            .room_directory
+            .lock()
+            .expect("room_directory lock")
+            .get(label)
+            .copied())
     }
 
     async fn load_subscriptions(&self) -> Result<Vec<StoredSubscription>, StoreError> {

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -188,7 +188,10 @@ impl EventStore for InMemoryEventStore {
     ) -> Result<RoomId, StoreError> {
         // Held across the read AND the write: the whole point is that
         // two concurrent claims cannot both mint.
-        let mut directory = self.room_directory.lock().expect("room_directory lock");
+        let mut directory = self
+            .room_directory
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
         Ok(*directory.entry(label.to_string()).or_insert(candidate))
     }
 
@@ -196,7 +199,7 @@ impl EventStore for InMemoryEventStore {
         Ok(self
             .room_directory
             .lock()
-            .expect("room_directory lock")
+            .map_err(|_| StoreError::LockPoisoned)?
             .get(label)
             .copied())
     }

--- a/crates/airc-store/src/migration/m20260814_000021_create_room_directory.rs
+++ b/crates/airc-store/src/migration/m20260814_000021_create_room_directory.rs
@@ -1,0 +1,57 @@
+//! The room directory — the account's `label → RoomId` index.
+//!
+//! Room ids are MINTED, never derived from a name, so two scopes on one
+//! account that each `airc join general` would otherwise mint two rooms
+//! and never see each other. This table is where they meet: the first
+//! scope to use a label claims it with the id it minted, and every later
+//! scope reads that id back and JOINS it.
+//!
+//! It is a discovery index, not an identity: the label is the key here
+//! and NOWHERE else, the id it maps to is the room's only address, and a
+//! room that never went through a label (dispatched into, handed over by
+//! a peer) is simply absent from this table and perfectly addressable.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(RoomDirectory::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(RoomDirectory::Label)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(RoomDirectory::RoomId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(RoomDirectory::ClaimedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(RoomDirectory::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum RoomDirectory {
+    Table,
+    Label,
+    RoomId,
+    ClaimedAtMs,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -30,6 +30,7 @@ mod m20260614_000017_add_peer_trust_last_seen;
 mod m20260629_000018_create_scoped_state;
 mod m20260723_000019_add_peer_trust_endpoints_stamp;
 mod m20260723_000020_add_peer_trust_endpoints_peer;
+mod m20260814_000021_create_room_directory;
 
 pub struct Migrator;
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260629_000018_create_scoped_state::Migration),
             Box::new(m20260723_000019_add_peer_trust_endpoints_stamp::Migration),
             Box::new(m20260723_000020_add_peer_trust_endpoints_peer::Migration),
+            Box::new(m20260814_000021_create_room_directory::Migration),
         ]
     }
 }

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -31,6 +31,7 @@ use airc_core::{
 
 use crate::account_registry::{StoredAccountRegistry, StoredAccountRegistryGistSentinel};
 use crate::beacon::StoredBeacon;
+use crate::entities::room_directory;
 use crate::entities::{
     account_registry, beacon, beacon_channel, event, local_identity, mesh_identity,
     peer_rotation_audit, peer_trust, refresh_lock, runtime_cursor, scoped_state, subscription,
@@ -42,7 +43,6 @@ use crate::peer_trust::{RotationAuditEntry, StoredPeer, TrustTier};
 use crate::refresh_lock::StoredRefreshLockOutcome;
 use crate::scoped_state::StoredScopedState;
 use crate::store::EventStore;
-use crate::entities::room_directory;
 use crate::subscriptions::StoredSubscription;
 
 /// Deadlock backstop for the single-connection pool — NOT a load limit.

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -42,6 +42,7 @@ use crate::peer_trust::{RotationAuditEntry, StoredPeer, TrustTier};
 use crate::refresh_lock::StoredRefreshLockOutcome;
 use crate::scoped_state::StoredScopedState;
 use crate::store::EventStore;
+use crate::entities::room_directory;
 use crate::subscriptions::StoredSubscription;
 
 /// Deadlock backstop for the single-connection pool — NOT a load limit.
@@ -1160,6 +1161,54 @@ impl EventStore for SqliteEventStore {
             .exec(&self.db)
             .await?;
         Ok(())
+    }
+
+    async fn claim_room_label(
+        &self,
+        label: &str,
+        candidate: RoomId,
+        claimed_at_ms: u64,
+    ) -> Result<RoomId, StoreError> {
+        // INSERT-then-read inside ONE transaction. A plain
+        // read-then-insert would let two tabs both see "absent" and
+        // both mint, which is exactly the split this table exists to
+        // prevent; `on_conflict … do_nothing` makes the loser's write
+        // a no-op and the SELECT hands it the winner's id.
+        let txn = self.db.begin().await?;
+        let active = room_directory::ActiveModel {
+            label: ActiveValue::Set(label.to_string()),
+            room_id: ActiveValue::Set(candidate.as_uuid()),
+            claimed_at_ms: ActiveValue::Set(u64_to_i64(
+                "room_directory.claimed_at_ms",
+                claimed_at_ms,
+            )?),
+        };
+        room_directory::Entity::insert(active)
+            .on_conflict(
+                sea_orm::sea_query::OnConflict::column(room_directory::Column::Label)
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .do_nothing()
+            .exec(&txn)
+            .await?;
+        let row = room_directory::Entity::find_by_id(label.to_string())
+            .one(&txn)
+            .await?
+            .ok_or_else(|| {
+                StoreError::InvariantBroken(format!(
+                    "room_directory row for {label:?} vanished inside its own claim transaction"
+                ))
+            })?;
+        txn.commit().await?;
+        Ok(RoomId::from_uuid(row.room_id))
+    }
+
+    async fn resolve_room_label(&self, label: &str) -> Result<Option<RoomId>, StoreError> {
+        Ok(room_directory::Entity::find_by_id(label.to_string())
+            .one(&self.db)
+            .await?
+            .map(|row| RoomId::from_uuid(row.room_id)))
     }
 
     async fn load_subscriptions(&self) -> Result<Vec<StoredSubscription>, StoreError> {

--- a/crates/airc-store/src/store.rs
+++ b/crates/airc-store/src/store.rs
@@ -134,6 +134,29 @@ pub trait EventStore: Send + Sync {
     /// files.
     async fn replace_subscriptions(&self, rows: Vec<StoredSubscription>) -> Result<(), StoreError>;
 
+    /// Claim `label` for `candidate` in the account's room directory,
+    /// returning the id the directory HOLDS — `candidate` if this call
+    /// won the label, the incumbent otherwise.
+    ///
+    /// One atomic call rather than read-then-write on purpose: two tabs
+    /// running `airc join general` at the same instant must land in ONE
+    /// room, and a check-then-insert would let both mint.
+    ///
+    /// This is the only place a room label is a key. It buys DISCOVERY
+    /// (a human types `#general` and reaches the room the account
+    /// already has); it never becomes the room's identity — the id it
+    /// returns is the address, and a room that never passed through a
+    /// label is absent here and addressed by id like any other.
+    async fn claim_room_label(
+        &self,
+        label: &str,
+        candidate: RoomId,
+        claimed_at_ms: u64,
+    ) -> Result<RoomId, StoreError>;
+
+    /// The id `label` resolves to, if the account has ever claimed it.
+    async fn resolve_room_label(&self, label: &str) -> Result<Option<RoomId>, StoreError>;
+
     /// Load the cached mesh identity row for `scope`, if present.
     async fn load_mesh_identity(
         &self,

--- a/crates/airc-trust/src/lib.rs
+++ b/crates/airc-trust/src/lib.rs
@@ -162,7 +162,8 @@ impl From<StoreError> for PeersStoreError {
             },
             StoreError::WrongPubkeyLength(got) => PeersStoreError::WrongPubkeyLength(got),
             StoreError::Base64(error) => PeersStoreError::Base64(error),
-            StoreError::Io(_)
+            StoreError::InvariantBroken(_)
+            | StoreError::Io(_)
             | StoreError::Database(_)
             | StoreError::LockPoisoned
             | StoreError::Migration(_)

--- a/crates/examples/persona_spawn_smoke/src/main.rs
+++ b/crates/examples/persona_spawn_smoke/src/main.rs
@@ -29,7 +29,7 @@ const TURN_WAIT: Duration = Duration::from_secs(30);
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> Result<(), Box<dyn Error>> {
     let config = PersonaAgentConfig::from_env()?;
-    let room = config.room.clone();
+    let room_id = config.room_id;
     let parent_lan_addr = config.parent_lan_addr;
 
     let mut agent = PersonaAgent::spawn(config).await?;
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!(
         "persona-ready persona_id={} room={} parent={}",
         agent.capabilities().persona_id,
-        room,
+        room_id,
         agent.parent_peer_id(),
     );
 

--- a/crates/examples/persona_spawn_smoke/src/persona_agent.rs
+++ b/crates/examples/persona_spawn_smoke/src/persona_agent.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
 
-use airc_core::{Identity, PeerId, PersonaCapabilities, PersonaCapabilitiesError};
+use airc_core::{Identity, PeerId, PersonaCapabilities, PersonaCapabilitiesError, RoomId};
 use airc_lib::{Airc, AircError, FilteredEventStream, PeerSpec};
 use airc_trust::{PeersStoreError, TrustTier};
 use consumer_shapes::continuum::{
@@ -29,8 +29,10 @@ pub const ENV_AIRC_HOME: &str = "AIRC_HOME";
 /// The parent's `peer_id:pubkey` spec (the `Airc::peer_spec` string).
 /// REQUIRED — the spawn relationship is the trust bootstrap.
 pub const ENV_PARENT_PEER_SPEC: &str = "AIRC_PARENT_PEER_SPEC";
-/// Room the persona serves turns in. Optional; defaults to
-/// [`DEFAULT_PERSONA_ROOM`].
+/// The ROOM ID (a uuid) the persona serves turns in, as the parent
+/// that spawned it knows the room. REQUIRED, and with no default —
+/// a child cannot guess which room its parent is in, and a name here
+/// would resolve inside the CHILD's own account to a different room.
 pub const ENV_PERSONA_ROOM: &str = "AIRC_PERSONA_ROOM";
 /// Optional loopback/LAN address of the parent's listener. When set,
 /// the binary dials it after spawn so turn traffic has a route
@@ -39,7 +41,13 @@ pub const ENV_PARENT_LAN_ADDR: &str = "AIRC_PARENT_LAN_ADDR";
 /// Optional persona id override for the capability advert.
 pub const ENV_PERSONA_ID: &str = "AIRC_PERSONA_ID";
 
-pub const DEFAULT_PERSONA_ROOM: &str = "persona-smoke";
+/// This scope's own display word for the room it was spawned into.
+///
+/// Purely local and purely cosmetic. It is NOT identity and NOT a
+/// default room: the room a persona serves in arrives as a `RoomId`
+/// from the parent that spawned it, and a scope may call that room
+/// whatever it likes without changing which room it is.
+pub const PERSONA_ROOM_LABEL: &str = "parent-room";
 pub const DEFAULT_PERSONA_ID: &str = "persona-smoke-echo";
 
 /// Everything the spawn loop hands a persona process.
@@ -49,8 +57,15 @@ pub struct PersonaAgentConfig {
     pub home: PathBuf,
     /// Parent's `peer_id:pubkey` spec string.
     pub parent_spec: String,
-    /// Room to join and serve turns in.
-    pub room: String,
+    /// The room to serve turns in, BY ID.
+    ///
+    /// A spawned persona opens its own home, which is its own account
+    /// — and a room label keys a room only within ONE account. So a
+    /// name here would put parent and child in two different rooms
+    /// wearing the same word, and every turn the parent requested
+    /// would be delivered to a room the child is not in. The parent
+    /// already holds the id; spawn is the rendezvous, so it passes it.
+    pub room_id: RoomId,
     /// What this persona advertises on its identity card.
     pub capabilities: PersonaCapabilities,
     /// Parent LAN listener to dial after spawn, when the route isn't
@@ -65,7 +80,19 @@ impl PersonaAgentConfig {
     pub fn from_env() -> Result<Self, PersonaAgentError> {
         let home = require_env(ENV_AIRC_HOME)?;
         let parent_spec = require_env(ENV_PARENT_PEER_SPEC)?;
-        let room = optional_env(ENV_PERSONA_ROOM).unwrap_or_else(|| DEFAULT_PERSONA_ROOM.into());
+        // REQUIRED, and with no default — deliberately. A default room
+        // name was the bug in constant form: it let a child that was
+        // told nothing invent a room, land somewhere its parent isn't,
+        // and wait forever for turns that were delivered elsewhere.
+        // A persona that was not told which room to serve cannot guess.
+        let room_raw = require_env(ENV_PERSONA_ROOM)?;
+        let room_id = room_raw
+            .parse::<RoomId>()
+            .map_err(|source| PersonaAgentError::BadEnv {
+                name: ENV_PERSONA_ROOM,
+                raw: room_raw.clone(),
+                detail: format!("expected the parent's room id (a uuid): {source}"),
+            })?;
         let persona_id = optional_env(ENV_PERSONA_ID).unwrap_or_else(|| DEFAULT_PERSONA_ID.into());
         let parent_lan_addr = match optional_env(ENV_PARENT_LAN_ADDR) {
             Some(raw) => Some(raw.parse().map_err(|source| PersonaAgentError::BadEnv {
@@ -78,7 +105,7 @@ impl PersonaAgentConfig {
         Ok(Self {
             home: PathBuf::from(home),
             parent_spec,
-            room,
+            room_id,
             capabilities: PersonaCapabilities {
                 persona_id,
                 capability_tags: vec!["echo".to_string(), "smoke".to_string()],
@@ -263,7 +290,10 @@ impl PersonaAgent {
             return Err(PersonaAgentError::ParentNotEnrolled { parent });
         }
 
-        airc.join(&config.room).await?;
+        // BY ID — the parent's room, not a room of the same name in
+        // this child's own account. The label is local decoration.
+        airc.join_room_id(config.room_id, PERSONA_ROOM_LABEL)
+            .await?;
         let inbox = airc.subscribe_filtered(any_persona_event_filter()).await?;
 
         Ok(Self {

--- a/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
+++ b/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
@@ -41,7 +41,6 @@ fn smoke_capabilities() -> PersonaCapabilities {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn parent_requests_turn_and_spawned_persona_replies() {
-    let room = "persona-smoke";
     let parent_tmp = TempDir::new().expect("parent tempdir");
     let persona_tmp = TempDir::new().expect("persona tempdir");
 
@@ -50,7 +49,13 @@ async fn parent_requests_turn_and_spawned_persona_replies() {
     let parent = Airc::open(parent_tmp.path().join(".airc"))
         .await
         .expect("parent open");
-    parent.join(room).await.expect("parent joins room");
+    // The parent's account mints the room; its ID is what the child
+    // is handed. A NAME here would put them in two different rooms —
+    // the persona opens its own home, so it is its own account.
+    let room = parent
+        .join("persona-smoke")
+        .await
+        .expect("parent joins room");
     let parent_addr: SocketAddr = parent
         .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await
@@ -61,7 +66,7 @@ async fn parent_requests_turn_and_spawned_persona_replies() {
     let config = PersonaAgentConfig {
         home: persona_tmp.path().join(".airc"),
         parent_spec: parent.peer_spec(),
-        room: room.to_string(),
+        room_id: room.channel,
         capabilities: smoke_capabilities(),
         parent_lan_addr: Some(parent_addr),
     };


### PR DESCRIPTION
## What

Room names are labels. Only the id addresses a room. This branch removes
every place that treated a name — or a rendering of an id — as identity,
and adds the verb that was missing so callers can say what they mean.

## The five commits

1. `8ed9f30` fmt + reunite a doc comment with its function (self-inflicted in `490dc76`, attributed in the message)
2. `4c5d262` kill prefix-matching on rendered uuids, the `Ambiguous` variant, and `format!("{name} ({id})")` error payloads; `InviteBeacon.rooms: Vec<RoomId>`; constructors 4→2
3. `2c91a3f` stop cloning N subscriptions to answer what the `Copy` ids already answer; add `SubscriptionSet::get`
4. `9a6b464` `into_all()` — move out of a dying set instead of cloning it
5. `46dc5d9` **`Airc::join_room_id(room_id, label)`** — the rendezvous verb, plus the test cleanup it unblocked

## Why the last one was needed

Ten tests across four files went red, and the cause was this branch's own
thesis pointed back at it: two scopes each called `join("name")` and got two
DIFFERENT rooms wearing the same word. A label keys a room only within one
account, so across two homes it keys nothing — every frame came back
`Undeliverable { UnknownChannel }`.

There was no API for "join the room whose id I already hold". So the tests
said it in labels, and the substrate could not hear them.

Both join paths now funnel through one `commit_join` (save → re-beacon
presence → emit `RoomJoined` → publish identity card), so a by-id join is
observable on exactly the same terms as a by-label one.

## Test-side compression

One `same_room(label, &[&scopes])` in `tests/common` — beside `trust`, its
peer-pairing sibling — replaces nine hand-rolled joins. The duplication WAS
the bug: each site was individually plausible and collectively wrong.

Also deleted `SubscriptionSet::join_with_wire_root`: byte-identical to `join`
after the constructor collapse, zero production callers, and its doc pointed
at a method this branch removed. Its test was real and now covers `join`.

Two stale comments went with it — "same-machine mesh identity resolution makes
the derived RoomId identical" and "both joined to the SAME room name". Both
describe the derivation this branch deletes; leaving them would teach the next
reader the thing that just broke ten tests.

## Verification

- `cargo test -p airc-lib` — 343 lib + all 36 integration suites green, 0 failures
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all` — clean; pre-push gate passed with no skip

## Known gap

`InviteBeacon.rooms` has no direct test yet. The field is carried and typed;
the rendezvous path that consumes it is what `join_room_id` now makes
expressible, and wiring a beacon-driven join test is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo