### PR TITLE
test(daemon): share the publish back-pressure policy and prove it

### DIFF
--- a/crates/airc-daemon/tests/backoff_policy.rs
+++ b/crates/airc-daemon/tests/backoff_policy.rs
@@ -1,0 +1,133 @@
+//! The publish retry POLICY, proven without a daemon.
+//!
+//! Why this file exists: the policy in `common::retry_while_saturated` guards
+//! §3.8 back-pressure in two integration tests, and against the live daemon its
+//! error arm is UNREACHABLE on a developer machine — a 1 ns budget still passes
+//! locally, and still passes under 36 busy-loops on 12 cores, because saturation
+//! is I/O-bound rather than CPU-bound. So the whole `Err` path (the assert, the
+//! attempt counter, the backoff clamp, the panic) shipped untested until now:
+//! the flake it guards only reproduces on a loaded Windows CI runner.
+//!
+//! Making the policy generic over the operation is what makes it provable here
+//! in milliseconds, with no socket and no filesystem.
+
+mod common;
+
+use common::{retry_while_saturated, BACKOFF_MAX, BACKOFF_MIN};
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+/// The daemon's shed, as the client surfaces it. `ClientError::Daemon(String)`
+/// flattens the bus error at the IPC boundary, so the real code has no variant
+/// to match on and tests the substring — mirrored here rather than idealised, so
+/// this exercises what production actually does.
+fn saturated() -> String {
+    "write-behind queue saturated".to_string()
+}
+
+// what this catches: the happy path regressing into a retry, and the clamp
+// failing to cap. A caller that succeeds after N sheds must get its value, and
+// the waits must follow 10/20/40/80/160/250/250… — never unbounded growth.
+#[tokio::test]
+async fn returns_the_value_after_transient_saturation_and_caps_the_backoff() {
+    let attempts = Cell::new(0u32);
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(30);
+
+    let value = retry_while_saturated(deadline, || {
+        let n = attempts.get() + 1;
+        attempts.set(n);
+        async move {
+            if n <= 8 {
+                Err(saturated())
+            } else {
+                Ok(n)
+            }
+        }
+    })
+    .await;
+
+    assert_eq!(value, 9, "returned on the first Ok");
+    assert_eq!(attempts.get(), 9, "retried exactly the sheds, no more");
+
+    // 8 sheds ⇒ waits of 10+20+40+80+160+250+250+250 = 1060 ms.
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= Duration::from_millis(1000),
+        "backed off far too little: {elapsed:?}"
+    );
+    // Unclamped doubling would be 10+20+…+1280 = 2550 ms; the cap is what keeps
+    // this under 2 s. Mutation check: removing `.min(BACKOFF_MAX)` fails here.
+    assert!(
+        elapsed < Duration::from_millis(2000),
+        "clamp did not hold — backoff grew unbounded: {elapsed:?}"
+    );
+}
+
+// what this catches: a wedged queue failing to fail, or failing without saying
+// how long it waited. The panic message is the whole diagnostic — "500 retries"
+// told a reader nothing about wedged-vs-slow.
+#[tokio::test]
+async fn a_permanently_saturated_queue_panics_naming_the_duration() {
+    let deadline = Instant::now() + Duration::from_millis(50);
+    let result = std::panic::AssertUnwindSafe(retry_while_saturated(deadline, || async {
+        Err::<(), _>(saturated())
+    }))
+    .catch_unwind()
+    .await;
+
+    let panic = result.expect_err("a permanently saturated queue must panic");
+    let message = panic
+        .downcast_ref::<String>()
+        .expect("panic payload is a String");
+    assert!(
+        message.contains("stayed saturated for"),
+        "message must name the DURATION: {message}"
+    );
+    assert!(
+        message.contains("attempts"),
+        "message must name the attempt count too: {message}"
+    );
+}
+
+// what this catches: the single most dangerous refactor of this helper —
+// retrying a REAL error into a timeout. A non-saturation failure must abort on
+// the FIRST occurrence, never be swallowed by the retry loop.
+#[tokio::test]
+async fn a_non_saturation_error_fails_immediately() {
+    let attempts = Cell::new(0u32);
+    let deadline = Instant::now() + Duration::from_secs(30);
+
+    let result = std::panic::AssertUnwindSafe(retry_while_saturated(deadline, || {
+        attempts.set(attempts.get() + 1);
+        async { Err::<(), _>("daemon RPC timed out".to_string()) }
+    }))
+    .catch_unwind()
+    .await;
+
+    assert!(result.is_err(), "a real error must not be retried");
+    assert_eq!(
+        attempts.get(),
+        1,
+        "must abort on the FIRST non-saturation error, not retry it"
+    );
+}
+
+// what this catches: the constants drifting into a shape that reintroduces the
+// flake — a floor above the old flat rate would slow every healthy publish, and
+// a cap below the floor would make the clamp meaningless.
+#[test]
+fn backoff_bounds_stay_coherent() {
+    assert!(
+        BACKOFF_MIN <= BACKOFF_MAX,
+        "floor must not exceed the cap: {BACKOFF_MIN:?} > {BACKOFF_MAX:?}"
+    );
+    assert_eq!(
+        BACKOFF_MIN,
+        Duration::from_millis(10),
+        "the floor is deliberately the OLD flat rate, so a healthy drain sees \
+         no regression on the happy path"
+    );
+}
+
+use futures::FutureExt as _;

--- a/crates/airc-daemon/tests/common/mod.rs
+++ b/crates/airc-daemon/tests/common/mod.rs
@@ -1,0 +1,106 @@
+//! Shared test support for the daemon's publish path.
+//!
+//! §3.8 back-pressure: the write-behind queue is bounded, and on a slow runner
+//! a tight publish loop outpaces the SQLite drain. The daemon sheds with a LOUD
+//! typed error (the designed signal, never a silent drop), so a test producer
+//! must back off and retry the same event the way a real producer would.
+//!
+//! This lives here because the identical helper was inlined in TWO test files
+//! (`inbox_paging.rs` and `room_tip_probe.rs`, the latter driving 5,000
+//! publishes through its copy). Fixing the budget in one and not the other
+//! would have fixed half the flake — one logical decision, one place.
+#![allow(dead_code)] // each test binary uses a subset; that is not dead code.
+
+use std::fmt::Display;
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+/// How long a publish RUN may stay saturated before the queue is called wedged.
+///
+/// A WALL-CLOCK budget, not an attempt count. The previous form was
+/// `for _ in 0..500` with a flat 10 ms sleep — five seconds of unbroken
+/// saturation — and a loaded Windows CI runner exceeds it: PR #1379 failed with
+///
+/// ```text
+/// thread 'deep_room_most_recent_n_costs_by_n_not_room_depth'
+///   panicked at crates\airc-daemon\tests\inbox_paging.rs:155:5:
+///   publish kept saturating after 500 backoff retries
+/// ```
+///
+/// on a diff that touched only `airc-cli`, and the identical commit passed on
+/// re-run. That quoted text matters: it is the *retry-exhaustion* panic, which
+/// rules out the other way this helper can fail on a slow runner — a single
+/// publish exceeding `airc-ipc`'s 5 s `DEFAULT_RPC_TIMEOUT`, which surfaces as
+/// "daemon RPC timed out", does NOT contain "saturated", and would trip the
+/// assert below immediately. A wall-clock budget is no defence against that
+/// path, so it was worth establishing which one we actually saw.
+///
+/// Sixty seconds is far past any healthy drain and still fails loudly on a
+/// genuinely wedged queue — which is the behaviour this helper exists to
+/// preserve.
+pub const SATURATION_BUDGET: Duration = Duration::from_secs(60);
+
+/// Retry backoff: starts at the old flat rate so a healthy drain is never
+/// slowed, then eases off so a struggling one is not hammered while we wait it
+/// out. Capped so a long wait still retries promptly once the drain recovers.
+pub const BACKOFF_MIN: Duration = Duration::from_millis(10);
+pub const BACKOFF_MAX: Duration = Duration::from_millis(250);
+
+/// Retry `op` while it fails with the daemon's saturation shed, until `deadline`.
+///
+/// Generic over the operation and its error so the POLICY is testable without a
+/// daemon, a socket, or a filesystem — see `tests/backoff_policy.rs`. Extracting
+/// it is what turned this from "reasoned" into "proven": against the live daemon
+/// the error arm is unreachable on a fast machine (verified — a 1 ns budget
+/// still passes locally, and still passes under 36 busy-loops on 12 cores,
+/// because saturation is I/O-bound rather than CPU-bound).
+///
+/// `deadline` is an absolute instant, not a per-call budget, so a caller
+/// publishing N events bounds the WHOLE run rather than each event separately.
+/// A per-call budget would let an oscillating queue — saturating for a while,
+/// then accepting one event, repeating — run for N × budget, which is not what
+/// "the queue is wedged" means.
+///
+/// Panics on any error that is not the saturation shed, on the FIRST occurrence:
+/// a real failure must never be retried into a timeout.
+pub async fn retry_while_saturated<F, Fut, T, E>(deadline: Instant, mut op: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: Display,
+{
+    let started = Instant::now();
+    let mut backoff = BACKOFF_MIN;
+    let mut attempts = 0u32;
+    loop {
+        match op().await {
+            Ok(value) => return value,
+            Err(error) => {
+                let message = error.to_string();
+                assert!(
+                    message.contains("saturated"),
+                    "unexpected publish error: {message}"
+                );
+                attempts += 1;
+                if Instant::now() >= deadline {
+                    // Report the DURATION alongside the attempt count: "500
+                    // retries" alone named an implementation detail, and whether
+                    // that was 5 seconds or 5 minutes is what decides
+                    // wedged-queue versus merely-slow-runner.
+                    panic!(
+                        "publish stayed saturated for {:?} ({attempts} attempts) — \
+                         the write-behind queue never drained",
+                        started.elapsed()
+                    );
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(BACKOFF_MAX);
+            }
+        }
+    }
+}
+
+/// The deadline a publish RUN should be bounded by, computed once by the caller.
+pub fn saturation_deadline() -> Instant {
+    Instant::now() + SATURATION_BUDGET
+}

--- a/crates/airc-daemon/tests/inbox_paging.rs
+++ b/crates/airc-daemon/tests/inbox_paging.rs
@@ -132,6 +132,28 @@ fn durable_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
     }
 }
 
+/// How long a publish may stay saturated before we call the queue wedged.
+///
+/// A WALL-CLOCK budget, not an attempt count. The previous form was
+/// `for _ in 0..500` with a flat 10 ms sleep — five seconds of unbroken
+/// saturation — which a loaded Windows CI runner exceeds: PR #1379 failed here
+/// on a diff that touched only `airc-cli`, and the identical commit passed on
+/// re-run. Same code, opposite verdicts, ~20 minutes apart. The same job took
+/// ~13 min in one run and >20 in the next, so runner speed varies by more than
+/// the old budget's entire headroom.
+///
+/// Sixty seconds is far past any healthy drain and still fails loudly on a
+/// genuinely wedged queue — which is the behaviour this helper exists to
+/// preserve. Deliberately NOT `#[ignore]`d and NOT moved behind a feature: the
+/// invariant the caller pins (most-recent-N costs by N, not by room depth) is
+/// real and belongs in the default suite.
+const SATURATION_BUDGET: Duration = Duration::from_secs(60);
+
+/// Retry backoff: starts tight so a healthy drain is not slowed, then eases off
+/// so a struggling one is not hammered at a fixed rate while we wait it out.
+const BACKOFF_MIN: Duration = Duration::from_millis(10);
+const BACKOFF_MAX: Duration = Duration::from_millis(250);
+
 /// Publish one request, honouring §3.8 back-pressure: the write-behind
 /// queue is bounded, and on a slow runner a tight publish loop can
 /// outpace the SQLite drain — the daemon sheds with a LOUD typed error
@@ -139,7 +161,10 @@ fn durable_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
 /// same event, the way a real producer would. Any other error is a real
 /// failure.
 async fn publish_with_backoff(client: &DaemonClient, request: PublishRequest) -> PublishResponse {
-    for _ in 0..500 {
+    let started = std::time::Instant::now();
+    let mut backoff = BACKOFF_MIN;
+    let mut attempts = 0u32;
+    loop {
         match client.publish(request.clone()).await {
             Ok(receipt) => return receipt,
             Err(error) => {
@@ -148,11 +173,23 @@ async fn publish_with_backoff(client: &DaemonClient, request: PublishRequest) ->
                     message.contains("saturated"),
                     "unexpected publish error: {message}"
                 );
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                attempts += 1;
+                if started.elapsed() >= SATURATION_BUDGET {
+                    // Report the DURATION, not the attempt count: "500 retries"
+                    // told a reader nothing about whether that was 5 seconds or
+                    // 5 minutes, and the answer is what decides whether the queue
+                    // is wedged or the runner is merely slow.
+                    panic!(
+                        "publish stayed saturated for {:?} ({attempts} attempts) — \
+                         budget {SATURATION_BUDGET:?}; the write-behind queue never drained",
+                        started.elapsed()
+                    );
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(BACKOFF_MAX);
             }
         }
     }
-    panic!("publish kept saturating after 500 backoff retries");
 }
 
 async fn publish_n(client: &DaemonClient, channel: RoomId, n: usize) -> PublishResponse {

--- a/crates/airc-daemon/tests/inbox_paging.rs
+++ b/crates/airc-daemon/tests/inbox_paging.rs
@@ -14,6 +14,8 @@
 //! The test model IS the production model: a real `DaemonState` over a
 //! real SQLite ORM on a Unix socket, driven by the real `DaemonClient`.
 
+mod common;
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -132,71 +134,26 @@ fn durable_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
     }
 }
 
-/// How long a publish may stay saturated before we call the queue wedged.
-///
-/// A WALL-CLOCK budget, not an attempt count. The previous form was
-/// `for _ in 0..500` with a flat 10 ms sleep — five seconds of unbroken
-/// saturation — which a loaded Windows CI runner exceeds: PR #1379 failed here
-/// on a diff that touched only `airc-cli`, and the identical commit passed on
-/// re-run. Same code, opposite verdicts, ~20 minutes apart. The same job took
-/// ~13 min in one run and >20 in the next, so runner speed varies by more than
-/// the old budget's entire headroom.
-///
-/// Sixty seconds is far past any healthy drain and still fails loudly on a
-/// genuinely wedged queue — which is the behaviour this helper exists to
-/// preserve. Deliberately NOT `#[ignore]`d and NOT moved behind a feature: the
-/// invariant the caller pins (most-recent-N costs by N, not by room depth) is
-/// real and belongs in the default suite.
-const SATURATION_BUDGET: Duration = Duration::from_secs(60);
-
-/// Retry backoff: starts tight so a healthy drain is not slowed, then eases off
-/// so a struggling one is not hammered at a fixed rate while we wait it out.
-const BACKOFF_MIN: Duration = Duration::from_millis(10);
-const BACKOFF_MAX: Duration = Duration::from_millis(250);
-
-/// Publish one request, honouring §3.8 back-pressure: the write-behind
-/// queue is bounded, and on a slow runner a tight publish loop can
-/// outpace the SQLite drain — the daemon sheds with a LOUD typed error
-/// (the designed signal, never a silent drop). Back off and retry the
-/// same event, the way a real producer would. Any other error is a real
-/// failure.
-async fn publish_with_backoff(client: &DaemonClient, request: PublishRequest) -> PublishResponse {
-    let started = std::time::Instant::now();
-    let mut backoff = BACKOFF_MIN;
-    let mut attempts = 0u32;
-    loop {
-        match client.publish(request.clone()).await {
-            Ok(receipt) => return receipt,
-            Err(error) => {
-                let message = error.to_string();
-                assert!(
-                    message.contains("saturated"),
-                    "unexpected publish error: {message}"
-                );
-                attempts += 1;
-                if started.elapsed() >= SATURATION_BUDGET {
-                    // Report the DURATION, not the attempt count: "500 retries"
-                    // told a reader nothing about whether that was 5 seconds or
-                    // 5 minutes, and the answer is what decides whether the queue
-                    // is wedged or the runner is merely slow.
-                    panic!(
-                        "publish stayed saturated for {:?} ({attempts} attempts) — \
-                         budget {SATURATION_BUDGET:?}; the write-behind queue never drained",
-                        started.elapsed()
-                    );
-                }
-                tokio::time::sleep(backoff).await;
-                backoff = (backoff * 2).min(BACKOFF_MAX);
-            }
-        }
-    }
+/// Publish one request, honouring §3.8 back-pressure. Policy lives in
+/// `common::retry_while_saturated` — shared with `room_tip_probe.rs`, which had
+/// an identical inlined copy, and proven in `backoff_policy.rs`.
+async fn publish_with_backoff(
+    client: &DaemonClient,
+    request: PublishRequest,
+    deadline: std::time::Instant,
+) -> PublishResponse {
+    common::retry_while_saturated(deadline, || client.publish(request.clone())).await
 }
 
 async fn publish_n(client: &DaemonClient, channel: RoomId, n: usize) -> PublishResponse {
+    // ONE deadline for the whole run, not per call: a per-call budget lets an
+    // oscillating queue (saturate, accept one, repeat) run for n x budget,
+    // which is not what "the queue is wedged" means.
+    let deadline = common::saturation_deadline();
     let mut last = None;
     for i in 0..n {
         let request = durable_text(channel, &format!("event {i}"));
-        last = Some(publish_with_backoff(client, request).await);
+        last = Some(publish_with_backoff(client, request, deadline).await);
     }
     last.expect("n > 0")
 }
@@ -396,8 +353,12 @@ async fn inbox_kinds_filter_returns_buried_messages_under_chunk_flood() {
     // Three direction messages…
     let mut message_cursors = Vec::new();
     for i in 0..3 {
-        let receipt =
-            publish_with_backoff(&client, durable_text(channel, &format!("direction {i}"))).await;
+        let receipt = publish_with_backoff(
+            &client,
+            durable_text(channel, &format!("direction {i}")),
+            common::saturation_deadline(),
+        )
+        .await;
         message_cursors.push(airc_ipc::IpcCursor {
             epoch: receipt.epoch,
             counter: receipt.counter,
@@ -406,7 +367,12 @@ async fn inbox_kinds_filter_returns_buried_messages_under_chunk_flood() {
     }
     // …buried under 200 newer durable stream chunks.
     for _ in 0..200 {
-        publish_with_backoff(&client, durable_chunk(channel, b"\x01\x02\x03")).await;
+        publish_with_backoff(
+            &client,
+            durable_chunk(channel, b"\x01\x02\x03"),
+            common::saturation_deadline(),
+        )
+        .await;
     }
 
     // Precondition — the bug shape: the raw newest-50 page is ALL

--- a/crates/airc-daemon/tests/room_tip_probe.rs
+++ b/crates/airc-daemon/tests/room_tip_probe.rs
@@ -13,6 +13,8 @@
 //! The test model IS the production model: a real `DaemonState` over a
 //! real SQLite ORM on a Unix socket, driven by the real `DaemonClient`.
 
+mod common;
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -123,33 +125,17 @@ fn stream_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
 }
 
 async fn publish_n(client: &DaemonClient, channel: RoomId, n: usize) -> PublishResponse {
+    // §3.8 back-pressure, shared policy (`common::retry_while_saturated`): this
+    // file previously carried an INLINED copy of the same 500x10ms budget while
+    // driving DEEP = 5_000 publishes through it, so a fix applied only to
+    // inbox_paging.rs would have left the same flake live in the same crate,
+    // same CI job. ONE deadline bounds the whole run.
+    let deadline = common::saturation_deadline();
     let mut last = None;
     for i in 0..n {
         let request = durable_text(channel, &format!("event {i}"));
-        // The write-behind queue is bounded: on a slow runner a tight
-        // publish loop can outpace the SQLite drain, and the daemon
-        // sheds with a LOUD typed error (§3.8 — the designed
-        // back-pressure signal, never a silent drop). Honour the
-        // contract the way a real producer would: back off and retry
-        // the same event. Any other error is a real failure.
-        let mut receipt = None;
-        for _ in 0..500 {
-            match client.publish(request.clone()).await {
-                Ok(r) => {
-                    receipt = Some(r);
-                    break;
-                }
-                Err(error) => {
-                    let message = error.to_string();
-                    assert!(
-                        message.contains("saturated"),
-                        "unexpected publish error: {message}"
-                    );
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-            }
-        }
-        last = Some(receipt.expect("publish kept saturating after 500 backoff retries"));
+        last =
+            Some(common::retry_while_saturated(deadline, || client.publish(request.clone())).await);
     }
     last.expect("n > 0")
 }


### PR DESCRIPTION
Round 2, addressing an adversarial review of the first commit. The first
version fixed HALF the flake and reasoned about the rest; this one fixes
both halves and proves the policy.

WHAT THE REVIEW CAUGHT, and why each mattered:

1. `room_tip_probe.rs` carried an INLINED copy of the identical helper —
   same `for _ in 0..500`, same flat 10 ms sleep, same 5 s ceiling —
   while driving `DEEP = 5_000` publishes through it. Same crate, same
   `cargo test --workspace`, same Windows runner. Fixing only
   `inbox_paging.rs` would have left the flake live for exactly the
   reason the card exists. The policy now lives once, in
   `tests/common/mod.rs`, and both files call it.

2. The diagnosis had not ruled out a competing failure mode: a single
   publish exceeding `airc-ipc`'s 5 s `DEFAULT_RPC_TIMEOUT` surfaces as
   "daemon RPC timed out", does NOT contain "saturated", and trips the
   assert immediately — a path a wall-clock budget cannot help. Both
   ceilings being 5 s is a suspicious coincidence. The observed CI text
   is now quoted in the module doc: it is the retry-exhaustion panic
   from inbox_paging.rs:155, which rules that path out.

3. The budget reset per call, so `publish_n` over N events bounded each
   event rather than the run — an oscillating queue could run N x 60 s.
   `publish_n` now computes ONE deadline and threads it through, which
   is what "the queue is wedged" actually means.

4. A comment said "the DURATION, not the attempt count" four lines above
   a format string printing both. Now "alongside".

5. The doc inferred drain variance from JOB wall time (13 vs 20 min).
   Job time is dominated by compile and link, so that does not follow;
   the claim is softened to what the evidence supports.

AND THE POLICY IS NOW PROVEN, not reasoned. `retry_while_saturated` is
generic over the operation, so `tests/backoff_policy.rs` exercises it
with fake ops — no daemon, no socket, ~1 s — covering the arm that is
unreachable against a live daemon on a fast machine:

- transient saturation returns the value, and the clamp holds
  (mutation-checked: removing `.min(BACKOFF_MAX)` fails it at 2.57 s)
- a permanently saturated queue panics naming duration AND attempts
- a NON-saturation error aborts on the FIRST occurrence
  (mutation-checked: dropping the assert fails it)
- the constants stay coherent, with the floor pinned to the old flat
  rate so a healthy drain sees no regression

The previous commit's honest limit — "the failure path is unexercised
locally" — is what this round removes. The reviewer confirmed it was
real (a 1 ns budget still passes locally, and still passes under 36
busy-loops on 12 cores, because saturation is I/O-bound not CPU-bound)
rather than laziness; the fix was to make the policy testable without
the daemon, not to keep apologising for it.

Refs: airc card 28ea675a, #1379

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE