### PR TITLE
refactor(gh): one dialect boundary — PrView/GhCheck are built by from_rest / from_graphql, so the gate never sees dialect

### DIFF
--- a/crates/airc-cli/src/gh_reqwest.rs
+++ b/crates/airc-cli/src/gh_reqwest.rs
@@ -345,47 +345,10 @@ impl GhClient for ReqwestGhClient {
         let runs_bytes = runs_resp.bytes().await.map_err(map_reqwest_error)?;
         let check_runs = airc_lib::gh::client::parse_check_runs(&runs_bytes)?;
 
-        let state = pr_json
-            .get("state")
-            .and_then(|s| s.as_str())
-            .unwrap_or("")
-            .to_uppercase();
-        // GitHub's mergeable field is tri-state: null (computing), true
-        // (MERGEABLE), false (CONFLICTING). gh exposes the same as the
-        // string variants.
-        let mergeable = match pr_json.get("mergeable") {
-            Some(serde_json::Value::Bool(true)) => "MERGEABLE",
-            Some(serde_json::Value::Bool(false)) => "CONFLICTING",
-            _ => "UNKNOWN",
-        }
-        .to_string();
-
-        // `mergedAt` is populated by GitHub's REST API only when the
-        // PR has been merged. For OPEN PRs the field is absent or
-        // null; we surface it as `None`. The merger's reconcile path
-        // (card acd72c81 follow-up) reads this to emit
-        // `PullRequestMerged` with the canonical GitHub timestamp.
-        let merged_at = pr_json
-            .get("merged_at")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-        // Card c03bb62f: REST says `closed` for a merged PR; GraphQL (the
-        // `gh pr view` client) says `MERGED`. One vocabulary for `state`
-        // across both clients — the gate decides on `merged_at` regardless,
-        // but a reader of `PrView.state` must not be told CLOSED when the
-        // PR merged.
-        let state = if merged_at.is_some() {
-            "MERGED".to_string()
-        } else {
-            state
-        };
-
-        Ok(PrView {
-            state,
-            mergeable,
-            status_check_rollup: Some(check_runs),
-            merged_at,
-        })
+        // Card fc483e57: the REST→canonical translation lives beside its
+        // GraphQL twin in airc-lib, not here. This client's job is the two
+        // HTTP calls; the dialect boundary owns the vocabulary.
+        Ok(PrView::from_rest(&pr_json, check_runs))
     }
 
     async fn pr_create(&self, args: PrCreateArgs) -> Result<PrCreated, GhError> {

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -414,7 +414,17 @@ pub(crate) fn baseline_failing_names(
 }
 
 /// Decide whether a PR is ready to merge, given the parsed `gh pr
-/// view` payload. Pure — no IO, no async. First-cut policy:
+/// view` payload. Pure — no IO, no async.
+///
+/// CONTRACT (card fc483e57): this function NEVER sees dialect. Its
+/// [`PrView`] comes from `PrView::from_graphql` / `PrView::from_rest`,
+/// which emit the canonical (GraphQL) vocabulary — so `MERGED`,
+/// `SUCCESS`, `COMPLETED` are matched as written, and a REST/GraphQL
+/// difference is fixed at that boundary, never here. Do not add a
+/// `to_uppercase()` or a `state == "closed"` arm below; add it to
+/// `canonicalize`.
+///
+/// First-cut policy:
 ///
 /// - state must be `OPEN` (not already MERGED/CLOSED)
 /// - mergeable must not be `CONFLICTING` (no rebase needed)

--- a/crates/airc-lib/src/gh/client.rs
+++ b/crates/airc-lib/src/gh/client.rs
@@ -307,8 +307,97 @@ pub struct MergeReceipt {
 /// Pure — synthetic JSON in, typed value out. The merger and the
 /// close-guard both depend on this shape, so this is where the
 /// schema round-trip is pinned in tests.
+///
+/// Alias for [`PrView::from_graphql`]; the constructor is the boundary
+/// (card fc483e57) and this name is kept for existing callers.
 pub fn parse_pr_view(json: &[u8]) -> Result<PrView, GhError> {
-    Ok(serde_json::from_slice(json)?)
+    PrView::from_graphql(json)
+}
+
+/// THE DIALECT BOUNDARY (card fc483e57).
+///
+/// GitHub speaks two dialects for the same facts: GraphQL (what
+/// `gh pr view --json` emits — `MERGED`, `SUCCESS`, `COMPLETED`,
+/// `mergedAt`) and REST (what `/repos/../pulls/N` emits — `closed` +
+/// `merged_at`, `success`, `completed`, `started_at`). Consumers —
+/// above all the merger's `evaluate_gh_view` — read ONE vocabulary and
+/// must never branch on which client produced the value.
+///
+/// Both bugs behind card c03bb62f were dialect leaking past this line
+/// at two different places: a merged PR read as `CLOSED` (so the
+/// reconcile never fired and cards sat at Review forever), and green
+/// checks read as in-flight (so the production merger could only ever
+/// merge through the pending-timeout bypass). Patching each site
+/// separately would have meant a third patch for the third difference.
+///
+/// So: [`PrView`] and [`GhCheck`] are constructed HERE, through
+/// `from_graphql` / `from_rest`, and both emit the canonical
+/// (GraphQL) vocabulary. Add a new dialect difference to
+/// `canonicalize`, never to a consumer.
+impl PrView {
+    /// `gh pr view --json state,mergeable,statusCheckRollup,mergedAt`.
+    /// Already canonical on the wire; canonicalized anyway so the two
+    /// constructors are interchangeable by contract, not by luck.
+    pub fn from_graphql(json: &[u8]) -> Result<PrView, GhError> {
+        let mut view: PrView = serde_json::from_slice(json)?;
+        view.canonicalize();
+        Ok(view)
+    }
+
+    /// REST `/repos/{owner}/{repo}/pulls/{n}` plus the separately
+    /// fetched check-runs for its head SHA (REST has no rollup field).
+    pub fn from_rest(pr_json: &serde_json::Value, checks: Vec<GhCheck>) -> PrView {
+        // GitHub's REST `mergeable` is tri-state: null (still
+        // computing), true, false. GraphQL names those states.
+        let mergeable = match pr_json.get("mergeable") {
+            Some(serde_json::Value::Bool(true)) => "MERGEABLE",
+            Some(serde_json::Value::Bool(false)) => "CONFLICTING",
+            _ => "UNKNOWN",
+        }
+        .to_string();
+        let mut view = PrView {
+            state: pr_json
+                .get("state")
+                .and_then(|s| s.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            mergeable,
+            status_check_rollup: Some(checks),
+            merged_at: pr_json
+                .get("merged_at")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        };
+        view.canonicalize();
+        view
+    }
+
+    /// The whole dialect translation, in one place.
+    fn canonicalize(&mut self) {
+        self.state = self.state.to_ascii_uppercase();
+        self.mergeable = self.mergeable.to_ascii_uppercase();
+        // A merged PR is `closed` in REST and `MERGED` in GraphQL. The
+        // fact is `merged_at`; the state string follows it.
+        if self.merged_at.is_some() {
+            self.state = "MERGED".to_string();
+        }
+        for check in self.status_check_rollup.iter_mut().flatten() {
+            check.canonicalize();
+        }
+    }
+}
+
+impl GhCheck {
+    /// REST spells conclusions/statuses in lowercase (`success`,
+    /// `completed`); GraphQL — and every consumer — in UPPERCASE.
+    fn canonicalize(&mut self) {
+        if let Some(c) = self.conclusion.as_mut() {
+            c.make_ascii_uppercase();
+        }
+        if let Some(s) = self.status.as_mut() {
+            s.make_ascii_uppercase();
+        }
+    }
 }
 
 /// Decode `gh issue view --json number,title,body,state`. Pure — JSON
@@ -334,6 +423,10 @@ pub fn parse_issue_view(json: &[u8]) -> Result<IssueView, GhError> {
 /// differs from the GraphQL `startedAt` here); we accept both via a
 /// custom Deserialize because [`GhCheck`] is the one struct shared
 /// across both code paths.
+///
+/// Canonicalizes each run through [`GhCheck::canonicalize`] — the same
+/// dialect boundary [`PrView::from_rest`] uses (card fc483e57), so a
+/// consumer never sees REST's lowercase.
 pub fn parse_check_runs(json: &[u8]) -> Result<Vec<GhCheck>, GhError> {
     #[derive(Deserialize)]
     struct RestRun {
@@ -352,22 +445,18 @@ pub fn parse_check_runs(json: &[u8]) -> Result<Vec<GhCheck>, GhError> {
         check_runs: Vec<RestRun>,
     }
     let env: Envelope = serde_json::from_slice(json)?;
-    // Card c03bb62f: REST speaks lowercase (`success`, `completed`);
-    // GraphQL — and every consumer of `GhCheck` (the merge gate's
-    // `Some("SUCCESS")` / `Some("COMPLETED")` arms, the strictly-less-red
-    // baseline's `FAILURE` filter) — speaks UPPERCASE. Passing REST through
-    // verbatim made every completed check read as in-flight, so the
-    // production ReqwestGhClient merger could only ever merge via the
-    // pending-timeout bypass and its baseline was always empty. One
-    // vocabulary at the parser: GhCheck is GraphQL-cased, whoever produced it.
     Ok(env
         .check_runs
         .into_iter()
-        .map(|r| GhCheck {
-            conclusion: r.conclusion.map(|c| c.to_ascii_uppercase()),
-            status: r.status.map(|s| s.to_ascii_uppercase()),
-            name: r.name,
-            started_at: r.started_at,
+        .map(|r| {
+            let mut check = GhCheck {
+                conclusion: r.conclusion,
+                status: r.status,
+                name: r.name,
+                started_at: r.started_at,
+            };
+            check.canonicalize();
+            check
         })
         .collect())
 }
@@ -634,6 +723,52 @@ mod tests {
         assert_eq!(runs[0].conclusion.as_deref(), Some("SUCCESS"));
         assert_eq!(runs[1].status.as_deref(), Some("IN_PROGRESS"));
         assert_eq!(runs[1].conclusion, None);
+    }
+
+    // what this catches: the dialect boundary must make the two
+    // constructors interchangeable — a merged PR is `closed` + merged_at in
+    // REST and `MERGED` in GraphQL, and checks are lowercase in REST. Both
+    // must land on the canonical vocabulary the merge gate matches, or the
+    // gate silently misreads (card c03bb62f: merged PRs left cards at
+    // Review; green checks read as in-flight). Card fc483e57.
+    #[test]
+    fn from_rest_and_from_graphql_agree_on_the_canonical_vocabulary() {
+        let rest_pr = serde_json::json!({
+            "state": "closed",
+            "mergeable": true,
+            "merged_at": "2026-09-04T18:01:58Z"
+        });
+        let rest_checks = parse_check_runs(
+            br#"{"check_runs":[{"name":"cargo test","status":"completed","conclusion":"success"}]}"#,
+        )
+        .expect("rest checks parse");
+        let from_rest = PrView::from_rest(&rest_pr, rest_checks);
+
+        let from_graphql = PrView::from_graphql(
+            br#"{"state":"MERGED","mergeable":"MERGEABLE","mergedAt":"2026-09-04T18:01:58Z",
+                 "statusCheckRollup":[{"name":"cargo test","status":"COMPLETED","conclusion":"SUCCESS"}]}"#,
+        )
+        .expect("graphql parses");
+
+        assert_eq!(from_rest, from_graphql, "the dialects must converge");
+        assert_eq!(from_rest.state, "MERGED");
+        assert_eq!(from_rest.mergeable, "MERGEABLE");
+        let check = &from_rest.status_check_rollup.as_ref().unwrap()[0];
+        assert_eq!(check.status.as_deref(), Some("COMPLETED"));
+        assert_eq!(check.conclusion.as_deref(), Some("SUCCESS"));
+    }
+
+    // what this catches: a PR closed WITHOUT merging keeps its real state —
+    // the boundary normalizes vocabulary, it must not invent the merge fact.
+    #[test]
+    fn from_rest_keeps_closed_when_never_merged() {
+        let view = PrView::from_rest(
+            &serde_json::json!({"state": "closed", "mergeable": false}),
+            Vec::new(),
+        );
+        assert_eq!(view.state, "CLOSED");
+        assert_eq!(view.mergeable, "CONFLICTING");
+        assert_eq!(view.merged_at, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

One dialect boundary. `PrView` and `GhCheck` are now built through `PrView::from_graphql` / `PrView::from_rest`, which both run a single private `canonicalize`:

- `state` ← uppercased, then forced to `MERGED` when `merged_at` is set (the fact, not the string)
- `mergeable` ← uppercased / mapped from REST's tri-state bool
- each check's `status` + `conclusion` ← uppercased (`GhCheck::canonicalize`, also used by `parse_check_runs`)

`ReqwestGhClient::pr_view` is now two HTTP calls plus `PrView::from_rest` — the REST→canonical translation moved out of the client and sits beside its GraphQL twin. `evaluate_gh_view`'s doc states the contract: **it never sees dialect** — "do not add a `to_uppercase()` or a `state == \"closed\"` arm here; add it to `canonicalize`."

## Why

M5's note on #1372: that PR fixed two REST-vs-GraphQL differences at two separate sites, so a third would have landed as a third patch in a third place. Both bugs were the same class and both silently disabled the production merger — merged PRs left cards at `Review` forever, and green checks read as in-flight so it could only merge through the pending-timeout bypass. The compression principle says one place: the constructors.

## Tests

Tests of the boundary, not of each consumer:

- `from_rest_and_from_graphql_agree_on_the_canonical_vocabulary` — the same merged PR, expressed in each dialect, must produce an **equal** `PrView`.
- `from_rest_keeps_closed_when_never_merged` — the boundary normalizes vocabulary; it must never invent the merge fact.

Plus the existing gate + gh-client suites unchanged (they now exercise canonical input by construction).

## Refs

- airc cards: fc483e57 (this) · c03bb62f / #1372 (the two patches this compresses) · 5e04ab56 (hardcoded `rust-rewrite` — same one-source-of-truth family)
- CLAUDE.md § THE COMPRESSION PRINCIPLE — one logical decision, one place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
