### PR TITLE
fix(work): airc's integration branch is canary — the stale rust-rewrite pin broke `work state review` for airc's own repo

### DIFF
--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -3859,25 +3859,26 @@ mod tests {
     }
 
     /// Card 28f1440c — the airc PR target branch must be the
-    /// substrate's working branch (`rust-rewrite`), NOT the repo's
-    /// GitHub default (`main`). Card 70e87d33 made the base per-repo
-    /// (so continuum can target `canary`), but the airc invariant is
-    /// unchanged and pinned here: a regression that routes airc
-    /// through the GitHub default would surface `main` and silently
-    /// bypass the substrate work the doctrine requires (AGENTS.md §8).
-    /// This is the per-repo-aware successor to the old constant test —
-    /// extended per its own instruction, not deleted.
+    /// substrate's working branch, NOT the repo's GitHub default
+    /// (`main`). Card 70e87d33 made the base per-repo (so continuum can
+    /// target `canary`); card 5e04ab56 retired `rust-rewrite` (deleted
+    /// on the remote — the stale pin broke `airc work state review` for
+    /// airc's own repo) and the working branch is now `canary`. The
+    /// INVARIANT is unchanged and is what this test pins: a regression
+    /// that routes airc through the GitHub default would surface `main`
+    /// and silently bypass the substrate work the doctrine requires
+    /// (AGENTS.md §8).
     #[test]
-    fn airc_pr_base_targets_rust_rewrite_never_main() {
+    fn airc_pr_base_targets_the_working_branch_never_main() {
         std::env::remove_var("AIRC_PR_BASE");
         let airc_repo = airc_work::RepoId::new("CambrianTech/airc").expect("valid repo key");
         let base = crate::work_commands_gh::configured_base_branch(&airc_repo);
         assert_eq!(
             base.as_deref(),
-            Some("rust-rewrite"),
-            "card 28f1440c: airc PR target must be the substrate working \
-             branch, never the repo's GitHub default ('main' on this \
-             repo today)"
+            Some("canary"),
+            "cards 28f1440c + 5e04ab56: airc PR target must be the substrate \
+             working branch (canary), never the repo's GitHub default \
+             ('main' on this repo today)"
         );
         assert_ne!(base.as_deref(), Some("main"));
     }

--- a/crates/airc-cli/src/work_commands_gh.rs
+++ b/crates/airc-cli/src/work_commands_gh.rs
@@ -158,13 +158,22 @@ pub(crate) fn extract_pr_number(url: &str) -> Option<u64> {
 /// `None` to signal "use the repo's GitHub default branch".
 ///
 /// History: card 28f1440c hardcoded a single global `rust-rewrite`
-/// base because airc's substrate work lives on rust-rewrite, not its
-/// GitHub default (`main`). Correct for airc, wrong for every other
+/// base because airc's substrate work lived on rust-rewrite, not its
+/// GitHub default (`main`). Correct for airc then, wrong for every other
 /// repo — continuum has no `rust-rewrite` branch, so `gh pr create
 /// --base rust-rewrite` failed, `PullRequestLinked` never fired, and
 /// the merger never saw the PR. The fix is per-repo, NOT a blanket
-/// default-branch switch (which would re-break airc by landing PRs on
-/// main — the exact fallback 28f1440c set out to refuse).
+/// default-branch switch (which would land PRs on main — the exact
+/// fallback 28f1440c set out to refuse).
+///
+/// Card 5e04ab56: airc's integration branch is now `canary`, and
+/// `rust-rewrite` no longer exists on the remote — so the airc pin
+/// itself had gone stale and `airc work state <card> review` could not
+/// open a PR for the airc repo at all ("No commits between rust-rewrite
+/// and <branch>, Base ref must be a branch"), i.e. the substrate's own
+/// disciplined review path was broken for its own repo. The invariant
+/// 28f1440c protects is unchanged: airc pins its integration branch and
+/// never falls through to `main`; only the branch's name moved.
 ///
 /// `AIRC_PR_BASE` overrides everything (tests / one-offs). The carded
 /// end state surfaces this as `.airc/work.toml` per-repo config; for
@@ -177,7 +186,7 @@ pub(crate) fn configured_base_branch(repo: &airc_work::RepoId) -> Option<String>
         }
     }
     match repo.as_str() {
-        "CambrianTech/airc" => Some("rust-rewrite".to_string()),
+        "CambrianTech/airc" => Some("canary".to_string()),
         "CambrianTech/continuum" => Some("canary".to_string()),
         _ => None,
     }
@@ -423,8 +432,9 @@ mod tests {
         std::env::remove_var("AIRC_PR_BASE");
         assert_eq!(
             configured_base_branch(&repo("CambrianTech/airc")).as_deref(),
-            Some("rust-rewrite"),
-            "airc must pin rust-rewrite, never fall through to main"
+            Some("canary"),
+            "airc must pin its integration branch (canary — card 5e04ab56 \
+             retired rust-rewrite), never fall through to main"
         );
         assert_eq!(
             configured_base_branch(&repo("CambrianTech/continuum")).as_deref(),
@@ -456,7 +466,7 @@ mod tests {
         std::env::set_var("AIRC_PR_BASE", "   ");
         assert_eq!(
             configured_base_branch(&repo("CambrianTech/airc")).as_deref(),
-            Some("rust-rewrite"),
+            Some("canary"),
             "blank AIRC_PR_BASE must not shadow the pinned base"
         );
         std::env::remove_var("AIRC_PR_BASE");

--- a/crates/airc-cli/src/workspace_cli.rs
+++ b/crates/airc-cli/src/workspace_cli.rs
@@ -22,9 +22,13 @@ pub enum WorkspaceAction {
         /// Workspace branch name.
         #[arg(long)]
         branch: String,
-        /// Base branch name.
-        #[arg(long, default_value = "rust-rewrite")]
-        base: String,
+        /// Base branch name. Defaults to the repo's configured
+        /// integration branch (card 5e04ab56: ONE source of truth —
+        /// `configured_base_branch`, the same resolver PR creation
+        /// uses — instead of a second hardcoded name that goes stale
+        /// when the branch is renamed).
+        #[arg(long)]
+        base: Option<String>,
     },
     /// Mark a requested workspace as allocated at a concrete path.
     Allocate {

--- a/crates/airc-cli/src/workspace_commands.rs
+++ b/crates/airc-cli/src/workspace_commands.rs
@@ -15,14 +15,30 @@ pub async fn run_request(
     claim_id: String,
     repo: String,
     branch: String,
-    base: String,
+    base: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = crate::commands::attached_airc(home).await?;
+    let repo = RepoId::new(repo)?;
+    // Card 5e04ab56: resolve the integration branch through the SAME
+    // resolver PR creation uses. A second hardcoded default is how the
+    // old `rust-rewrite` pin went stale in two places at once. No
+    // fallback: an unpinned repo must be told explicitly, loudly
+    // ([[no-fallbacks-ever]]).
+    let base = match base {
+        Some(explicit) => explicit,
+        None => crate::work_commands_gh::configured_base_branch(&repo).ok_or_else(|| {
+            format!(
+                "no integration branch configured for {} — pass --base explicitly \
+                 (or add the repo to configured_base_branch)",
+                repo.as_str()
+            )
+        })?,
+    };
     let workspace_id = airc
         .request_workspace(RequestWorkspace {
             card_id: parse_work_card_id(&card_id)?,
             claim_id: parse_claim_id(&claim_id)?,
-            repo: RepoId::new(repo)?,
+            repo,
             branch: BranchName::new(branch)?,
             base: BranchName::new(base)?,
         })


### PR DESCRIPTION
`rust-rewrite` no longer exists on the remote (git ls-remote --heads
origin -> canary, main), but configured_base_branch still pinned it for
CambrianTech/airc. So `airc work state <card> review` could not open a
PR for the airc repo at all:

  gh pr create skipped — GraphQL: Head sha can't be blank, Base sha
  can't be blank, No commits between rust-rewrite and <branch>,
  Base ref must be a branch

i.e. the substrate's own disciplined review path was broken for its own
repo, and every airc card had to fall back to `gh pr create` +
`airc work link` — the exact bypass the merge gate exists to refuse.
Hit twice today (cards c03bb62f, fc483e57).

Pin airc to canary. The invariant card 28f1440c protects is unchanged
and still pinned by both tests: airc targets its integration branch and
NEVER falls through to the GitHub default (main); only the branch's
name moved.

`airc workspace request --base` carried the same string as its own
clap default_value — one rename, two stale places. It is now optional
and resolves through configured_base_branch, the SAME resolver PR
creation uses; an unpinned repo errors loudly telling you to pass
--base rather than guessing ([[no-fallbacks-ever]]).

Remaining `rust-rewrite` mentions in src are test fixtures using the
name as arbitrary data, plus the origin/rust-rewrite entry in the
dirty-check candidate list (harmless when absent) and historical
comments.

airc card: 5e04ab56

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE