### PR TITLE
feat(work): room-scoped card state change (change_work_card_state_in) — WRITE half of the #345 class

### DIFF
--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -507,20 +507,37 @@ impl Airc {
 
     /// Change a work card's lifecycle state through the work event
     /// stream. This is the queue hygiene path agents use to stop
-    /// completed work from remaining claimable.
+    /// completed work from remaining claimable. Current-room projection
+    /// of [`Airc::change_work_card_state_in`].
     pub async fn change_work_card_state(
         &self,
         request: ChangeWorkCardState,
     ) -> Result<(), AircError> {
-        self.ensure_work_card_in_current_room(request.card_id)
-            .await?;
+        let room = self.current_room().await?;
+        self.change_work_card_state_in(&room, request).await
+    }
+
+    /// Change a work card's lifecycle state in a SPECIFIC room, without
+    /// touching this scope's current-room pointer — the mutate sibling of
+    /// [`Airc::work_board_in`]. The reads grew room-scoped variants while
+    /// every mutate stayed pinned to `current_room()`, which made
+    /// multi-room supervisors (a grader sweeping lapsed bench cards across
+    /// per-run rooms) structurally unable to act on any board but the one
+    /// their author happened to be standing in. The guard is unchanged in
+    /// strength: the card must be on THIS room's board.
+    pub async fn change_work_card_state_in(
+        &self,
+        room: &Room,
+        request: ChangeWorkCardState,
+    ) -> Result<(), AircError> {
+        self.ensure_work_card_in_room(room, request.card_id).await?;
         let event = WorkEvent::CardStateChanged(CardStateChanged {
             card_id: request.card_id,
             state: request.state,
             changed_by: self.peer_id(),
             changed_at_ms: now_ms()?,
         });
-        self.publish_work_event(&event).await?;
+        self.publish_work_event_in(room, &event).await?;
         Ok(())
     }
 
@@ -1154,10 +1171,41 @@ impl Airc {
         self.send_frame(FrameKind::Event, body, headers).await
     }
 
+    /// Room-targeted sibling of [`Airc::publish_work_event`]: the event
+    /// frame is addressed to `room`'s channel, not the current room's, so
+    /// board mutations land where the card actually lives.
+    async fn publish_work_event_in(
+        &self,
+        room: &Room,
+        event: &WorkEvent,
+    ) -> Result<EventId, AircError> {
+        let (headers, body) = encode_work_event(event)?;
+        self.send_frame_to_room(
+            FrameKind::Event,
+            crate::MentionTarget::All,
+            body,
+            headers,
+            room,
+        )
+        .await
+        .map(|receipt| receipt.event_id)
+    }
+
     async fn ensure_work_card_in_current_room(&self, card_id: WorkCardId) -> Result<(), AircError> {
         let room = self.current_room().await?;
+        self.ensure_work_card_in_room(&room, card_id).await
+    }
+
+    /// The one mutation guard, room-parameterized: a card may only be
+    /// mutated against a board it is actually on. `..._in_current_room`
+    /// is its current-room projection.
+    async fn ensure_work_card_in_room(
+        &self,
+        room: &Room,
+        card_id: WorkCardId,
+    ) -> Result<(), AircError> {
         let board = self
-            .project_room_work_board(&room, WORK_MUTATION_PAGE_SIZE)
+            .project_room_work_board(room, WORK_MUTATION_PAGE_SIZE)
             .await?;
         if board.card(card_id).is_some() {
             return Ok(());
@@ -1165,7 +1213,7 @@ impl Airc {
 
         Err(AircError::WorkCardNotInCurrentRoom {
             card_id,
-            room_name: room.name,
+            room_name: room.name.clone(),
             room_id: room.channel,
         })
     }

--- a/crates/airc-lib/tests/work_board_room_scoped.rs
+++ b/crates/airc-lib/tests/work_board_room_scoped.rs
@@ -125,3 +125,97 @@ async fn resolving_an_unsubscribed_room_refuses_loudly_instead_of_falling_back()
         "refusal must name the remedy, got: {rendered}"
     );
 }
+
+#[tokio::test]
+async fn a_state_change_for_a_named_room_lands_on_that_rooms_card() {
+    // What this catches: the WRITE half of the #345 class. Reads grew
+    // `work_board_in` while every mutate stayed pinned to `current_room()`,
+    // so a multi-room supervisor (continuum's bench-grade sweeper, first live
+    // tick 2026-08-15) had 21 auto-closes refused in one pass — every target
+    // card lived in a room its author wasn't standing in. The guard must keep
+    // its strength (card must be ON the named room's board) while the room
+    // becomes a parameter instead of ambient state.
+    let machine = Machine::boot().await;
+    let alice = machine.attach("alice").await;
+
+    let other = alice
+        .join("other-room")
+        .await
+        .expect("alice joins other-room");
+    create_card(&alice, "OTHER-ROOM CARD").await;
+    let other_card = alice
+        .work_board()
+        .await
+        .expect("other board")
+        .snapshot()
+        .cards[0]
+        .card_id;
+
+    let home = alice
+        .join("home-room")
+        .await
+        .expect("alice joins home-room");
+    create_card(&alice, "HOME-ROOM CARD").await;
+
+    // Current-room mutate of an out-of-room card still refuses — the guard
+    // keeps its strength.
+    alice
+        .change_work_card_state(airc_lib::ChangeWorkCardState {
+            card_id: other_card,
+            state: airc_lib::CardState::Closed,
+        })
+        .await
+        .expect_err("mutating a card outside the current room must refuse");
+
+    // Room-scoped mutate closes the card WHERE IT LIVES, without moving the
+    // current-room pointer.
+    alice
+        .change_work_card_state_in(
+            &other,
+            airc_lib::ChangeWorkCardState {
+                card_id: other_card,
+                state: airc_lib::CardState::Closed,
+            },
+        )
+        .await
+        .expect("room-scoped state change");
+    let closed = alice
+        .work_board_in(&other)
+        .await
+        .expect("re-read other board")
+        .snapshot()
+        .cards
+        .into_iter()
+        .find(|c| c.card_id == other_card)
+        .expect("card still on the board");
+    assert_eq!(
+        closed.state,
+        airc_lib::CardState::Closed,
+        "BUG: the room-scoped state change did not land on the named room's card"
+    );
+
+    // And the guard is room-parameterized, not gone: a card NOT in the named
+    // room refuses with the same error class.
+    let home_card = alice
+        .work_board()
+        .await
+        .expect("home board")
+        .snapshot()
+        .cards[0]
+        .card_id;
+    alice
+        .change_work_card_state_in(
+            &other,
+            airc_lib::ChangeWorkCardState {
+                card_id: home_card,
+                state: airc_lib::CardState::Closed,
+            },
+        )
+        .await
+        .expect_err("a card not on the NAMED room's board must refuse");
+    let current = alice.current_room().await.expect("current room");
+    assert_eq!(
+        current.channel, home.channel,
+        "BUG: a room-scoped mutate moved the default-room pointer"
+    );
+}


### PR DESCRIPTION
Reads grew `work_board_in` while every mutate stayed pinned to `current_room()`. Live consequence (continuum, 2026-08-15): the bench-grade sweeper's first tick had **21 auto-closes refused in one pass** — every target card lived in a room its author wasn't standing in, error: *"work card X is not in current room …; switch to the card's room before mutating it"*.

**Change:** `change_work_card_state_in(room, req)` — the mutate sibling of `work_board_in`. Guard keeps full strength: card must be on the **named** room's board (`ensure_work_card_in_room`, with the current-room check as its projection). Event frame addressed to the named room's channel via `publish_work_event_in` over the existing `send_frame_to_room` primitive. Current-room verb becomes a thin wrapper — one implementation, one guard.

**Tests:** `work_board_room_scoped` gains the write-side case: current-room mutate of an out-of-room card still refuses; scoped mutate lands on the named room's card without moving the pointer; a card not on the NAMED room's board refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo