### PR TITLE
fix(test): the handover test picks an identity whose port THIS host will bind (canary red on windows)

### DIFF
--- a/crates/airc-lib/src/lan.rs
+++ b/crates/airc-lib/src/lan.rs
@@ -615,13 +615,41 @@ mod tests {
     /// it fails with an ephemeral port, which is the regression.
     #[tokio::test]
     async fn a_busy_stable_port_is_retried_across_the_restart_handover() {
-        let (_dir, airc) = test_airc().await;
-        let preferred = stable_lan_port(airc.inner.identity.peer_id);
-
-        // Stand in for the outgoing daemon still holding the listener.
-        let outgoing =
-            std::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, preferred)))
-                .expect("test must be able to hold the stable port to simulate the handover");
+        // Find an identity whose derived port this HOST will actually let us
+        // hold. `stable_lan_port` spreads uniformly over the IANA dynamic
+        // range, and a Windows box reserves chunks of that range for
+        // WinNAT/Hyper-V — binding inside a reservation returns
+        // `PermissionDenied` (os 10013) no matter that nothing is listening.
+        // A random identity therefore made this test a coin flip on CI: it
+        // turned canary RED on windows-latest at the `.expect()` below while
+        // passing on every developer box whose exclusions happened to miss.
+        //
+        // Retrying identities is the honest fix, not a skip: the invariant
+        // ("a busy preferred port is retried across the handover") holds for
+        // EVERY identity, so any bindable one proves it. What a skip would
+        // hide — and this does not — is a host where the whole range is
+        // unusable; that still fails, loudly, with the last OS error.
+        const IDENTITY_ATTEMPTS: usize = 24;
+        let mut chosen: Option<(tempfile::TempDir, Airc, u16, std::net::TcpListener)> = None;
+        let mut last_error = None;
+        for _ in 0..IDENTITY_ATTEMPTS {
+            let (dir, airc) = test_airc().await;
+            let preferred = stable_lan_port(airc.inner.identity.peer_id);
+            // Stand in for the outgoing daemon still holding the listener.
+            match std::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, preferred)))
+            {
+                Ok(listener) => {
+                    chosen = Some((dir, airc, preferred, listener));
+                    break;
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+        let (_dir, airc, preferred, outgoing) = chosen.unwrap_or_else(|| {
+            panic!(
+                "no identity out of {IDENTITY_ATTEMPTS} derived a bindable port on this host —                  the dynamic range appears unusable (last error: {last_error:?}). On Windows                  check `netsh interface ipv4 show excludedportrange protocol=tcp`."
+            )
+        });
 
         // Release it partway through the retry window, as a real handover does.
         tokio::spawn(async move {


### PR DESCRIPTION
**My test, my red canary — fixed at once.**

`a_busy_stable_port_is_retried_across_the_restart_handover` failed on windows-latest:

```
lan.rs:624  TcpListener::bind(stable_lan_port(peer_id))
            Os { code: 10013, kind: PermissionDenied }
```

`stable_lan_port` spreads uniformly over the IANA dynamic range, and Windows reserves chunks of it for WinNAT/Hyper-V — binding inside a reservation is refused regardless of whether anything is listening. The identity is random per run, so the test was **a coin flip on the runner's exclusion layout**: green on dev boxes whose ranges happened to miss, red on CI when they didn't.

**Fix:** retry identities (bounded, 24) until one derives a port this host will actually hold. Honest rather than a skip — the invariant holds for *every* identity, so any bindable one proves it. And what a skip would hide, this still surfaces: a host where the whole range is unusable fails loudly, naming the last OS error and the `netsh` command that lists exclusions.

**Worth noting the shape:** the substrate was never wrong. `bind_preferred_or_ephemeral` already retries a refused preferred port then degrades loudly — exactly what a reserved-range host needs. Only the test's own scaffolding, standing in for the outgoing daemon, assumed a bind it had no right to assume.

Thanks to IntelMac for carding it with the root cause (fa9bb57f) rather than just 'CI is red'.

Verified: `cargo test -p airc-lib --lib lan::` — 8 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc