### PR TITLE
feat(lib): NAT traversal — ICE/STUN + evidence-gated DataChannel data routing (the free coffee-shop rung)

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -344,6 +344,12 @@ pub(crate) struct AircInner {
     pub(crate) relay_server: Mutex<Option<airc_relay::RelayServer>>,
     pub(crate) udp: Mutex<Option<UdpAdapter>>,
     pub(crate) udp_subscriber: Mutex<Option<FrameSubscriber>>,
+    /// ICE gathering configuration for every PeerConnection this handle
+    /// builds (STUN servers + bind address). Defaults to
+    /// [`crate::IceConfig::from_env`] — NAT-capable out of the box; tests
+    /// pin [`crate::IceConfig::loopback_only`] via
+    /// [`crate::Airc::set_ice_config`] to stay hermetic.
+    pub(crate) ice_config: std::sync::RwLock<crate::IceConfig>,
     /// Per-peer WebRTC DataChannel adapters, keyed by the remote
     /// peer id. Populated by `Airc::open_webrtc_to` /
     /// `Airc::accept_webrtc_offers` after a handshake completes.
@@ -713,6 +719,7 @@ impl Airc {
                 relay_server: Mutex::new(None),
                 udp: Mutex::new(None),
                 udp_subscriber: Mutex::new(None),
+                ice_config: std::sync::RwLock::new(crate::IceConfig::from_env()),
                 webrtc_channels: Mutex::new(HashMap::new()),
                 webrtc_subscribers: Mutex::new(HashMap::new()),
                 webrtc_peer_connections: Mutex::new(HashMap::new()),
@@ -791,6 +798,27 @@ impl Airc {
     /// Emit a diagnostic through this handle's configured sink.
     pub(crate) fn emit_diag(&self, event: airc_diagnostics::DiagnosticEvent) {
         self.diag_sink().emit(event);
+    }
+
+    /// Replace the ICE gathering config for PeerConnections this handle
+    /// builds from now on (existing connections are unaffected). Tests
+    /// pin [`crate::IceConfig::loopback_only`] to stay hermetic;
+    /// embedders may point STUN at their own infrastructure.
+    pub fn set_ice_config(&self, config: crate::IceConfig) {
+        *self
+            .inner
+            .ice_config
+            .write()
+            .expect("ice_config lock poisoned") = config;
+    }
+
+    /// The ICE gathering config PeerConnections are currently built with.
+    pub fn ice_config(&self) -> crate::IceConfig {
+        self.inner
+            .ice_config
+            .read()
+            .expect("ice_config lock poisoned")
+            .clone()
     }
 
     /// Return the home directory backing this handle.
@@ -1586,6 +1614,7 @@ impl Airc {
             relay_server: Mutex::new(None),
             udp: Mutex::new(None),
             udp_subscriber: Mutex::new(None),
+            ice_config: std::sync::RwLock::new(crate::IceConfig::from_env()),
             webrtc_channels: Mutex::new(HashMap::new()),
             webrtc_subscribers: Mutex::new(HashMap::new()),
             webrtc_peer_connections: Mutex::new(HashMap::new()),

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -805,11 +805,13 @@ impl Airc {
     /// pin [`crate::IceConfig::loopback_only`] to stay hermetic;
     /// embedders may point STUN at their own infrastructure.
     pub fn set_ice_config(&self, config: crate::IceConfig) {
+        // Poison-recover: a panicked writer can't corrupt a plain config
+        // swap — take the lock anyway rather than propagate the panic.
         *self
             .inner
             .ice_config
             .write()
-            .expect("ice_config lock poisoned") = config;
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = config;
     }
 
     /// The ICE gathering config PeerConnections are currently built with.
@@ -817,7 +819,7 @@ impl Airc {
         self.inner
             .ice_config
             .read()
-            .expect("ice_config lock poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -57,6 +57,7 @@ pub mod lane_coordination;
 pub mod lifecycle;
 pub mod mesh_identity;
 mod messaging;
+pub mod nat_ice;
 mod peers;
 pub mod publish;
 pub mod registry;
@@ -123,6 +124,7 @@ pub use diagnostic_event_sink::{
     AircEventDiagnosticSink, RecentDiagnostics, HEADER_DIAG_CODE, HEADER_DIAG_COMPONENT,
     HEADER_DIAG_SEVERITY,
 };
+pub use nat_ice::IceConfig;
 pub use rendezvous::{
     parse_rendezvous_dir, resolve_account_registry_store, GistRendezvous, RendezvousChoice,
     RendezvousConfigError, RENDEZVOUS_DIR_ENV,

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -199,7 +199,7 @@ impl Airc {
         // "wrote it down" with "you heard it" is what made an offline node
         // mute.
         let __route = airc_diagnostics::timing::start();
-        match self.resolve_send_route(kind) {
+        match self.resolve_send_route(kind, &frame.envelope.target).await {
             Ok(route) => {
                 if let Err(error) = self.execute_send_route(route.kind, room, frame).await {
                     tracing::warn!(
@@ -233,11 +233,48 @@ impl Airc {
         })
     }
 
-    fn resolve_send_route(&self, kind: FrameKind) -> Result<TransportRoute, AircError> {
+    async fn resolve_send_route(
+        &self,
+        kind: FrameKind,
+        target: &airc_core::MentionTarget,
+    ) -> Result<TransportRoute, AircError> {
         let class = route_class_for_frame(kind);
-        let samples = self.inner.route_health.samples();
-        TransportResolver::from_health(samples)
-            .resolve(class)
+        // Peer-directed frames may ride the per-peer direct rung — but only
+        // on the EVIDENCE of an established DataChannel to that exact peer
+        // (see RouteTarget docs; a phantom claim would route frames into
+        // "no webrtc channel for peer" instead of a live Relay).
+        let route_target = match target {
+            airc_core::MentionTarget::Peer(peer) => crate::route::policy::RouteTarget::Peer {
+                webrtc_channel_ready: self.has_webrtc_channel(*peer).await,
+            },
+            airc_core::MentionTarget::All | airc_core::MentionTarget::Room(_) => {
+                crate::route::policy::RouteTarget::Broadcast
+            }
+        };
+        let mut candidates = self
+            .inner
+            .route_health
+            .samples()
+            .into_iter()
+            .map(crate::route::health::TransportHealthSample::candidate)
+            .collect::<Vec<_>>();
+        // The per-peer DataChannel never registers in the kind-keyed health
+        // table (one row can't speak for N peers); the registered channel to
+        // THIS peer is its own health evidence, injected per-resolution.
+        if matches!(
+            route_target,
+            crate::route::policy::RouteTarget::Peer {
+                webrtc_channel_ready: true
+            }
+        ) {
+            candidates.push(crate::route::policy::TransportCandidate {
+                kind: crate::route::policy::TransportKind::WebRtcDataChannel,
+                role: crate::route::policy::TransportRole::Direct,
+                healthy: true,
+            });
+        }
+        TransportResolver::new(candidates)
+            .resolve_for_target(class, route_target)
             .map_err(format_route_refusal)
     }
 

--- a/crates/airc-lib/src/nat_ice.rs
+++ b/crates/airc-lib/src/nat_ice.rs
@@ -1,0 +1,154 @@
+//! ICE configuration for WebRTC NAT traversal — the free coffee-shop rung.
+//!
+//! ## Why this exists
+//!
+//! `webrtc.rs` shipped with the loopback follow-up open: PeerConnections
+//! bound `127.0.0.1:0` with no ICE servers, so the DataChannel path only
+//! worked between two endpoints on the same machine. This module closes
+//! it: real-interface binds + STUN servers give ICE server-reflexive
+//! candidates, which is standard UDP hole-punching — the majority of
+//! NAT'd peer pairs (home router ↔ coffee-shop wifi) connect DIRECTLY,
+//! no subscription, no VPN. Pairs that can't punch (symmetric↔symmetric)
+//! keep the relay rung; the relay only ever carries what can't go direct.
+//!
+//! ## Defaults, and who pays
+//!
+//! Nobody. STUN is a stateless "what's my public address:port" echo —
+//! several operators run free public servers precisely because it costs
+//! them almost nothing. We default to a small redundant set and let
+//! operators point at their own (`AIRC_STUN_SERVERS`), including a grid
+//! member's future STUN-speaking relay. TURN-style relaying is NOT
+//! configured here — bulk fallback belongs to the grid's own relay rung,
+//! not a third party's.
+//!
+//! ## Env overrides
+//!
+//! - `AIRC_STUN_SERVERS` — comma-separated `stun:host:port` URLs. Empty
+//!   string means "no STUN" (host candidates only — LAN/loopback use).
+//! - `AIRC_WEBRTC_BIND` — UDP bind address for ICE gathering. Defaults
+//!   to `0.0.0.0:0` (all interfaces, OS-assigned port).
+//!
+//! Tests use [`IceConfig::loopback_only`] explicitly — never env
+//! mutation, which races parallel tests.
+
+use webrtc::peer_connection::{RTCConfiguration, RTCConfigurationBuilder, RTCIceServer};
+
+/// Default public STUN set. Two independent operators for redundancy;
+/// both are long-lived, free, and rate-benign for our call volume (one
+/// query pair per ICE gather, not per frame).
+const DEFAULT_STUN_URLS: &[&str] = &[
+    "stun:stun.l.google.com:19302",
+    "stun:stun.cloudflare.com:3478",
+];
+
+/// Default gather bind: every interface, OS-assigned port.
+const DEFAULT_BIND: &str = "0.0.0.0:0";
+
+/// Loopback gather bind — same-machine only (the pre-NAT-traversal
+/// behavior, kept for tests and explicitly-local embeddings).
+const LOOPBACK_BIND: &str = "127.0.0.1:0";
+
+/// How a PeerConnection gathers ICE candidates: where to bind, and
+/// which STUN servers (if any) to learn public reflexive addresses from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IceConfig {
+    /// `stun:host:port` URLs. Empty = host candidates only.
+    pub stun_urls: Vec<String>,
+    /// UDP address the ICE agent binds for gathering.
+    pub udp_bind: String,
+}
+
+impl IceConfig {
+    /// Production resolution: env overrides, else real-interface bind +
+    /// the default public STUN set.
+    pub fn from_env() -> Self {
+        Self::from_parts(
+            std::env::var("AIRC_STUN_SERVERS").ok().as_deref(),
+            std::env::var("AIRC_WEBRTC_BIND").ok().as_deref(),
+        )
+    }
+
+    /// The pure core of [`from_env`] — testable without env mutation.
+    /// `stun`: `None` = default set; `Some("")` = explicitly none;
+    /// `Some("a,b")` = exactly those. `bind`: `None`/empty = default.
+    pub fn from_parts(stun: Option<&str>, bind: Option<&str>) -> Self {
+        let stun_urls = match stun {
+            None => DEFAULT_STUN_URLS.iter().map(|s| s.to_string()).collect(),
+            Some(raw) => raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect(),
+        };
+        let udp_bind = match bind {
+            None => DEFAULT_BIND.to_string(),
+            Some(raw) if raw.trim().is_empty() => DEFAULT_BIND.to_string(),
+            Some(raw) => raw.trim().to_string(),
+        };
+        Self {
+            stun_urls,
+            udp_bind,
+        }
+    }
+
+    /// Same-machine-only gathering: loopback bind, no STUN. The exact
+    /// pre-NAT-traversal behavior — what the webrtc integration tests
+    /// pin so they stay hermetic (no STUN round-trips in CI).
+    pub fn loopback_only() -> Self {
+        Self {
+            stun_urls: Vec::new(),
+            udp_bind: LOOPBACK_BIND.to_string(),
+        }
+    }
+
+    /// Project into the webrtc crate's `RTCConfiguration`.
+    pub fn rtc_configuration(&self) -> RTCConfiguration {
+        let servers = self
+            .stun_urls
+            .iter()
+            .map(|url| RTCIceServer {
+                urls: vec![url.clone()],
+                username: String::new(),
+                credential: String::new(),
+            })
+            .collect::<Vec<_>>();
+        RTCConfigurationBuilder::new()
+            .with_ice_servers(servers)
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_parts_resolves_defaults_overrides_and_explicit_none() {
+        // what this catches: the env contract — None means the public
+        // default set (production is NAT-capable by default, never a
+        // silent loopback), "" means explicitly no STUN, and a CSV is
+        // taken verbatim. A regression here silently re-opens the
+        // "works on my LAN, dead at the coffee shop" gap.
+        let default = IceConfig::from_parts(None, None);
+        assert_eq!(default.stun_urls.len(), DEFAULT_STUN_URLS.len());
+        assert_eq!(default.udp_bind, DEFAULT_BIND);
+
+        let none = IceConfig::from_parts(Some(""), None);
+        assert!(none.stun_urls.is_empty());
+
+        let custom = IceConfig::from_parts(
+            Some(" stun:relay.grid.example:3478 , stun:other:19302 "),
+            Some("192.168.1.10:0"),
+        );
+        assert_eq!(
+            custom.stun_urls,
+            vec!["stun:relay.grid.example:3478", "stun:other:19302"]
+        );
+        assert_eq!(custom.udp_bind, "192.168.1.10:0");
+
+        let loopback = IceConfig::loopback_only();
+        assert!(loopback.stun_urls.is_empty());
+        assert_eq!(loopback.udp_bind, LOOPBACK_BIND);
+    }
+}

--- a/crates/airc-lib/src/route/policy.rs
+++ b/crates/airc-lib/src/route/policy.rs
@@ -58,26 +58,56 @@ pub enum RouteDecision {
     NoRoute { class: RouteClass },
 }
 
+/// The delivery shape of the frame being routed. Peer-directed frames
+/// may ride per-peer transports (an established WebRTC DataChannel);
+/// broadcasts never can — a datachannel reaches ONE peer, and selecting
+/// it for a room fan-out would silently narrow delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RouteTarget {
+    /// Room/All fan-out — only shared transports are admissible.
+    Broadcast,
+    /// Directed at one peer. `webrtc_channel_ready` is whether an
+    /// established DataChannel to THAT peer is registered right now —
+    /// the admission evidence for the direct-p2p rung. Passing `true`
+    /// without a live channel would route frames into "no webrtc
+    /// channel for peer" errors, so callers must derive it from the
+    /// per-peer channel table, never assume it.
+    Peer { webrtc_channel_ready: bool },
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RoutePolicy;
 
 impl RoutePolicy {
+    /// Target-agnostic selection — equivalent to
+    /// [`choose_for_target`](Self::choose_for_target) with
+    /// [`RouteTarget::Broadcast`], the conservative shape (per-peer
+    /// transports never admitted).
     pub fn choose(
         &self,
         class: RouteClass,
         candidates: impl IntoIterator<Item = TransportCandidate>,
     ) -> RouteDecision {
+        self.choose_for_target(class, RouteTarget::Broadcast, candidates)
+    }
+
+    pub fn choose_for_target(
+        &self,
+        class: RouteClass,
+        target: RouteTarget,
+        candidates: impl IntoIterator<Item = TransportCandidate>,
+    ) -> RouteDecision {
         candidates
             .into_iter()
             .filter(|candidate| candidate.healthy)
-            .filter(|candidate| allows(class, *candidate))
+            .filter(|candidate| allows(class, target, *candidate))
             .min_by_key(|candidate| priority(class, candidate.kind, candidate.role))
             .map(|candidate| RouteDecision::Selected(candidate.kind))
             .unwrap_or(RouteDecision::NoRoute { class })
     }
 }
 
-fn allows(class: RouteClass, candidate: TransportCandidate) -> bool {
+fn allows(class: RouteClass, target: RouteTarget, candidate: TransportCandidate) -> bool {
     match candidate.kind {
         TransportKind::GhGist => matches!(
             (class, candidate.role),
@@ -88,7 +118,7 @@ fn allows(class: RouteClass, candidate: TransportCandidate) -> bool {
             candidate.role == TransportRole::Direct
                 && (is_live_class(class) || class == RouteClass::PeerRendezvous)
         }
-        TransportKind::Udp | TransportKind::WebRtcDataChannel => {
+        TransportKind::Udp => {
             candidate.role == TransportRole::Direct
                 && matches!(
                     class,
@@ -96,6 +126,22 @@ fn allows(class: RouteClass, candidate: TransportCandidate) -> bool {
                         | RouteClass::MediaSignaling
                         | RouteClass::PresenceEphemeral
                 )
+        }
+        TransportKind::WebRtcDataChannel => {
+            candidate.role == TransportRole::Direct
+                && (matches!(
+                    class,
+                    RouteClass::ControlInteractive
+                        | RouteClass::MediaSignaling
+                        | RouteClass::PresenceEphemeral
+                )
+                // The direct-p2p data rung: an ESTABLISHED DataChannel to
+                // the target peer carries durable data classes — this is
+                // the NAT-traversed coffee-shop path. Evidence-gated
+                // (channel registered NOW) so no phantom route ever beats
+                // a live Relay/Reticulum.
+                || (matches!(class, RouteClass::DataInteractive | RouteClass::DataBulk)
+                    && matches!(target, RouteTarget::Peer { webrtc_channel_ready: true })))
         }
         TransportKind::Reticulum => {
             (candidate.role == TransportRole::Direct
@@ -141,13 +187,11 @@ fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
         },
         RouteClass::DataInteractive => match kind {
             TransportKind::LanTcp => 0,
+            TransportKind::WebRtcDataChannel => 1,
             TransportKind::Tailscale => 2,
             TransportKind::Reticulum => 3,
             TransportKind::Relay => 4,
-            TransportKind::Udp
-            | TransportKind::WebRtcDataChannel
-            | TransportKind::Ssh
-            | TransportKind::GhGist => 255,
+            TransportKind::Udp | TransportKind::Ssh | TransportKind::GhGist => 255,
         },
         RouteClass::MediaSignaling => match kind {
             TransportKind::Udp => 1,
@@ -160,13 +204,11 @@ fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
         },
         RouteClass::DataBulk => match kind {
             TransportKind::LanTcp => 0,
+            TransportKind::WebRtcDataChannel => 1,
             TransportKind::Tailscale => 2,
             TransportKind::Reticulum => 3,
             TransportKind::Relay => 4,
-            TransportKind::Udp
-            | TransportKind::WebRtcDataChannel
-            | TransportKind::Ssh
-            | TransportKind::GhGist => 255,
+            TransportKind::Udp | TransportKind::Ssh | TransportKind::GhGist => 255,
         },
         RouteClass::PeerRendezvous => match (kind, role) {
             (TransportKind::LanTcp, TransportRole::Direct) => 0,
@@ -221,6 +263,86 @@ pub fn crypto_mode(transport: TransportKind) -> CryptoMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn direct(kind: TransportKind) -> TransportCandidate {
+        TransportCandidate {
+            kind,
+            role: TransportRole::Direct,
+            healthy: true,
+        }
+    }
+
+    // what this catches: the direct-p2p data rung's admission contract.
+    // A DataChannel reaches exactly ONE peer — selecting it for a
+    // broadcast silently narrows room fan-out to one recipient, and
+    // selecting it without an established channel routes durable frames
+    // into "no webrtc channel for peer" instead of a live Relay. The
+    // rung must be evidence-gated (Peer + channel-ready) and must beat
+    // Relay/Tailscale only then; LAN stays first.
+    #[test]
+    fn webrtc_data_rung_is_peer_directed_and_evidence_gated() {
+        let policy = RoutePolicy;
+        let with_channel = RouteTarget::Peer {
+            webrtc_channel_ready: true,
+        };
+        let without_channel = RouteTarget::Peer {
+            webrtc_channel_ready: false,
+        };
+        let candidates = || {
+            [
+                direct(TransportKind::WebRtcDataChannel),
+                TransportCandidate {
+                    kind: TransportKind::Relay,
+                    role: TransportRole::Relay,
+                    healthy: true,
+                },
+            ]
+        };
+
+        for class in [RouteClass::DataInteractive, RouteClass::DataBulk] {
+            // Established channel: direct p2p beats the relay.
+            assert_eq!(
+                policy.choose_for_target(class, with_channel, candidates()),
+                RouteDecision::Selected(TransportKind::WebRtcDataChannel),
+                "{class:?}: established channel must win over relay"
+            );
+            // No channel: the relay carries it — never the phantom rung.
+            assert_eq!(
+                policy.choose_for_target(class, without_channel, candidates()),
+                RouteDecision::Selected(TransportKind::Relay),
+                "{class:?}: no channel means relay"
+            );
+            // Broadcast: never a per-peer transport, channel or not.
+            assert_eq!(
+                policy.choose_for_target(class, RouteTarget::Broadcast, candidates()),
+                RouteDecision::Selected(TransportKind::Relay),
+                "{class:?}: broadcast must not ride a per-peer channel"
+            );
+            // Same LAN: LanTcp still outranks the datachannel.
+            assert_eq!(
+                policy.choose_for_target(
+                    class,
+                    with_channel,
+                    [
+                        direct(TransportKind::LanTcp),
+                        direct(TransportKind::WebRtcDataChannel)
+                    ]
+                ),
+                RouteDecision::Selected(TransportKind::LanTcp),
+                "{class:?}: LAN beats datachannel"
+            );
+        }
+
+        // The legacy classes keep their target-agnostic admission (the
+        // signaling path itself rides them) — choose() == Broadcast shape.
+        assert_eq!(
+            policy.choose(
+                RouteClass::MediaSignaling,
+                [direct(TransportKind::WebRtcDataChannel)]
+            ),
+            RouteDecision::Selected(TransportKind::WebRtcDataChannel),
+        );
+    }
 
     // what this catches: the two-plane crypto split — ONLY the packet-rate
     // stream transports use a session; every other transport keeps per-frame

--- a/crates/airc-lib/src/route/resolver.rs
+++ b/crates/airc-lib/src/route/resolver.rs
@@ -8,7 +8,7 @@
 
 use crate::route::health::TransportHealthSample;
 use crate::route::policy::{
-    RouteClass, RouteDecision, RoutePolicy, TransportCandidate, TransportKind,
+    RouteClass, RouteDecision, RoutePolicy, RouteTarget, TransportCandidate, TransportKind,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,7 +47,21 @@ impl TransportResolver {
     }
 
     pub fn resolve(&self, class: RouteClass) -> Result<TransportRoute, RouteDecision> {
-        match self.policy.choose(class, self.candidates.iter().copied()) {
+        self.resolve_for_target(class, RouteTarget::Broadcast)
+    }
+
+    /// Target-aware resolution: peer-directed frames may ride the
+    /// per-peer direct rung (an established WebRTC DataChannel);
+    /// broadcasts never can. See [`RouteTarget`].
+    pub fn resolve_for_target(
+        &self,
+        class: RouteClass,
+        target: RouteTarget,
+    ) -> Result<TransportRoute, RouteDecision> {
+        match self
+            .policy
+            .choose_for_target(class, target, self.candidates.iter().copied())
+        {
             RouteDecision::Selected(kind) => Ok(TransportRoute { kind }),
             decision @ RouteDecision::NoRoute { .. } => Err(decision),
         }

--- a/crates/airc-lib/src/webrtc.rs
+++ b/crates/airc-lib/src/webrtc.rs
@@ -23,10 +23,12 @@
 //! ICE, STUN/TURN configuration, reconnect-on-drop, and renegotiation
 //! are explicit non-goals here.
 //!
-//! Loopback bind: PCs gather candidates on `127.0.0.1:0`, which means
-//! this PR's path only works between two endpoints on the same
-//! machine. Real-network NAT traversal needs configurable ICE servers
-//! — flagged as a follow-up.
+//! NAT traversal: PCs gather on the handle's [`crate::IceConfig`] —
+//! real-interface bind + STUN by default (`AIRC_STUN_SERVERS` /
+//! `AIRC_WEBRTC_BIND` override), so ICE hole-punches across NATs and
+//! most peer pairs connect DIRECTLY. Tests pin
+//! [`crate::IceConfig::loopback_only`] to stay hermetic. Trickle ICE,
+//! TURN, reconnect-on-drop, and renegotiation remain non-goals.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -114,8 +116,10 @@ impl Airc {
             .ok_or_else(|| AircError::Transport("webrtc default runtime unavailable".into()))?;
         let (gather_tx, mut gather_rx) = rtc_channel::<()>(1);
         let (connected_tx, mut connected_rx) = rtc_channel::<()>(1);
+        let ice = self.ice_config();
         let pc: Arc<dyn PeerConnection> = Arc::new(
             PeerConnectionBuilder::new()
+                .with_configuration(ice.rtc_configuration())
                 .with_media_engine(default_media_engine()?)
                 .with_handler(Arc::new(OffererHandler {
                     airc: self.clone(),
@@ -124,7 +128,7 @@ impl Airc {
                     connected_tx,
                 }))
                 .with_runtime(runtime)
-                .with_udp_addrs(vec!["127.0.0.1:0"])
+                .with_udp_addrs(vec![ice.udp_bind.as_str()])
                 .build()
                 .await
                 .map_err(|error| AircError::Transport(format!("webrtc build: {error}")))?,
@@ -262,8 +266,10 @@ impl Airc {
         let (gather_tx, mut gather_rx) = rtc_channel::<()>(1);
         let (connected_tx, mut connected_rx) = rtc_channel::<()>(1);
         let (channel_tx, mut channel_rx) = mpsc::channel::<Arc<dyn DataChannel>>(1);
+        let ice = self.ice_config();
         let pc: Arc<dyn PeerConnection> = Arc::new(
             PeerConnectionBuilder::new()
+                .with_configuration(ice.rtc_configuration())
                 .with_media_engine(default_media_engine()?)
                 .with_handler(Arc::new(AnswererHandler {
                     airc: self.clone(),
@@ -273,7 +279,7 @@ impl Airc {
                     channel_tx,
                 }))
                 .with_runtime(runtime)
-                .with_udp_addrs(vec!["127.0.0.1:0"])
+                .with_udp_addrs(vec![ice.udp_bind.as_str()])
                 .build()
                 .await
                 .map_err(|error| AircError::Transport(format!("webrtc build: {error}")))?,

--- a/crates/airc-lib/tests/webrtc_route.rs
+++ b/crates/airc-lib/tests/webrtc_route.rs
@@ -54,6 +54,11 @@ async fn paired_airc(room: &str) -> PairedAircFixture {
     let machine = Machine::boot().await;
     let alice = machine.attach("alice").await;
     let bob = machine.attach("bob").await;
+    // Hermetic ICE: loopback bind, no STUN — CI must not depend on (or
+    // wait for) public STUN round-trips. Production default is the
+    // NAT-capable IceConfig::from_env().
+    alice.set_ice_config(airc_lib::IceConfig::loopback_only());
+    bob.set_ice_config(airc_lib::IceConfig::loopback_only());
 
     let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
     let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");


### PR DESCRIPTION
The "everyone talks to everyone across tabs, computers, humans, agents, personas — without paying for one thing" build (Joel, 2026-08-27). Tailscale stays exactly what it is today: one optional rung.

## What lands

**1. `IceConfig` — the declared loopback follow-up in webrtc.rs, closed.**
PeerConnections gathered on `127.0.0.1:0` with no ICE servers, so DataChannels only worked same-machine. Now both builder sites (offerer + answerer) gather on a real-interface bind with STUN by default — server-reflexive candidates mean standard UDP hole-punching, so most NAT'd pairs (home router ↔ coffee-shop wifi) connect **directly, free**. `AIRC_STUN_SERVERS` / `AIRC_WEBRTC_BIND` override — including pointing at a grid member's own STUN-speaking relay later. Tests pin `IceConfig::loopback_only()` so CI never waits on public STUN.

**2. `RouteTarget` — the DataChannel becomes a real data transport, on evidence only.**
`WebRtcDataChannel` is now admissible for `DataInteractive`/`DataBulk`, gated three ways:
- **peer-directed frames only** — a 1:1 channel selected for a room fan-out would silently narrow delivery to one recipient;
- **only when an established channel to that exact peer is registered** (`has_webrtc_channel` at resolve time, injected as its own candidate — the kind-keyed health table can't speak for N peers; no phantom route ever beats a live Relay);
- **priority LAN 0 → DataChannel 1 → Tailscale 2 → Reticulum 3 → Relay 4** — direct p2p beats every relay-shaped rung, LAN stays first.

## The transport ladder after this PR
LAN direct → hole-punched direct p2p (free STUN) → Reticulum → grid relay (self-elected, ours) → and Tailscale as an optional rung for those who run it. Nobody pays; pairs that can't punch (symmetric↔symmetric) ride the grid's own relay, which now only ever carries what can't go direct.

## Receipts
350/350 airc-lib tests green, including the `webrtc_route` e2e (hermetic loopback) and the new admission-contract regression test (`webrtc_data_rung_is_peer_directed_and_evidence_gated`).

## Follow-ups (not this PR)
- Auto-dial-on-demand: dial the DataChannel when repeated sends to a peer defer while a signaling route exists (today `open_webrtc_to` is explicit).
- Cross-machine live receipt: needs a second machine on a different NAT — the M1/IntelMac battery.
- TURN is a non-goal: bulk fallback belongs to the grid's own relay rung, not a third party.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo