### PR TITLE
feat(discovery): the daemon derives a peer's identity port itself — the by-hand dial, encoded (#1301 caller side)

### DIFF
--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -98,6 +98,49 @@ fn learned_lan_candidates(
     candidates
 }
 
+/// #1301 (caller side): pair every IP we know for a peer with the port its
+/// transport host's IDENTITY derives — [`crate::lan::stable_lan_port`] —
+/// because that is the one port knowable WITHOUT any advertisement.
+///
+/// Why this rung exists, measured live 2026-08-15 (BigMama -> M5): the peer
+/// was enrolled, its Mac answered mDNS, its daemon was LISTENING on its
+/// stable port — and every STORED endpoint for it carried a stale ephemeral
+/// port from the pre-#1369 churn, so discovery dialed corpses and reported
+/// "0 routes, 96 enrolled". The connection that finally worked was a human
+/// running the derivation by hand: arp for the IP, `stable_lan_port(peer)`
+/// for the port, `airc dial --expected-peer`. A user without a terminal
+/// cannot do that, so the daemon must.
+///
+/// The port derives from the TRANSPORT HOST (the dial pin), not the record
+/// peer: the listener binds the wire-owning scope's identity port, and a
+/// record whose endpoints are answered by a declared host must derive from
+/// that host (machine-vs-scope, same rule as the TLS pin).
+///
+/// Appended AFTER stored/learned candidates, not prepended: post-#1369 the
+/// advertised port IS the stable port, so stored endpoints usually win and
+/// this rung costs nothing. It pays exactly when the stored set is stale —
+/// churn-era records, or a peer whose bind fell back — and failure-counted
+/// eviction retires the corpses so this rung stops paying their timeouts.
+fn identity_port_candidates(
+    existing: &[RouteEndpoint],
+    transport_host: PeerId,
+) -> Vec<RouteEndpoint> {
+    let derived = crate::lan::stable_lan_port(transport_host);
+    let mut candidates = Vec::new();
+    for endpoint in existing {
+        // Same non-wildcard match discipline as `learned_lan_candidates`.
+        if let RouteEndpoint::LanTcp { addr } | RouteEndpoint::TailscaleTcp { addr } = endpoint {
+            let candidate = RouteEndpoint::LanTcp {
+                addr: std::net::SocketAddr::from((addr.ip(), derived)),
+            };
+            if !existing.contains(&candidate) && !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+    candidates
+}
+
 /// Card 625abe6d slice 1 — a stored peer endpoint that could not be
 /// dialed during discovery. Surfaced on the snapshot (and printed by
 /// `airc transport health`) instead of being swallowed: an offline
@@ -515,6 +558,11 @@ impl Airc {
                             );
                         }
                     }
+                    // #1301 caller side: the identity-derived port rides as
+                    // the LAST candidate for every known IP — the recovery
+                    // rung when every stored endpoint is a churn-era corpse.
+                    let mut eps = eps;
+                    eps.extend(identity_port_candidates(&eps, pin));
                     (peer_id, pin, eps, stamp, alive)
                 })
             })
@@ -1194,6 +1242,62 @@ mod tests {
             substitute_self_relay_port(recorded, None),
             recorded,
             "foreign relay (or no live server): dial as recorded"
+        );
+    }
+
+    /// what this catches: the by-hand dial that connected BigMama->M5 on
+    /// 2026-08-15, encoded so no human ever runs it again. Every STORED
+    /// endpoint carried a churn-era ephemeral port; the peer was listening on
+    /// its identity-derived port at a known IP. The candidate set must
+    /// therefore include (known_ip, stable_lan_port(transport_host)) — and
+    /// derive from the TRANSPORT HOST, not the record peer, because the
+    /// listener binds the wire-owning scope's identity (machine-vs-scope,
+    /// same rule as the TLS pin).
+    #[test]
+    fn identity_port_candidates_pair_known_ips_with_the_derived_port() {
+        let record_peer = PeerId::from_u128(0x2f0aed7f_3359_4dd5_9f9b_aaa0b07c6266);
+        let host = PeerId::from_u128(0x7711fe60_a19f_4f41_9ab6_24c884757338);
+        let stale = RouteEndpoint::LanTcp {
+            addr: "192.168.1.249:65209".parse().unwrap(),
+        };
+
+        // Derives from the record peer when it is its own transport host…
+        let own = identity_port_candidates(std::slice::from_ref(&stale), record_peer);
+        assert_eq!(
+            own,
+            vec![RouteEndpoint::LanTcp {
+                addr: std::net::SocketAddr::from((
+                    "192.168.1.249".parse::<std::net::IpAddr>().unwrap(),
+                    crate::lan::stable_lan_port(record_peer),
+                )),
+            }],
+            "a stale stored port must still yield (same ip, identity-derived port)"
+        );
+
+        // …and from the DECLARED HOST when one answers the endpoints.
+        let hosted = identity_port_candidates(std::slice::from_ref(&stale), host);
+        assert_eq!(
+            hosted[0],
+            RouteEndpoint::LanTcp {
+                addr: std::net::SocketAddr::from((
+                    "192.168.1.249".parse::<std::net::IpAddr>().unwrap(),
+                    crate::lan::stable_lan_port(host),
+                )),
+            },
+            "the port must derive from the transport host that owns the listener"
+        );
+
+        // A stored endpoint ALREADY at the derived port adds nothing — the
+        // rung is free exactly when #1369 has done its job.
+        let current = RouteEndpoint::LanTcp {
+            addr: std::net::SocketAddr::from((
+                "192.168.1.249".parse::<std::net::IpAddr>().unwrap(),
+                crate::lan::stable_lan_port(record_peer),
+            )),
+        };
+        assert!(
+            identity_port_candidates(std::slice::from_ref(&current), record_peer).is_empty(),
+            "no duplicate candidate when the stored endpoint already carries the derived port"
         );
     }
 

--- a/crates/airc-lib/tests/stored_endpoint_dial.rs
+++ b/crates/airc-lib/tests/stored_endpoint_dial.rs
@@ -133,10 +133,16 @@ async fn discovery_records_failed_dial_instead_of_swallowing_it() {
         .await
         .expect("refresh must survive an unreachable peer");
 
+    // TWO failures since the identity-port rung (#1370): the stored
+    // endpoint, then (same ip, stable_lan_port(peer)) appended as the
+    // recovery candidate. Post-#1369 records advertise their stable port,
+    // so the derived candidate dedups away and this costs nothing; a
+    // synthetic/churn-era record like this one pays exactly one extra
+    // fast local dial. Order is pinned: stored endpoint first.
     assert_eq!(
         snapshot.peer_dial_failures.len(),
-        1,
-        "exactly one failed dial must be recorded: {:?}",
+        2,
+        "stored endpoint + identity-derived recovery candidate must both record: {:?}",
         snapshot.peer_dial_failures
     );
     let failure = &snapshot.peer_dial_failures[0];
@@ -200,8 +206,8 @@ async fn quarantined_endpoint_surfaces_as_skip_not_failure_on_re_refresh() {
     let first = bob.refresh_route_discovery().await.expect("first refresh");
     assert_eq!(
         first.peer_dial_failures.len(),
-        1,
-        "first refresh attempts and fails the dial"
+        2,
+        "first refresh attempts and fails the stored endpoint AND its          identity-derived recovery candidate (#1370)"
     );
     assert!(
         first.peer_dial_skips.is_empty(),
@@ -220,8 +226,8 @@ async fn quarantined_endpoint_surfaces_as_skip_not_failure_on_re_refresh() {
     );
     assert_eq!(
         second.peer_dial_skips.len(),
-        1,
-        "the backed-off endpoint is surfaced as a skip: {:?}",
+        2,
+        "both backed-off endpoints (stored + derived, #1370) surface as skips: {:?}",
         second.peer_dial_skips
     );
     let skip = &second.peer_dial_skips[0];
@@ -464,8 +470,8 @@ async fn identity_mismatch_never_retries_an_unenrolled_identity() {
     );
     assert_eq!(
         snapshot.peer_dial_failures.len(),
-        1,
-        "the refused dial must be recorded loudly: {:?}",
+        2,
+        "the refused dial AND its identity-derived recovery candidate (#1370)          must be recorded loudly: {:?}",
         snapshot.peer_dial_failures
     );
     let failure = &snapshot.peer_dial_failures[0];
@@ -977,10 +983,15 @@ async fn peers_are_dialed_concurrently_not_serially() {
     let elapsed = started.elapsed();
 
     // Every tarpit dial must be recorded as a failure (none connects).
+    // 2 per peer since #1370: the tarpit endpoint (3s timeout) plus the
+    // identity-derived candidate (instant local refuse — nothing listens
+    // there). The concurrency bound below is unaffected: the slow dial per
+    // peer is still the single 3s tarpit; the derived dial adds
+    // milliseconds to each peer's serial walk.
     assert_eq!(
         snapshot.peer_dial_failures.len(),
-        N_TARPITS,
-        "each tarpit peer must record one failed dial: {:?}",
+        2 * N_TARPITS,
+        "each tarpit peer must record its stored + derived failed dials: {:?}",
         snapshot.peer_dial_failures
     );
     // The load-bearing assert: concurrent, not serial. Serial would be
@@ -1121,8 +1132,8 @@ async fn heal_failed_dials_rereads_rendezvous_and_dials_fresh_endpoint() {
         .expect("bob discovery refresh");
     assert_eq!(
         snapshot.peer_dial_failures.len(),
-        1,
-        "the stale endpoint must fail: {:?}",
+        2,
+        "the stale endpoint AND its identity-derived recovery candidate (#1370)          must both fail: {:?}",
         snapshot.peer_dial_failures
     );
 


### PR DESCRIPTION
## The by-hand dial this replaces

Measured live today, BigMama → M5: peer enrolled, its Mac answering mDNS, its daemon **listening** on its identity-derived stable port — and every stored endpoint for it carrying a stale ephemeral port from the pre-#1369 churn. Discovery dialed corpses and reported `0 routes, 96 enrolled peers`.

What finally connected was a human doing the derivation manually:

```
arp/mDNS             -> the IP    (192.168.1.249)
stable_lan_port(id)  -> the port  (57958, from peer 2f0aed7f)
airc dial --expected-peer ...     -> CONNECTED, authenticated
```

A user without a terminal cannot do any of that — Joel's standing rule: *"There is no one to manually do shit... all of this must work automatically for users."* So the sequence becomes a dial rung.

## The rung

`identity_port_candidates` pairs every IP already known for a peer with the one port knowable **without any advertisement**: `stable_lan_port` of the peer's **transport host** (the dial pin, not the record peer — the listener binds the wire-owning scope's identity; machine-vs-scope, same rule as the TLS pin).

**Appended last, not prepended:** post-#1369 the advertised port *is* the stable port, so stored endpoints normally win and this rung costs nothing. It pays exactly when the stored set is stale — churn-era records, or a peer whose bind fell back — and failure-counted eviction retires the corpses so the rung stops paying their timeouts. A stored endpoint already at the derived port adds no candidate (pinned by test).

## The pair this completes

- **#1369** — the listener *stays* where identity says it should be (bind survives the restart handover)
- **this** — the dialer can *find* it there with nothing but the trust store

Between them, the churn class that kept two current, healthy, firewalled-open nodes mutually unreachable for two days stops being representable.

## Verification

`cargo test -p airc-lib --lib` — **336 passed, 0 failed**, including the new candidate test (derives from record peer when self-hosted, from the declared host when hosted, adds nothing when the stored endpoint is already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc