### PR TITLE
feat(lib): reply_in — replies ride the REQUEST's channel, not the responder's current room

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -2337,6 +2337,10 @@ fn relay_bind_candidates(persisted: Option<u16>) -> Vec<u16> {
 /// Self-elect as a relay on a RESTART-STABLE port (#267). Tries the
 /// persisted previous port, falls back to OS-assigned, and persists
 /// whatever actually bound so the next incarnation lands on it again.
+// AircError is >=128B (clippy 1.98 result_large_err); this is a cold
+// startup path, not a hot loop — scoped allow until AircError's large
+// variants are boxed library-wide.
+#[allow(clippy::result_large_err)]
 async fn become_relay_with_stable_port(
     airc: &Airc,
     lan_ip: Option<std::net::Ipv4Addr>,

--- a/crates/airc-cli/src/knock_commands.rs
+++ b/crates/airc-cli/src/knock_commands.rs
@@ -142,7 +142,7 @@ fn hex_decode(name: &str, value: &str) -> Result<Vec<u8>, Box<dyn Error>> {
         return Err(format!("{name}: hex input has odd length").into());
     }
     let mut out = Vec::with_capacity(value.len() / 2);
-    for pair in value.as_bytes().chunks_exact(2) {
+    for pair in value.as_bytes().as_chunks::<2>().0 {
         let high = hex_nibble(pair[0]).ok_or_else(|| format!("{name}: not valid hex"))?;
         let low = hex_nibble(pair[1]).ok_or_else(|| format!("{name}: not valid hex"))?;
         out.push((high << 4) | low);

--- a/crates/airc-core/src/humanhash.rs
+++ b/crates/airc-core/src/humanhash.rs
@@ -323,7 +323,9 @@ pub fn humanhash(hex_input: &str, word_count: usize) -> Result<String, Humanhash
 fn decode_hex(input: &str) -> Result<Vec<u8>, HumanhashError> {
     input
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let high = hex_value(pair[0])?;
             let low = hex_value(pair[1])?;

--- a/crates/airc-lib/src/command_bus.rs
+++ b/crates/airc-lib/src/command_bus.rs
@@ -221,9 +221,53 @@ impl Airc {
         })
     }
 
+    /// Reply to an in-flight request INTO THE CHANNEL THE REQUEST ARRIVED ON.
+    ///
+    /// [`reply`](Self::reply) sends via the responder's CURRENT room — correct
+    /// only when both sides happen to share it. Two scopes on one machine can
+    /// be parked in different rooms (an operator CLI in `#general`, citizens
+    /// landed in `#academy`): the request crosses (responders subscribe every
+    /// room) but the answer leaves through the responder's room and the
+    /// requester — awaiting on the channel it asked in — never sees it. Every
+    /// dispatch then dies at the command deadline (2026-08-27 grid-smoke 0/3).
+    ///
+    /// `channel` is the request event's `room_id`, adopted verbatim;
+    /// `channel_name` is the request's stamped
+    /// [`airc_protocol::HEADER_AIRC_CHANNEL_NAME`] (for the blind-room heal
+    /// header on the reply), if present.
+    pub async fn reply_in(
+        &self,
+        channel: airc_core::RoomId,
+        channel_name: Option<&str>,
+        reply_to: PeerId,
+        correlation_id: Uuid,
+        mut headers: Headers,
+        body: Body,
+    ) -> Result<(), AircError> {
+        headers.insert(
+            HEADER_AIRC_CORRELATION_ID.into(),
+            correlation_id.to_string(),
+        );
+        headers.insert(HEADER_AIRC_REPLY_TO.into(), reply_to.to_string());
+        let room = crate::Room::at_channel(self.home(), channel_name.unwrap_or(""), channel)?;
+        self.send_frame_to_room(
+            airc_protocol::FrameKind::Message,
+            MentionTarget::Peer(reply_to),
+            body,
+            headers,
+            &room,
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Reply to an in-flight request. `reply_to` is the
     /// `airc.reply_to` value read off the request event;
     /// `correlation_id` is the request's `airc.correlation_id`.
+    ///
+    /// Sends via the responder's CURRENT room — prefer
+    /// [`reply_in`](Self::reply_in) with the request's own channel when the
+    /// requester may live in a different room than this scope.
     pub async fn reply(
         &self,
         reply_to: PeerId,

--- a/crates/airc-lib/src/room.rs
+++ b/crates/airc-lib/src/room.rs
@@ -92,6 +92,22 @@ impl Room {
         Self::from_name(home, DEFAULT_ROOM_NAME)
     }
 
+    /// A `Room` handle for a channel we did NOT derive ourselves — the
+    /// channel is adopted verbatim instead of re-derived from `name`.
+    ///
+    /// This exists for replying into the channel a REQUEST arrived on.
+    /// Identity-scoped channel derivation can diverge between machines
+    /// (the M5↔bigmama blind-room bug), and two scopes on one machine
+    /// can be parked in different rooms — a responder that answers into
+    /// its own current room talks past a requester listening where it
+    /// asked. The request event's `room_id` is the one channel both
+    /// sides provably share; use it as-is.
+    pub fn at_channel(home: &Path, name: &str, channel: RoomId) -> Result<Self, RoomError> {
+        let mut room = Self::from_name(home, name)?;
+        room.channel = channel;
+        Ok(room)
+    }
+
     /// Stamp this room's human NAME onto outbound headers
     /// ([`airc_protocol::HEADER_AIRC_CHANNEL_NAME`]) — the convergence
     /// key that lets a receiving machine whose identity-scoped channel

--- a/crates/airc-lib/src/room/tests.rs
+++ b/crates/airc-lib/src/room/tests.rs
@@ -25,3 +25,23 @@ fn sanitise_replaces_path_separators() {
     assert_eq!(sanitise_name("../etc/passwd"), "---etc-passwd");
     assert_eq!(sanitise_name("normal-name_42"), "normal-name_42");
 }
+
+#[test]
+fn at_channel_adopts_the_given_channel_verbatim() {
+    // what this catches: a reply built for the REQUEST's channel must ride
+    // that exact channel — re-deriving from the name (which can diverge per
+    // identity scope, or be absent) re-creates the blind-room miss that made
+    // every cross-scope command dispatch die at the deadline (2026-08-27).
+    let home = TempDir::new().unwrap();
+    let foreign = RoomId::from_uuid(Uuid::new_v4());
+    let room = Room::at_channel(home.path(), "general", foreign).unwrap();
+    assert_eq!(room.channel, foreign);
+    assert_ne!(
+        Room::from_name(home.path(), "general").unwrap().channel,
+        foreign
+    );
+    // Empty name (request had no stamped channel-name header) still yields
+    // a usable room on the adopted channel.
+    let unnamed = Room::at_channel(home.path(), "", foreign).unwrap();
+    assert_eq!(unnamed.channel, foreign);
+}

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -354,7 +354,9 @@ pub fn turn_reply_address(headers: &Headers) -> Result<TurnReplyAddress, Persona
 #[derive(Debug)]
 pub enum PersonaTurnError {
     Codec(PersonaCodecError),
-    Substrate(AircError),
+    // Boxed: AircError is 128+ bytes and rides the Err path of every turn
+    // helper (clippy::result_large_err) — the Ok path shouldn't pay for it.
+    Substrate(Box<AircError>),
 }
 
 impl std::fmt::Display for PersonaTurnError {
@@ -383,7 +385,7 @@ impl From<PersonaCodecError> for PersonaTurnError {
 
 impl From<AircError> for PersonaTurnError {
     fn from(error: AircError) -> Self {
-        Self::Substrate(error)
+        Self::Substrate(Box::new(error))
     }
 }
 

--- a/crates/examples/embedded_consumer_smoke/src/lib.rs
+++ b/crates/examples/embedded_consumer_smoke/src/lib.rs
@@ -28,4 +28,11 @@
 //! forces a substrate-internal import into `src/`, that's a signal
 //! `airc-lib` is missing a re-export.
 
+// Examples deliberately mirror airc-lib's REAL signatures, whose Err type
+// (`AircError`) is >=128 bytes — clippy 1.98's `result_large_err` fires on
+// every such fn. Boxing here would misdocument the API; the actual fix is
+// shrinking `AircError` (boxing its large variants) library-wide. Scoped
+// allow until that refactor lands.
+#![allow(clippy::result_large_err)]
+
 pub mod agent;


### PR DESCRIPTION
Two scopes on one machine park in different rooms (operator CLI in #general, citizens landed in #academy). A command request crosses fine — responders subscribe every room — but `Airc::reply` sends via the responder's CURRENT room, so the answer leaves through a channel the requester never subscribed to and every dispatch dies at the command deadline (continuum grid-smoke 0/3, 2026-08-27).

- `Room::at_channel` adopts the request event's `room_id` verbatim (never re-derived from the name — identity-scoped derivation can diverge, the M5↔bigmama blind-room class)
- `Airc::reply_in` sends the reply into that channel, preserving the blind-room heal name header
- `Airc::reply` keeps current-room semantics with a doc pointer to prefer `reply_in`
- regression test: `at_channel_adopts_the_given_channel_verbatim`

Continuum side (command_handler → reply_in) follows in a continuum PR that bumps the pin to this rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo