### PR TITLE
feat(lib): room-scoped twins — publish_wall_post_in, create_work_card_in

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1216,6 +1216,26 @@ impl Airc {
         supersedes: Option<uuid::Uuid>,
     ) -> Result<uuid::Uuid, AircError> {
         let room = self.current_room().await?;
+        self.publish_wall_post_in(&room, category, body, supersedes)
+            .await
+    }
+
+    /// Publish a wall post on a room the caller RESOLVED for itself.
+    ///
+    /// [`Self::publish_wall_post`] writes "whatever room I happen to point
+    /// at"; this writes THIS room. Same split, and the same reason, as
+    /// [`Self::wall_posts`] vs [`Self::wall_posts_in`]: a verb that means a
+    /// specific room (Continuum's `activity/archive --room`, a standing
+    /// declared on a finished round from wherever the operator stands) must
+    /// be able to say so — the silent current-room default lands the post on
+    /// a plausible wrong room and nothing in the receipt says which.
+    pub async fn publish_wall_post_in(
+        &self,
+        room: &crate::Room,
+        category: String,
+        body: String,
+        supersedes: Option<uuid::Uuid>,
+    ) -> Result<uuid::Uuid, AircError> {
         let post_id = uuid::Uuid::new_v4();
         let event = airc_core::doctrine::DoctrineEvent::WallPostPublished(
             airc_core::doctrine::WallPostPublished {
@@ -1242,7 +1262,7 @@ impl Airc {
         // owner-core (no daemon in front of it).
         if self.is_daemon_attached() {
             self.daemon_publish(
-                &room,
+                room,
                 airc_protocol::FrameKind::Event,
                 body,
                 airc_core::headers::Headers::new(),

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -443,6 +443,30 @@ impl Airc {
         Ok(card_id)
     }
 
+    /// Create a card on the board of a room the caller RESOLVED for itself.
+    ///
+    /// [`Self::create_work_card`] lands the card on "whatever room the scope's
+    /// pointer is on" — which on a fresh node is `#general`, so project cards
+    /// were landing in the lobby (Continuum, 2026-09-04). A card belongs to
+    /// its ACTIVITY's room; a caller that knows the room must be able to say
+    /// so. Same split as `work_board` / `work_board_in`.
+    pub async fn create_work_card_in(
+        &self,
+        room: &Room,
+        request: CreateWorkCard,
+    ) -> Result<WorkCardId, AircError> {
+        let card_id = WorkCardId::new();
+        let peer_id = self.peer_id();
+        let event = WorkEvent::CardCreated(build_operator_card_created(
+            card_id,
+            peer_id,
+            now_ms()?,
+            request,
+        ));
+        self.publish_work_event_in(room, &event).await?;
+        Ok(card_id)
+    }
+
     /// Claim a work card for this peer. Returns the UUIDv4 claim id
     /// generated locally for the lease.
     pub async fn claim_work_card(&self, request: ClaimWorkCard) -> Result<ClaimId, AircError> {


### PR DESCRIPTION
A verb that means a specific room must be able to say so. `publish_wall_post` and `create_work_card` landed on `current_room()` — whatever room the scope's pointer is on — so Continuum's `activity/archive` could only conclude the caller's current room, and `work/create` on a fresh node put project cards in #general (ce8b9074's finding, 2026-09-04). Joel today: "You never work in rooms. You just use whatever one of you reuses."

Same split, same reason, as `wall_posts` / `wall_posts_in` and `work_board` / `work_board_in`.

- `publish_wall_post` delegates to `publish_wall_post_in(&current_room, …)`; no behaviour change for existing callers.
- `create_work_card_in` rides the existing private `publish_work_event_in`.

`cargo check -p airc-lib` green. Continuum consumer (activity/archive --room, activity/protect --room, work/create --room) follows on the pin bump.

No auto-merge; a peer's no-objection please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo