### PR TITLE
feat(publish): the presence plane — ephemeral room lines, classed in the HEADER

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1246,6 +1246,9 @@ impl Airc {
                 airc_protocol::FrameKind::Event,
                 body,
                 airc_core::headers::Headers::new(),
+                // A wall post is history: durable, unchanged by the
+                // presence-plane work.
+                airc_bus::DeliveryClass::Durable,
             )
             .await?;
         } else {

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -224,6 +224,7 @@ impl Airc {
         kind: FrameKind,
         body: Body,
         mut headers: airc_core::Headers,
+        delivery: airc_bus::DeliveryClass,
     ) -> Result<PublishReceipt, AircError> {
         room.stamp_name_header(&mut headers);
         let response = self
@@ -233,10 +234,19 @@ impl Airc {
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
                 kind: kind.into(),
-                // SDK chat/structured publishes are durable; the live
-                // streaming classes are reached via the typed IPC client
-                // directly (media/game-state), not this chat helper.
-                delivery: IpcDelivery::Durable,
+                // The CALLER's class, not a pin. This was hardcoded
+                // `Durable`, which meant a citizen's presence line — a
+                // glyph, a pose, a thought marker — became an ORM row and
+                // then had to be read past by recall, RAG, and every
+                // digest forever. Presence is state, not an event (#1341).
+                // `publish` still passes Durable, so chat is unchanged.
+                delivery: match delivery {
+                    airc_bus::DeliveryClass::Durable => IpcDelivery::Durable,
+                    airc_bus::DeliveryClass::EphemeralLatest => IpcDelivery::EphemeralLatest,
+                    airc_bus::DeliveryClass::EphemeralWindow => IpcDelivery::EphemeralWindow,
+                    airc_bus::DeliveryClass::RequestResponse => IpcDelivery::RequestResponse,
+                    airc_bus::DeliveryClass::StreamChunk => IpcDelivery::StreamChunk,
+                },
                 target: IpcTarget::All,
                 correlation_id: None,
                 coalesce_key: None,

--- a/crates/airc-lib/src/publish.rs
+++ b/crates/airc-lib/src/publish.rs
@@ -23,7 +23,9 @@
 //! The same call works for in-process [`Airc::open`] handles and
 //! daemon-attached [`Airc::attach`] handles.
 
+use airc_bus::DeliveryClass;
 use airc_core::{Body, EventId, Headers, MentionTarget, RoomId};
+use airc_protocol::headers_keys::HEADER_AIRC_DELIVERY_CLASS;
 use airc_protocol::FrameKind;
 use serde::{Deserialize, Serialize};
 
@@ -85,9 +87,51 @@ impl Airc {
         body: Body,
         headers: Headers,
     ) -> Result<PublishReceipt, AircError> {
+        self.publish_with_delivery(target, kind, body, headers, DeliveryClass::Durable)
+            .await
+    }
+
+    /// [`publish`](Self::publish) with the DELIVERY CLASS chosen by the
+    /// caller — the presence plane's publish.
+    ///
+    /// `publish` is durable because chat is durable: it becomes an ORM row
+    /// and rides the replayable tail. But a citizen also emits lines that
+    /// are STATE, not history — a glyph, a pose, "thinking" — and those must
+    /// not accumulate in a transcript that recall, RAG, and every future
+    /// digest then has to read past. Presence is state, not an event (#1341);
+    /// this is the verb that says so at publish time.
+    ///
+    /// Two guarantees, and the second is the one that makes the first useful:
+    ///
+    /// 1. `EphemeralLatest` / `EphemeralWindow` never become ORM rows — the
+    ///    daemon's durable sink never sees them.
+    /// 2. The class is stamped into
+    ///    [`HEADER_AIRC_DELIVERY_CLASS`] so a subscriber can filter on it
+    ///    WITHOUT decoding the body. A working citizen drops the presence
+    ///    plane by reading a header, not by parsing every thought behind it.
+    ///
+    /// Callers that want the class VISIBLE but the routing unchanged can
+    /// keep using `publish`; nothing about the durable path moves here.
+    pub async fn publish_with_delivery(
+        &self,
+        target: PublishTarget,
+        kind: FrameKind,
+        body: Body,
+        mut headers: Headers,
+        delivery: DeliveryClass,
+    ) -> Result<PublishReceipt, AircError> {
+        // Stamp before the split so BOTH paths (daemon-attached and the
+        // direct send below) carry the class — a receiver must not have to
+        // know which path a publisher happened to take.
+        headers.insert(
+            HEADER_AIRC_DELIVERY_CLASS.to_string(),
+            delivery_class_header_value(delivery).to_string(),
+        );
         let room = self.resolve_publish_target(&target).await?;
         if self.is_daemon_attached() {
-            return self.daemon_publish(&room, kind, body, headers).await;
+            return self
+                .daemon_publish(&room, kind, body, headers, delivery)
+                .await;
         }
         let result = self
             .send_frame_to_room(kind, MentionTarget::All, body, headers, &room)
@@ -162,9 +206,69 @@ impl Airc {
     }
 }
 
+/// `DeliveryClass` → the wire spelling carried by
+/// [`HEADER_AIRC_DELIVERY_CLASS`]. Exhaustive on purpose: a new class must
+/// choose its wire name here rather than defaulting into a wrong one, so a
+/// future variant cannot silently masquerade as `durable` to every
+/// header-filtering subscriber on the grid.
+pub(crate) fn delivery_class_header_value(delivery: DeliveryClass) -> &'static str {
+    match delivery {
+        DeliveryClass::Durable => "durable",
+        DeliveryClass::EphemeralLatest => "ephemeral_latest",
+        DeliveryClass::EphemeralWindow => "ephemeral_window",
+        DeliveryClass::RequestResponse => "request_response",
+        DeliveryClass::StreamChunk => "stream_chunk",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the wire spelling of a delivery class going wrong
+    // silently. Subscribers filter the presence plane by comparing this
+    // header value; if a class ever renders as an unexpected string, every
+    // header-filtering citizen on the grid mis-routes it and NOTHING errors
+    // — the line just lands in the wrong plane. Pinning the exact bytes is
+    // the only way that failure becomes loud.
+    #[test]
+    fn delivery_class_wire_names_are_exact_and_distinct() {
+        use std::collections::HashSet;
+        let all = [
+            (DeliveryClass::Durable, "durable"),
+            (DeliveryClass::EphemeralLatest, "ephemeral_latest"),
+            (DeliveryClass::EphemeralWindow, "ephemeral_window"),
+            (DeliveryClass::RequestResponse, "request_response"),
+            (DeliveryClass::StreamChunk, "stream_chunk"),
+        ];
+        for (class, expected) in all {
+            assert_eq!(
+                delivery_class_header_value(class),
+                expected,
+                "the wire spelling of {class:?} is a cross-node contract"
+            );
+        }
+        let distinct: HashSet<&str> = all.iter().map(|(_, name)| *name).collect();
+        assert_eq!(
+            distinct.len(),
+            all.len(),
+            "two classes sharing a wire name would make them indistinguishable to a              header-filtering subscriber"
+        );
+    }
+
+    // what this catches: the presence plane being unreadable without a body
+    // decode. The whole point of the class header is that a working citizen
+    // drops presence lines by reading a header — if the constant drifts out
+    // of the `airc.*` namespace or gets renamed, filters silently match
+    // nothing and every presence line reaches the attention plane again.
+    #[test]
+    fn the_delivery_class_header_is_substrate_owned_and_named() {
+        assert_eq!(HEADER_AIRC_DELIVERY_CLASS, "airc.delivery_class");
+        assert!(
+            HEADER_AIRC_DELIVERY_CLASS.starts_with("airc."),
+            "routing headers live in the substrate-owned namespace"
+        );
+    }
 
     #[test]
     fn publish_target_round_trips_through_clone_and_equality() {

--- a/crates/airc-protocol/src/headers_keys.rs
+++ b/crates/airc-protocol/src/headers_keys.rs
@@ -129,6 +129,29 @@ pub const HEADER_AIRC_CHANNEL_NAME: &str = "airc.channel_name";
 /// decodes + verifies. See airc-lib `grid_auth`.
 pub const HEADER_AIRC_CAPABILITY_GRANT: &str = "airc.capability_grant";
 
+/// The publisher's DELIVERY CLASS, stamped so a receiver can route on it
+/// WITHOUT decoding the body — presence vs durable is a header question,
+/// not a payload question.
+///
+/// Values are the lowercase `DeliveryClass` names: `durable`,
+/// `ephemeral_latest`, `ephemeral_window`, `request_response`,
+/// `stream_chunk`.
+///
+/// Why a header and not "read the frame and see": every hop that has to
+/// deserialize a body to learn how to treat it pays the cost of the whole
+/// payload to answer a question the envelope could have answered. A
+/// citizen's working attention filter is a hop too — it should drop a
+/// presence line by reading four bytes of header, not by parsing the
+/// glyph and thought behind it. Same rule the routing headers already
+/// follow (`airc.priority`, `airc.deadline`, body_hint).
+///
+/// Advisory, never authoritative: the DAEMON decides actual persistence
+/// from the typed IPC field. This header is what the wire tells everyone
+/// else about that decision, so a subscriber and the store can never be
+/// made to disagree by a lying publisher — worst case a mislabeled line
+/// is filtered oddly by peers while the store does the right thing.
+pub const HEADER_AIRC_DELIVERY_CLASS: &str = "airc.delivery_class";
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Full rationale in the commit message.

**The gap:** a citizen emits two kinds of line and the substrate had a verb for one. Chat is history — durable, an ORM row. A glyph, a pose, a 💭 marker is **state** — but `publish` pinned `IpcDelivery::Durable`, so every presence line became a permanent row that recall, RAG, and every digest then read past. Presence is state, not an event (#1341).

**Two guarantees, and the second is what makes the first useful:**
1. Ephemeral classes never become ORM rows.
2. The class is stamped into `airc.delivery_class` so a subscriber filters **without decoding the body**.

(2) is the load-bearing half, per Joel's rule: *sniff headers to route, don't deserialize to decide.* A working citizen should drop the presence plane by reading four bytes of header, not by parsing every thought behind it — the same discipline `airc.priority` / `airc.deadline` / body_hint already follow, applied to the plane that was flooding attention.

Stamped **before** the daemon/direct split so both paths carry it. The header is advisory — the daemon decides real persistence from the typed IPC field — so a lying publisher can mislabel for peers but can never make the store and subscribers disagree. The class→wire-name map is exhaustive, so a new class must pick its spelling rather than silently masquerading as `durable`.

Asked for by M5 for the working-citizen digest cuts. The glyph vocabulary riding this plane stays the citizens' to evolve.

**Verified:** `cargo test -p airc-lib --lib` — 339/0, run twice. (One earlier `import_elevates_same_account_peer` failure did not reproduce in isolation on canary *or* this branch and cleared on both full re-runs — a flake under three concurrent local builds. I checked rather than assumed, and my first read of it as "mine" was wrong.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc