### PR TITLE
feat(publish): --stdin, because #1382 stopped at one verb

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -712,6 +712,19 @@ pub enum Command {
         /// frame body. Pass `-` to read from stdin.
         #[arg(long, group = "body")]
         body_json: Option<String>,
+        /// Read the message body from stdin instead of an argument,
+        /// so prose never passes through shell quoting. Same flag,
+        /// same meaning as `airc msg --stdin` — `--body-text` covers
+        /// the current room only via `msg`, and every cross-room post
+        /// was forced back to inline quoting without this.
+        ///
+        /// Measured 2026-09-05: a backtick in a `--body-text` argument
+        /// was command-substituted by the shell and ate part of the
+        /// message, in a room where the fix for exactly that hazard
+        /// had already merged for `msg`. A flag that stops at one verb
+        /// stops at the verb people happen to use least.
+        #[arg(long, group = "body")]
+        stdin: bool,
         /// Header in `key=value` form. Repeatable.
         #[arg(long = "header", value_name = "KEY=VALUE")]
         headers: Vec<String>,

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -476,11 +476,14 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             room,
             body_text,
             body_json,
+            stdin,
             headers,
             kind,
         } => {
-            publish_commands::run_publish(&home, room.room, body_text, body_json, headers, kind)
-                .await
+            publish_commands::run_publish(
+                &home, room.room, body_text, body_json, stdin, headers, kind,
+            )
+            .await
         }
 
         Command::Inbox {

--- a/crates/airc-cli/src/publish_commands.rs
+++ b/crates/airc-cli/src/publish_commands.rs
@@ -20,10 +20,11 @@ pub async fn run_publish(
     room: Option<String>,
     body_text: Option<String>,
     body_json: Option<String>,
+    stdin: bool,
     headers: Vec<String>,
     kind: PublishFrameKind,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let body = load_body(body_text, body_json)?;
+    let body = load_body(body_text, body_json, stdin)?;
     let parsed_headers = parse_headers(&headers)?;
     let target = match room {
         Some(name) => PublishTarget::RoomByName(name),
@@ -53,7 +54,11 @@ fn frame_kind_from(kind: PublishFrameKind) -> FrameKind {
 fn load_body(
     body_text: Option<String>,
     body_json: Option<String>,
+    stdin: bool,
 ) -> Result<Body, Box<dyn std::error::Error>> {
+    if stdin {
+        return Ok(Body::text(read_prose_from_stdin()?));
+    }
     match (body_text, body_json) {
         (Some(text), None) => Ok(Body::text(text)),
         (None, Some(source)) => {
@@ -63,7 +68,7 @@ fn load_body(
             })?;
             Ok(Body::Json(value))
         }
-        (None, None) => Err("publish requires --body-text or --body-json".into()),
+        (None, None) => Err("publish requires --body-text, --body-json, or --stdin".into()),
         (Some(_), Some(_)) => {
             // Clap's `conflicts_with` catches this normally; this
             // branch is defensive in case the args are passed
@@ -71,6 +76,40 @@ fn load_body(
             Err("--body-text and --body-json are mutually exclusive".into())
         }
     }
+}
+
+/// Read a prose body from stdin, refusing the two ways that silently go wrong.
+///
+/// Both guards are the ones `airc msg --stdin` carries (#1382), and both were
+/// found there by review rather than by design: an empty pipe posted a BLANK
+/// message, and a terminal blocked forever waiting for an EOF the operator had
+/// to know to send. Duplicating the behaviour here rather than the reasoning —
+/// a flag whose guards differ between two verbs is worse than no flag, because
+/// the operator learns one contract and gets another.
+fn read_prose_from_stdin() -> Result<String, Box<dyn std::error::Error>> {
+    use std::io::IsTerminal;
+    if std::io::stdin().is_terminal() {
+        return Err(
+            "`--stdin` was passed but stdin is a terminal — nothing is piped in and \
+                    this would wait forever. Redirect a file (`airc publish --stdin < body.txt`) \
+                    or use a heredoc."
+                .to_string()
+                .into(),
+        );
+    }
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .map_err(|error| format!("reading message body from stdin: {error}"))?;
+    if buf.trim().is_empty() {
+        return Err(
+            "`--stdin` produced an empty message body — nothing was piped in, or it \
+                    expanded to whitespace. Refusing rather than publishing a blank frame."
+                .to_string()
+                .into(),
+        );
+    }
+    Ok(buf)
 }
 
 fn read_body_source(source: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -147,18 +186,35 @@ mod tests {
         // `Body::text` is sugar for `Body::Json({"text": "..."})` —
         // the canonical chat shape. Confirm the CLI sugar
         // round-trips through it correctly.
-        match load_body(Some("hello".into()), None).expect("ok") {
+        match load_body(Some("hello".into()), None, false).expect("ok") {
             Body::Json(value) => assert_eq!(value["text"], "hello"),
             other => panic!("expected json-wrapped text body, got {other:?}"),
         }
     }
 
+    // what this catches: `--stdin` silently doing nothing because the flag was
+    // added to the CLI but never consulted by load_body — the wiring, not the
+    // read. A `true` here must NOT fall through to the "requires a source"
+    // error, which is what an unwired flag would produce.
+    #[test]
+    fn stdin_flag_is_consulted_before_the_body_source_match() {
+        // stdin is not a terminal under `cargo test` and is empty, so this
+        // reaches the empty-body refusal — proving the flag routed there rather
+        // than into the (None, None) arm.
+        let err = load_body(None, None, true).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--stdin") && !msg.contains("requires --body-text"),
+            "`--stdin` was not consulted; got: {msg}"
+        );
+    }
+
     #[test]
     fn load_body_requires_one_source() {
-        let err = load_body(None, None).unwrap_err();
+        let err = load_body(None, None, false).unwrap_err();
         assert!(
             err.to_string()
-                .contains("requires --body-text or --body-json"),
+                .contains("requires --body-text, --body-json, or --stdin"),
             "unexpected error: {err}"
         );
     }
@@ -168,7 +224,8 @@ mod tests {
         // Write a temp file with bad JSON.
         let tmp = tempfile::NamedTempFile::new().expect("tempfile");
         std::fs::write(tmp.path(), b"{ not json }").expect("write");
-        let err = load_body(None, Some(tmp.path().to_string_lossy().into_owned())).unwrap_err();
+        let err =
+            load_body(None, Some(tmp.path().to_string_lossy().into_owned()), false).unwrap_err();
         assert!(
             err.to_string().contains("not valid JSON"),
             "unexpected error: {err}"
@@ -179,7 +236,7 @@ mod tests {
     fn load_body_json_file_parses() {
         let tmp = tempfile::NamedTempFile::new().expect("tempfile");
         std::fs::write(tmp.path(), br#"{"kind":"chat","text":"hi"}"#).expect("write");
-        match load_body(None, Some(tmp.path().to_string_lossy().into_owned())).expect("ok") {
+        match load_body(None, Some(tmp.path().to_string_lossy().into_owned()), false).expect("ok") {
             Body::Json(value) => {
                 assert_eq!(value["kind"], "chat");
                 assert_eq!(value["text"], "hi");


### PR DESCRIPTION
`airc msg --stdin` (#1382) exists so prose never passes through shell quoting. `airc publish` — the verb for posting to a room **other** than the current one — had no equivalent, so every cross-room message went back to inline `--body-text "..."` and back into the hazard.

## Measured, hours after #1382 merged

A backtick inside a `--body-text` argument was command-substituted by the shell and ate part of the message — **in the room where the fix for exactly that had already landed**.

A flag that stops at one verb stops at the verb people happen to use least. The workaround (switch the current room with `airc room`, then `msg --stdin`) mutates a scope pointer as a side effect of wanting to say something.

`--body-json -` already reads stdin, but that path parses JSON. There was no way to hand `publish` a body of prose without the shell in between.

## Both guards duplicated on purpose

Not the reasoning — the behaviour:

- **stdin is a TERMINAL** → refuse with the redirect and heredoc forms, rather than block forever waiting for an EOF the operator has to know to send.
- **body is EMPTY or whitespace** → refuse, rather than publish a blank frame.

Both were found on #1382 by review rather than by design (ce8b9074's catch). A flag whose guards differ between two verbs is worse than no flag: the operator learns one contract and gets another.

## The test pins the wiring

The specific way this would silently do nothing is a `--stdin` added to the CLI but never consulted by `load_body` — it would fall through to the "requires a body source" error. The test asserts a `true` reaches the stdin path instead.

`cargo test -p airc-cli --bins publish` → **12 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
