### PR TITLE
fix(join): publish the identity card, which subscribe_room's doc has always promised

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1951,6 +1951,40 @@ impl Airc {
         let is_default = set.default_subscription().map(|s| &s.name) == Some(&channel);
         subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set).await?;
+
+        // GROUND THIS PEER BY NAME, which `subscribe_room`'s own doc has always
+        // promised — "this peer's identity card is published into the room so its
+        // roster sees a named arrival" — and which nothing did. `publish_presence`
+        // above beacons the channel list; it is not the identity card, so a peer
+        // that joined was PRESENT but ANONYMOUS, and every desktop rendered it as
+        // `peer-<hex>`. Measured 2026-09-05: `publish_identity` had exactly three
+        // references in the tree — its definition, its own test mod, and the ACP
+        // adapter (integrations/acp/src/main.rs:117, "ground by name so room_roster
+        // + whois see it"). The CLI and daemon never called it, so every agent scope
+        // on the fleet was nameless while Continuum personas — which DO call it, at
+        // persona/airc_runtime.rs:590 — were named. Joel: "It ought to work from
+        // install… default to agent name… this was an airc requirement."
+        //
+        // Published AFTER presence and the durable save, matching the ordering both
+        // existing callers already use: the ACP adapter publishes after subscribe,
+        // and PersonaAircRuntime after attached-and-joined. Identity is a fact about
+        // a peer that is already in the room.
+        //
+        // NON-FATAL, deliberately, and this is the one judgement call here: a join
+        // whose identity card fails to publish leaves a WORKING subscription with an
+        // anonymous peer, which is exactly today's behaviour. Failing the join
+        // instead would turn a cosmetic gap into an outage, and `airc join` is the
+        // command every install path runs. Loud in the log, never fatal.
+        if let Err(source) = self.publish_identity().await {
+            tracing::warn!(
+                agent = %self.agent_name(),
+                channel = %channel.as_str(),
+                %source,
+                "joined the room but could not publish the identity card — this peer \
+                 will render as peer-<hex> until the next successful publish"
+            );
+        }
+
         let room = subscription.as_room();
 
         // Emit the lifecycle event after the subscription is durable
@@ -3006,6 +3040,37 @@ mod publish_identity_tests {
         assert_eq!(
             stored.identity.name, "Ivar",
             "the grounded citizen is named by its agent_name, not anonymous"
+        );
+    }
+
+    // what this catches: JOIN ITSELF not grounding the peer by name — the gap that
+    // made every agent scope on the fleet render as `peer-<hex>` while Continuum
+    // personas were named. `subscribe_room`'s doc has always claimed join publishes
+    // "this peer's identity card... so its roster sees a named arrival"; until
+    // 2026-09-05 nothing did, because `publish_presence` beacons the channel list and
+    // is not the identity card. Note this deliberately does NOT call
+    // publish_identity() — the whole point is that an operator who only ever runs
+    // `airc join` ends up named. The sibling test above still calls it explicitly and
+    // pins the function itself.
+    #[tokio::test]
+    async fn join_alone_grounds_the_peer_by_name_without_an_explicit_publish() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("solveig/.airc");
+        let airc = Airc::open_as(&home, "Solveig")
+            .await
+            .expect("open as Solveig");
+
+        airc.join("general").await.expect("join a channel");
+
+        let stored = airc
+            .event_store()
+            .load_local_identity_by_agent_name("Solveig")
+            .await
+            .expect("store read")
+            .expect("join must publish the identity card — an operator who only joins must not be anonymous");
+        assert_eq!(
+            stored.identity.name, "Solveig",
+            "a peer that joined is named on the wire, never peer-<hex>"
         );
     }
 


### PR DESCRIPTION
## The doc promised it. The code never did.

`subscribe_room` documents its own effect as:

> the subscription is saved, presence is re-beaconed with the new channel list, the `RoomJoined` lifecycle event is emitted, **and this peer's identity card is published into the room so its roster sees a named arrival.**

The last clause never happened. `join_channel` calls `publish_presence` — which beacons the channel list and is **not** the identity card — so a peer that joined was PRESENT but ANONYMOUS, and every desktop rendered it `peer-<hex>`.

## Why the fleet is nameless and the citizens are not

`publish_identity` had exactly three references in the tree (2026-09-05):

| where | what |
|---|---|
| `airc-lib/src/airc.rs:2031` | the definition |
| `airc-lib/src/airc.rs:2918` | its own test mod |
| `integrations/acp/src/main.rs:117` | the ACP adapter — *"ground by name so room_roster + whois see it"* |

The CLI and the daemon never called it. Continuum personas **did** (`persona/airc_runtime.rs:590`, the name-floor publish), which is exactly why citizens have names everywhere and every agent scope on the fleet does not.

Joel: *"you are still a bunch of peer numbers"* / *"It ought to work from install… default to agent name… this was an airc requirement."*

## Placement and the one judgement call

Published **after** presence and the durable save, matching the ordering both existing callers already use — the ACP adapter publishes after subscribe, `PersonaAircRuntime` after attached-and-joined. Identity is a fact about a peer that is already in the room.

**Non-fatal, deliberately.** A join whose identity publish fails leaves a working subscription with an anonymous peer — which is exactly today's behaviour. Failing the join instead would turn a cosmetic gap into an outage on the command every install path runs. Loud in the log, never fatal.

## Proven by mutation

With the call disabled:

```
join_alone_grounds_the_peer_by_name_without_an_explicit_publish  FAILED
publish_identity_grounds_named_citizen_from_agent_name           ok
```

Only the test pinning the new behaviour fails. The sibling calls `publish_identity` explicitly, so the join-side call cannot affect it — that asymmetry is what shows the new test measures the **join path** and not the function. Restored: **4 passed, 0 failed**.

The new test deliberately does *not* call `publish_identity`: the whole point is that an operator who only ever runs `airc join` ends up named.

## Merge timing

Per the fleet rule, an airc merge restarts every daemon — this should ride the announced batch, not go in mid-round.

Card: `9cfaeece`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE