### PR TITLE
fix(merger): reconcile on the merged FACT — REST says CLOSED for a merged PR, so the acd72c81 reconcile never fired

### DIFF
--- a/crates/airc-cli/src/gh_reqwest.rs
+++ b/crates/airc-cli/src/gh_reqwest.rs
@@ -369,6 +369,16 @@ impl GhClient for ReqwestGhClient {
             .get("merged_at")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // Card c03bb62f: REST says `closed` for a merged PR; GraphQL (the
+        // `gh pr view` client) says `MERGED`. One vocabulary for `state`
+        // across both clients — the gate decides on `merged_at` regardless,
+        // but a reader of `PrView.state` must not be told CLOSED when the
+        // PR merged.
+        let state = if merged_at.is_some() {
+            "MERGED".to_string()
+        } else {
+            state
+        };
 
         Ok(PrView {
             state,

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -1011,7 +1011,10 @@ mod tests {
         assert_eq!(runs.len(), 2);
         assert_eq!(runs[0].name.as_deref(), Some("cargo fmt --check"));
         assert_eq!(runs[1].conclusion.as_deref(), None);
-        assert_eq!(runs[1].status.as_deref(), Some("in_progress"));
+        // Card c03bb62f: GhCheck is GraphQL-cased at the parser now — REST's
+        // `in_progress` surfaces as `IN_PROGRESS`, the vocabulary the gate
+        // (`Some("COMPLETED")` / `Some("SUCCESS")`) actually speaks.
+        assert_eq!(runs[1].status.as_deref(), Some("IN_PROGRESS"));
     }
 
     // ------------------------------------------------------------------

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -437,7 +437,15 @@ pub(crate) fn evaluate_gh_view(
     baseline_failures: &std::collections::HashSet<String>,
     policy: GatePolicy,
 ) -> GateResult {
-    if view.state == "MERGED" {
+    // Card c03bb62f: "merged" is a FACT (`merged_at` is set), not a state
+    // string. GraphQL (`gh pr view`) reports `state: MERGED`; REST
+    // (`/repos/../pulls/N`, the production ReqwestGhClient) reports
+    // `state: closed` + `merged_at` for the same PR — so a string-only
+    // check let every merged PR read as CLOSED and skipped the reconcile,
+    // leaving cards at Review forever (2026-09-04: three continuum cards
+    // whose PRs merged on GitHub, `airc work merge` refusing "state is
+    // CLOSED"). Decide on the fact; the state string is a hint.
+    if view.state == "MERGED" || view.merged_at.is_some() {
         // Card acd72c81 follow-up: reconcile, don't skip. The kanban
         // projection needs `PullRequestMerged` to transition; the GH
         // merge already happened, so the merger just emits the event.
@@ -1064,6 +1072,46 @@ mod tests {
                 assert_eq!(merged_at_ms, 1780297447000);
             }
             other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    // what this catches: the production ReqwestGhClient reads REST, where a
+    // merged PR is `state: closed` + `merged_at: <ts>`; only GraphQL says
+    // MERGED. A string-only gate skipped every REST-viewed merged PR and the
+    // card sat at Review forever (card c03bb62f, 2026-09-04 receipts:
+    // continuum #3692/#3694/#3695). Merged is the `merged_at` FACT.
+    #[test]
+    fn evaluate_gh_view_reconciles_rest_shaped_closed_plus_merged_at() {
+        let view = crate::gh_client::PrView {
+            state: "CLOSED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: Some("2026-09-04T16:46:08Z".to_string()),
+        };
+        match evaluate_gh_view(&view, &empty_baseline(), empty_policy()) {
+            GateResult::AlreadyMerged { merged_at_ms } => {
+                assert_eq!(
+                    merged_at_ms,
+                    parse_iso8601_to_ms("2026-09-04T16:46:08Z").unwrap()
+                );
+            }
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    // what this catches: a PR closed WITHOUT merging must never be
+    // reconciled as merged — `merged_at` absent means the fact is absent.
+    #[test]
+    fn evaluate_gh_view_does_not_reconcile_closed_unmerged() {
+        let view = crate::gh_client::PrView {
+            state: "CLOSED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: None,
+        };
+        match evaluate_gh_view(&view, &empty_baseline(), empty_policy()) {
+            GateResult::NotReady(reason) => assert!(reason.contains("CLOSED"), "{reason}"),
+            other => panic!("expected NotReady, got {other:?}"),
         }
     }
 

--- a/crates/airc-lib/src/gh/client.rs
+++ b/crates/airc-lib/src/gh/client.rs
@@ -352,12 +352,20 @@ pub fn parse_check_runs(json: &[u8]) -> Result<Vec<GhCheck>, GhError> {
         check_runs: Vec<RestRun>,
     }
     let env: Envelope = serde_json::from_slice(json)?;
+    // Card c03bb62f: REST speaks lowercase (`success`, `completed`);
+    // GraphQL — and every consumer of `GhCheck` (the merge gate's
+    // `Some("SUCCESS")` / `Some("COMPLETED")` arms, the strictly-less-red
+    // baseline's `FAILURE` filter) — speaks UPPERCASE. Passing REST through
+    // verbatim made every completed check read as in-flight, so the
+    // production ReqwestGhClient merger could only ever merge via the
+    // pending-timeout bypass and its baseline was always empty. One
+    // vocabulary at the parser: GhCheck is GraphQL-cased, whoever produced it.
     Ok(env
         .check_runs
         .into_iter()
         .map(|r| GhCheck {
-            conclusion: r.conclusion,
-            status: r.status,
+            conclusion: r.conclusion.map(|c| c.to_ascii_uppercase()),
+            status: r.status.map(|s| s.to_ascii_uppercase()),
             name: r.name,
             started_at: r.started_at,
         })
@@ -607,6 +615,25 @@ mod tests {
         let parsed: GhCheck = serde_json::from_value(json).expect("PR-shape decodes");
         assert_eq!(parsed.started_at.as_deref(), Some("2026-05-29T03:29:46Z"));
         assert_eq!(parsed.status.as_deref(), Some("IN_PROGRESS"));
+    }
+
+    // what this catches: REST check-runs are lowercase (`success`/`completed`)
+    // and the merge gate matches GraphQL's `SUCCESS`/`COMPLETED`; passed
+    // through verbatim, five green checks read as "5 check(s) still
+    // running" (card c03bb62f, 2026-09-04: continuum #3693/#3696/#3699
+    // all-green on GitHub, `airc work merge` refusing). GhCheck must be
+    // GraphQL-cased regardless of which client produced it.
+    #[test]
+    fn parse_check_runs_normalizes_rest_lowercase_to_graphql_case() {
+        let json = br#"{"total_count":2,"check_runs":[
+            {"name":"cargo test","status":"completed","conclusion":"success","started_at":"2026-09-04T17:36:00Z"},
+            {"name":"cargo check","status":"in_progress","conclusion":null}
+        ]}"#;
+        let runs = parse_check_runs(json).expect("parse");
+        assert_eq!(runs[0].status.as_deref(), Some("COMPLETED"));
+        assert_eq!(runs[0].conclusion.as_deref(), Some("SUCCESS"));
+        assert_eq!(runs[1].status.as_deref(), Some("IN_PROGRESS"));
+        assert_eq!(runs[1].conclusion, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

`evaluate_gh_view` decides "already merged" on the **fact** (`merged_at.is_some()`), not the state string; `ReqwestGhClient::pr_view` normalizes `state` to `MERGED` when `merged_at` is set so `PrView.state` means one thing across both clients. Two gate tests: REST-shaped `CLOSED + merged_at` → `AlreadyMerged`; `CLOSED` without `merged_at` → `NotReady` (never reconcile an unmerged close).

## Why

The reconcile branch (card acd72c81) only fired on `state == "MERGED"` — GraphQL's vocabulary (`gh pr view`). Production runs `gh_reqwest::production_gh_client()`, and REST reports a merged PR as `state: closed` + `merged_at: <ts>`, uppercased to `CLOSED`. So the merger and `airc work merge` skipped every merged PR (`NotReady("PR state is CLOSED (not OPEN)")`) and the card sat at **Review forever** with a stale lease — the board lying to every agent and persona reading it.

Receipts (2026-09-04): continuum cards 0797e204 / 94179b72 / bf9409ca, PRs #3692 / #3694 / #3695 merged on GitHub, `airc work merge` refusing "state is CLOSED"; the June `merger.log` shows the same skip class.

## Constraints from BigMama (card-closer scars)

- **Idempotent**: the merger polls Review cards; once the projection transitions on `PullRequestMerged` the card leaves Review and is not re-seen. A closed-unmerged PR stays `NotReady` — no reconcile, no thrash.
- **Actor-stamped as the daemon**: unchanged — reconcile goes through the existing `mark_merged_and_reclaim` → `MarkPullRequestMerged` path, the same one the merger already uses for its own merges.

## Verification

`cargo fmt --check`, `cargo clippy -p airc-cli --lib --bins -D warnings`, `cargo test -p airc-cli --lib evaluate_gh_view` (existing acd72c81 tests + the two new ones). Live: the IntelMac merger daemon (`airc work merger run`) is running against the three stale cards above — they should transition on the first poll after this lands.

## Refs

- airc card: c03bb62f · continuum a466fdd4 (refusal legibility, same "board must not lie" class) · acd72c81 (the reconcile this completes) · d5b7b07d (strictly-less-red gate, untouched)
