### PR TITLE
feat(lib): router-side delivery-class filter on multi-room subscribe (the unused-fields perf fix)

### DIFF
--- a/crates/airc-core/src/headers.rs
+++ b/crates/airc-core/src/headers.rs
@@ -93,6 +93,24 @@ pub enum HeaderFilter {
     },
     All(Vec<HeaderFilter>),
     AnyOf(Vec<HeaderFilter>),
+    /// Matches when `key` is present, whatever its value. The
+    /// presence check `Prefix { key, value_prefix: "" }` also
+    /// expresses is intentionally NOT the idiom — an empty-prefix
+    /// match reads as an accident at the call site; `Has` reads as
+    /// the decision it is.
+    Has {
+        key: String,
+    },
+    /// Inverts the inner predicate. This is the exclusion half the
+    /// combinator set was missing: a consumer that wants "every
+    /// event EXCEPT the `airc.heartbeat.*`-stamped liveness beacons"
+    /// (continuum #445 — measured 149 of 177 inbound events on a
+    /// persona subscription were heartbeats, all discarded
+    /// post-decode) writes `Not(Has { key })` and the router drops
+    /// them BEFORE fan-out. Without `Not`, allowlists were the only
+    /// shape, and an allowlist over headers no publisher stamps yet
+    /// matches nothing.
+    Not(Box<HeaderFilter>),
 }
 
 impl HeaderFilter {
@@ -109,6 +127,8 @@ impl HeaderFilter {
                 .is_some_and(|value| value.starts_with(value_prefix)),
             HeaderFilter::All(filters) => filters.iter().all(|filter| filter.matches(headers)),
             HeaderFilter::AnyOf(filters) => filters.iter().any(|filter| filter.matches(headers)),
+            HeaderFilter::Has { key } => headers.get(key).is_some(),
+            HeaderFilter::Not(inner) => !inner.matches(headers),
         }
     }
 
@@ -134,6 +154,8 @@ impl HeaderFilter {
                 .is_some_and(|value| value.starts_with(value_prefix.as_str())),
             HeaderFilter::All(filters) => filters.iter().all(|filter| filter.matches_view(view)),
             HeaderFilter::AnyOf(filters) => filters.iter().any(|filter| filter.matches_view(view)),
+            HeaderFilter::Has { key } => view.get(key).is_some(),
+            HeaderFilter::Not(inner) => !inner.matches_view(view),
         }
     }
 }
@@ -377,6 +399,16 @@ mod tests {
                     value: "video-room".to_string(),
                 },
             ]),
+            HeaderFilter::Has {
+                key: "continuum.widget".to_string(),
+            },
+            HeaderFilter::Has {
+                key: "missing.key".to_string(),
+            },
+            HeaderFilter::Not(Box::new(HeaderFilter::Has {
+                key: "continuum.widget".to_string(),
+            })),
+            HeaderFilter::Not(Box::new(HeaderFilter::Any)),
         ];
         for filter in &cases {
             assert_eq!(
@@ -385,6 +417,34 @@ mod tests {
                 "matches/matches_view divergence for {filter:?}"
             );
         }
+    }
+
+    #[test]
+    fn not_has_excludes_stamped_events_and_round_trips_the_wire() {
+        // what this catches: the continuum #445 exclusion shape — a
+        // persona subscription that wants room content but not the
+        // 60s liveness beacons every peer emits. Heartbeats already
+        // stamp `airc.heartbeat.kind`; `Not(Has)` is the first
+        // filter that can act on that stamp as an exclusion. The
+        // serde round-trip half pins the wire encoding: this enum
+        // crosses the IPC boundary inside AttachRequest, so a
+        // variant that (de)serializes asymmetrically would filter
+        // correctly in-process and silently mis-filter daemon-side.
+        let beacon = Headers::from([("airc.heartbeat.kind".to_string(), "alive".to_string())]);
+        let chat = Headers::from([("continuum.schema".to_string(), "chat".to_string())]);
+        let exclude_beacons = HeaderFilter::Not(Box::new(HeaderFilter::Has {
+            key: "airc.heartbeat.kind".to_string(),
+        }));
+        assert!(!exclude_beacons.matches(&beacon), "beacon must be excluded");
+        assert!(exclude_beacons.matches(&chat), "chat must pass");
+        assert!(
+            exclude_beacons.matches(&Headers::new()),
+            "unstamped events pass an exclusion filter — exclusion is never an allowlist"
+        );
+
+        let encoded = serde_json::to_string(&exclude_beacons).expect("encode");
+        let decoded: HeaderFilter = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, exclude_beacons, "wire round-trip must be identity");
     }
 
     /// Large-scale fixture: 50 headers (dense), modelling a busy room

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -512,9 +512,23 @@ impl Airc {
     /// owned by the stream (aborted on drop). Each attach is registered
     /// at the live edge before we move on (subscribe-before-ack on the
     /// daemon side), so no early event is missed.
+    ///
+    /// `delivery`: optional ROUTER-SIDE delivery-class filter, applied on
+    /// every attach (initial AND every reconnect). `None` keeps the
+    /// historical behaviour — every class is delivered. This is the seam
+    /// [`AttachRequest`] built for and nobody used: without it, a consumer
+    /// that only wants settled room lines receives every peer's
+    /// StreamChunks and ephemeral fan-out and pays a decode per event to
+    /// discard them. Measured on a continuum node 2026-08-15: 6,736
+    /// events crossed to EVERY persona subscription in 40 minutes and
+    /// 100% were discarded post-decode; an earlier solve measured 55% of
+    /// inbound as stream chunks decoded identically by four minds. Filter
+    /// at the router; the socket never carries what the consumer will
+    /// throw away.
     pub(crate) async fn daemon_subscribe(
         &self,
         channels: Vec<RoomId>,
+        delivery: Option<Vec<IpcDelivery>>,
     ) -> Result<EventStream, AircError> {
         // Own the client so each reader task can re-attach after a daemon
         // restart (the borrow from `require_daemon_client` can't outlive
@@ -534,8 +548,12 @@ impl Airc {
             // stream starts at the live edge. Catch-up is a separate,
             // bounded concern (`resume_from_subscribed_filtered` with a
             // stored cursor — see `join_feed`).
+            let mut request = AttachRequest::live(channel);
+            if let Some(classes) = delivery.clone() {
+                request = request.with_delivery(classes);
+            }
             let mut stream = client
-                .attach(AttachRequest::live(channel))
+                .attach(request)
                 .await
                 .map_err(|e| AircError::Route(format!("daemon attach: {e}")))?;
             match read_frame::<_, Response>(&mut stream).await {
@@ -550,6 +568,10 @@ impl Airc {
             }
             let tx = tx.clone();
             let client = client.clone();
+            // Per-task copy of the delivery filter: each channel's reader
+            // task re-applies it on every reconnect (see below), and the
+            // loop must keep its own copy for the remaining channels.
+            let delivery = delivery.clone();
             handles.push(tokio::spawn(async move {
                 // Drain the live stream; when it drops (daemon restart /
                 // transient loss) re-attach and RESUME strictly after the
@@ -631,10 +653,16 @@ impl Airc {
                             Some(cursor) => AttachStart::After(cursor),
                             None => AttachStart::Live,
                         };
-                        let mut s = match client
-                            .attach(AttachRequest::new(channel, start))
-                            .await
-                        {
+                        // The reconnect attach carries the SAME delivery
+                        // filter as the initial one — a filter that
+                        // silently vanished on the first daemon restart
+                        // would re-open the fan-out flood and no reader
+                        // could tell why the socket got loud again.
+                        let mut request = AttachRequest::new(channel, start);
+                        if let Some(classes) = delivery.clone() {
+                            request = request.with_delivery(classes);
+                        }
+                        let mut s = match client.attach(request).await {
                             Ok(s) => s,
                             Err(error) => {
                                 // Card 807193ab: silent `continue` left

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -529,6 +529,7 @@ impl Airc {
         &self,
         channels: Vec<RoomId>,
         delivery: Option<Vec<IpcDelivery>>,
+        headers: airc_core::HeaderFilter,
     ) -> Result<EventStream, AircError> {
         // Own the client so each reader task can re-attach after a daemon
         // restart (the borrow from `require_daemon_client` can't outlive
@@ -552,6 +553,7 @@ impl Airc {
             if let Some(classes) = delivery.clone() {
                 request = request.with_delivery(classes);
             }
+            request = request.with_headers(headers.clone());
             let mut stream = client
                 .attach(request)
                 .await
@@ -568,10 +570,12 @@ impl Airc {
             }
             let tx = tx.clone();
             let client = client.clone();
-            // Per-task copy of the delivery filter: each channel's reader
-            // task re-applies it on every reconnect (see below), and the
-            // loop must keep its own copy for the remaining channels.
+            // Per-task copy of the delivery + header filters: each
+            // channel's reader task re-applies them on every reconnect
+            // (see below), and the loop must keep its own copy for the
+            // remaining channels.
             let delivery = delivery.clone();
+            let headers = headers.clone();
             handles.push(tokio::spawn(async move {
                 // Drain the live stream; when it drops (daemon restart /
                 // transient loss) re-attach and RESUME strictly after the
@@ -662,6 +666,7 @@ impl Airc {
                         if let Some(classes) = delivery.clone() {
                             request = request.with_delivery(classes);
                         }
+                        request = request.with_headers(headers.clone());
                         let mut s = match client.attach(request).await {
                             Ok(s) => s,
                             Err(error) => {

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -278,7 +278,7 @@ impl Airc {
     pub async fn subscribe(&self) -> Result<EventStream, AircError> {
         let room = self.current_room().await?;
         if self.is_daemon_attached() {
-            return self.daemon_subscribe(vec![room.channel]).await;
+            return self.daemon_subscribe(vec![room.channel], None).await;
         }
         let rx = self.inner.live_tx.subscribe();
         Ok(EventStream::from_broadcast(rx))
@@ -303,6 +303,27 @@ impl Airc {
         &self,
         filter: EventFilter,
     ) -> Result<FilteredEventStream, AircError> {
+        self.subscribe_subscribed_delivery(filter, None).await
+    }
+
+    /// [`Self::subscribe_subscribed_filtered`] with a ROUTER-SIDE
+    /// delivery-class filter: when `delivery` is `Some`, the daemon only
+    /// fans out events of those classes to this subscription — nothing
+    /// else ever crosses the socket. This is the consumer-shaped
+    /// subscription [`airc_ipc::AttachRequest`] always supported and
+    /// clients never used: a mind that perceives settled room lines
+    /// attaches with `[IpcDelivery::Durable]` and stops paying a decode
+    /// per peer StreamChunk / ephemeral fan-out (measured on a continuum
+    /// node 2026-08-15: 6,736 events crossed to every persona in 40
+    /// minutes, 100% discarded post-decode). The `EventFilter` still
+    /// applies client-side on top, and is the ONLY filter on the
+    /// non-daemon (in-process broadcast) fallback, which has no router
+    /// to filter at.
+    pub async fn subscribe_subscribed_delivery(
+        &self,
+        filter: EventFilter,
+        delivery: Option<Vec<airc_ipc::IpcDelivery>>,
+    ) -> Result<FilteredEventStream, AircError> {
         let filter = self.subscribed_event_filter(filter).await?;
         if self.is_daemon_attached() {
             let channels: Vec<airc_core::RoomId> = self
@@ -312,7 +333,7 @@ impl Airc {
                 .map(|sub| sub.as_room().channel)
                 .collect();
             return Ok(FilteredEventStream {
-                inner: self.daemon_subscribe(channels).await?,
+                inner: self.daemon_subscribe(channels, delivery).await?,
                 filter,
             });
         }

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -278,7 +278,9 @@ impl Airc {
     pub async fn subscribe(&self) -> Result<EventStream, AircError> {
         let room = self.current_room().await?;
         if self.is_daemon_attached() {
-            return self.daemon_subscribe(vec![room.channel], None).await;
+            return self
+                .daemon_subscribe(vec![room.channel], None, airc_core::HeaderFilter::Any)
+                .await;
         }
         let rx = self.inner.live_tx.subscribe();
         Ok(EventStream::from_broadcast(rx))
@@ -309,7 +311,12 @@ impl Airc {
     /// [`Self::subscribe_subscribed_filtered`] with a ROUTER-SIDE
     /// delivery-class filter: when `delivery` is `Some`, the daemon only
     /// fans out events of those classes to this subscription — nothing
-    /// else ever crosses the socket. This is the consumer-shaped
+    /// else ever crosses the socket. The caller's
+    /// `filter.headers_filter` also rides the attach, so header
+    /// predicates (including `HeaderFilter::Not` exclusions — e.g.
+    /// dropping `airc.heartbeat.*`-stamped liveness beacons) are
+    /// enforced BEFORE fan-out too, not just client-side after a
+    /// decode the consumer paid for. This is the consumer-shaped
     /// subscription [`airc_ipc::AttachRequest`] always supported and
     /// clients never used: a mind that perceives settled room lines
     /// attaches with `[IpcDelivery::Durable]` and stops paying a decode
@@ -333,7 +340,9 @@ impl Airc {
                 .map(|sub| sub.as_room().channel)
                 .collect();
             return Ok(FilteredEventStream {
-                inner: self.daemon_subscribe(channels, delivery).await?,
+                inner: self
+                    .daemon_subscribe(channels, delivery, filter.headers_filter.clone())
+                    .await?,
                 filter,
             });
         }


### PR DESCRIPTION
The filters existed in AttachRequest and the daemon router all along — the lib surface never exposed them on the multi-room subscribe, so every consumer attached unfiltered. Full measurements in the commit message. Backward compatible: existing callers unchanged (delegate with None); filter re-applied on every reconnect. First consumer is continuum's persona turn stream (Durable-only), which kills the decode-per-spam-event flood at the router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo