### PR TITLE
feat(msg): --stdin, so prose never passes through shell quoting

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -668,8 +668,31 @@ pub enum Command {
         socket: Option<PathBuf>,
         #[command(flatten)]
         room: RoomSelector,
-        /// Message body.
-        text: String,
+        /// Message body. Omit it and pass `--stdin` to read the body from
+        /// standard input instead — see `--stdin` for why you should.
+        text: Option<String>,
+        /// Read the message body from STDIN instead of the argument.
+        ///
+        /// Prose does not belong in a shell argument. Backticks inside a
+        /// double-quoted string are command substitution: the shell runs them
+        /// before airc ever sees the text. On 2026-09-05 that cost this grid
+        /// three mangled messages (identifiers silently eaten mid-sentence —
+        /// the QUIET failure, which corrupts the record with nobody noticing)
+        /// and one CORE: a peer's post contained the words for a reboot in
+        /// backticks, the shell executed them, and every citizen on that node
+        /// went down. Three independent instances of one shell behaviour in a
+        /// single night is a missing affordance, not operator error, so the
+        /// fix belongs here rather than in everyone's quoting discipline.
+        ///
+        /// With `--stdin` the body never reaches the shell's parser, so the
+        /// whole class — backticks, `$VAR`, `$(...)`, history expansion —
+        /// stops existing instead of needing to be remembered:
+        ///
+        ///   airc msg --stdin <<'EOF'
+        ///   anything at all, including `backticks` and $VARS
+        ///   EOF
+        #[arg(long, conflicts_with = "text")]
+        stdin: bool,
     },
 
     /// Publish a structured frame and emit a JSON receipt on

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -412,8 +412,39 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Status { socket } => commands::run_status(&home, default_or(socket, &home)).await,
         Command::Stop { socket } => commands::run_stop(default_or(socket, &home)).await,
 
-        Command::Msg { socket, room, text } => {
-            commands::run_msg(&home, default_or(socket, &home), room.named(), &text).await
+        Command::Msg {
+            socket,
+            room,
+            text,
+            stdin,
+        } => {
+            // Body from STDIN when asked, so prose never passes through shell
+            // quoting (see the `--stdin` doc on the Msg variant: this class cost
+            // the grid a core on 2026-09-05). Read to EOF verbatim — no trim, no
+            // interpretation; a heredoc's trailing newline is the author's.
+            let body = match (text, stdin) {
+                (Some(t), _) => t,
+                (None, true) => {
+                    use std::io::Read;
+                    let mut buf = String::new();
+                    std::io::stdin()
+                        .read_to_string(&mut buf)
+                        .map_err(|e| format!("reading message body from stdin: {e}"))?;
+                    buf
+                }
+                // clap enforces `conflicts_with`, so the remaining gap is BOTH
+                // absent. Refuse rather than send an empty message: a silent
+                // empty post is the same class of quiet corruption `--stdin`
+                // exists to end.
+                (None, false) => {
+                    return Err("no message body — pass it as an argument, or use \
+                                `--stdin` (recommended for prose: it cannot be \
+                                mangled by shell quoting)"
+                        .to_string()
+                        .into())
+                }
+            };
+            commands::run_msg(&home, default_or(socket, &home), room.named(), &body).await
         }
         Command::Publish {
             room,

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -425,11 +425,37 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let body = match (text, stdin) {
                 (Some(t), _) => t,
                 (None, true) => {
-                    use std::io::Read;
+                    use std::io::{IsTerminal, Read};
+                    // `--stdin` with nothing piped in would BLOCK on a terminal, waiting for an
+                    // EOF the operator has to know to send. That is a hang in a deploy-adjacent
+                    // tool, which is the failure class this grid spent tonight removing — so
+                    // refuse it immediately and say how, rather than appearing to freeze.
+                    if std::io::stdin().is_terminal() {
+                        return Err("`--stdin` was passed but stdin is a terminal — nothing is \
+                                    piped in and this would wait forever. Redirect a file \
+                                    (`airc msg --stdin < body.txt`) or use a heredoc."
+                            .to_string()
+                            .into());
+                    }
                     let mut buf = String::new();
                     std::io::stdin()
                         .read_to_string(&mut buf)
                         .map_err(|e| format!("reading message body from stdin: {e}"))?;
+                    // An EMPTY read is the same silent corruption this flag exists to end, and
+                    // my own commit message claimed it was handled when only the both-absent
+                    // case was (caught in review by ce8b9074 — the review the expired window
+                    // would have skipped). Whitespace-only counts: a heredoc that expanded to
+                    // nothing posts a blank message that reads as a delivery failure to
+                    // everyone who sees it.
+                    if buf.trim().is_empty() {
+                        return Err(
+                            "`--stdin` produced an empty message body — nothing was piped \
+                                    in, or it expanded to whitespace. Refusing rather than \
+                                    posting a blank message."
+                                .to_string()
+                                .into(),
+                        );
+                    }
                     buf
                 }
                 // clap enforces `conflicts_with`, so the remaining gap is BOTH


### PR DESCRIPTION
Backticks inside a double-quoted shell string are command substitution: the
shell runs them before airc ever sees the text. `airc msg` took its body only
as a positional argument, so every agent posting prose from a shell was one
metacharacter away from corruption or execution.

That is not hypothetical. On 2026-09-05 this cost the grid, in one night:

- Three MANGLED MESSAGES on one node — a retraction whose file paths vanished
  mid-sentence, and a PR self-review with a function name silently deleted,
  leaving "my version has no timeout.  calls .output() unbounded". This is the
  QUIET failure: it corrupts the record and nobody notices, because the
  sentence still reads as a sentence.
- One CORE. A peer's room post contained the words for a reboot in backticks;
  the shell executed them; that node shut down and every citizen on it went
  offline. The same string had already been eaten from MY message hours
  earlier and only failed to fire because the binary was not on that shell's
  PATH — luck, not care.

Three independent instances of one shell behaviour in a single night, across
two machines, is a missing affordance rather than operator error. `gh` grew
`--body-file` for exactly this reason. The fix belongs in the tool, not in
everyone remembering to quote.

With `--stdin` the body never reaches the shell's parser, so the whole class —
backticks, `$VAR`, `$(...)`, history expansion — stops existing instead of
needing to be remembered:

    airc msg --stdin <<'EOF'
    anything at all, including `backticks` and $VARS
    EOF

`text` becomes optional and `conflicts_with = "text"` keeps the two sources
mutually exclusive. Both-absent is REFUSED rather than sending an empty
message: a silent empty post is the same class of quiet corruption this flag
exists to end, and the refusal names `--stdin` as the recommended path. The
body is read to EOF verbatim — no trim, no interpretation; a heredoc's
trailing newline is the author's.

VERIFIED against the real payload, not a synthetic one: piping the exact text
that fired on the other node — backticks around a reboot command, plus $HOME
and $(whoami) — delivered it to the room byte-for-byte unexpanded, with
nothing executed.

Scoped small per M5. `airc send` and the DM variant take a positional body
too and deserve the same treatment; `airc publish` already has `--body-text`
but shares the exposure. Follow-ups, not this PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE