### PR TITLE
feat(transcript): name the kinds a peer must receive — one predicate, asked at the definition site

### DIFF
--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -135,6 +135,68 @@ impl TranscriptKind {
         )
     }
 
+    /// True for the lifecycle kinds a REMOTE peer must receive — the announcements one
+    /// citizen publishes *for the room*, as opposed to the observations a scope makes
+    /// *about itself*.
+    ///
+    /// ## Why this is not `is_lifecycle`
+    ///
+    /// `is_lifecycle` answers "did the substrate author this, rather than a human typing",
+    /// and it deliberately includes kinds that must NEVER leave the box: `WireEstablished`
+    /// / `WireLost` are this scope's transport observations, `PeerArrived` / `PeerDeparted`
+    /// are mutations of the LOCAL trust registry, `RoomJoined` / `RoomParted` are what THIS
+    /// scope did, and `SubscriptionAdvanced` is a local consumer's cursor. "My wire came up"
+    /// is nobody else's event. Using `is_lifecycle` as the routing predicate would broadcast
+    /// every one of those.
+    ///
+    /// The four below are the opposite: each one's own doc says another peer consumes it —
+    /// the identity card is emitted on join *"so other peers populate their roster on
+    /// attach"*, the doctrine is *"the 'how we work here' markdown every attaching agent
+    /// loads on join"*, the wall post is the room's living document, and the channel
+    /// purpose is what *"a citizen calibrates participation to"*. A published announcement
+    /// that reaches no peer has not been published.
+    ///
+    /// ## Why the decision lives on the KIND
+    ///
+    /// So it is made once. Measured on IntelMac 2026-09-05: every one of these four is
+    /// emitted through `airc-lib`'s `emit_lifecycle`, which persists locally and sends to an
+    /// in-process broadcast channel and never calls `router.publish` — so identity cards are
+    /// structurally process-local. Three nodes each held a full LOCAL identity and rendered
+    /// every peer as `peer-<hex>`, permanently and symmetrically, which is the signature of
+    /// a reader looking at a store the writer never reaches rather than of propagation lag.
+    /// Bolting a publish onto one call site would fix identity and leave the other three,
+    /// which is how there came to be four of them.
+    ///
+    /// Adding a variant: answer this question at the definition site. The exhaustive match
+    /// below makes the compiler ask.
+    pub fn crosses_to_peers(self) -> bool {
+        match self {
+            // Announcements: published BY a citizen FOR the room.
+            TranscriptKind::IdentityPublished
+            | TranscriptKind::DoctrinePublished
+            | TranscriptKind::WallPostPublished
+            | TranscriptKind::ChannelPurposePublished => true,
+
+            // This scope's own observations — local by nature.
+            TranscriptKind::PeerArrived
+            | TranscriptKind::PeerDeparted
+            | TranscriptKind::WireEstablished
+            | TranscriptKind::WireLost
+            | TranscriptKind::RoomJoined
+            | TranscriptKind::RoomParted
+            | TranscriptKind::SubscriptionAdvanced => false,
+
+            // Not lifecycle at all: these already ride their own send paths
+            // (`say` / attachments / receipts), so routing them here would double-send.
+            TranscriptKind::Message
+            | TranscriptKind::Attachment
+            | TranscriptKind::Receipt
+            | TranscriptKind::Presence
+            | TranscriptKind::SessionControl
+            | TranscriptKind::System => false,
+        }
+    }
+
     /// Stable wire / storage discriminator string. This is the single
     /// source of truth for the `TranscriptKind ↔ &str` mapping that
     /// downstream codecs (airc-store SQLite, future JSON envelopes,
@@ -338,5 +400,54 @@ mod tests {
             None,
             "unknown discriminators must return None (so callers can wrap as an error)"
         );
+    }
+
+    // what this catches: an announcement kind that silently stops crossing the wire, and a
+    // local observation that starts crossing. Measured 2026-09-05: all four announcements
+    // were emitted through a path that never reached the bus, so three nodes each rendered
+    // every peer as `peer-<hex>` forever while holding a full local identity. The bug was
+    // invisible because each half worked — the card was written, and the reader read; they
+    // just used different stores. Pinning the SET here means the next kind added has to
+    // answer the question at its definition site instead of inheriting silence.
+    #[test]
+    fn only_the_room_announcements_cross_to_peers() {
+        let crossing: Vec<&str> = TranscriptKind::ALL_VARIANTS
+            .iter()
+            .filter(|k| k.crosses_to_peers())
+            .map(|k| k.as_wire_str())
+            .collect();
+        assert_eq!(
+            crossing,
+            vec![
+                "identity_published",
+                "doctrine_published",
+                "wall_post_published",
+                "channel_purpose_published",
+            ],
+            "the set of kinds a remote peer receives changed — if that is deliberate, say \
+             why here; `is_lifecycle` is NOT this set and must not be substituted for it"
+        );
+    }
+
+    // what this catches: substituting `is_lifecycle` for the routing predicate. It is the
+    // tempting one-liner and it would broadcast this scope's own transport and registry
+    // observations to every peer in the room — "my wire came up" is nobody else's event.
+    #[test]
+    fn a_scopes_own_observations_never_cross() {
+        for local in [
+            TranscriptKind::PeerArrived,
+            TranscriptKind::PeerDeparted,
+            TranscriptKind::WireEstablished,
+            TranscriptKind::WireLost,
+            TranscriptKind::RoomJoined,
+            TranscriptKind::RoomParted,
+            TranscriptKind::SubscriptionAdvanced,
+        ] {
+            assert!(local.is_lifecycle(), "{local:?} should still be lifecycle");
+            assert!(
+                !local.crosses_to_peers(),
+                "{local:?} is this scope's own observation and must not be broadcast"
+            );
+        }
     }
 }


### PR DESCRIPTION
Slice 1 of card 9cfaeece. This adds the DECISION and its tests; it does not yet
change routing. Handing the seam to @M5 before touching airc's event spine.

MEASURED on IntelMac 2026-09-05, three nodes all running the build carrying
airc#1385:

  - every node held a fully populated LOCAL identity card
  - no node rendered ANY other node by name; all read "not published yet"
  - the symmetry is the signature. Propagation lag resolves; a missing re-join
    breaks symmetry (M5 genuinely re-joined, BigMama did not, same result).
    A reader looking at a store the writer never reaches is symmetric,
    immediate and permanent — which is what three boxes saw.

The store says the same thing on this box:

    events (legacy, local)   3 identity_published, ALL from my own scope peer
    bus_events (the wire)    183,103 durable rows, kinds `event`/`message` only
    scoped_state             13 identity cards, every one a peer LOCAL to this
                             machine; neither of the other two nodes present

And the code says why: `airc-lib`'s `emit_lifecycle` does `store.append` plus an
in-process `live_tx.send` and never calls `router.publish`. Identity cards are
structurally process-local, so airc#1385 (publish on join) was correct and
insufficient — it faithfully emits, persists and self-indexes a card that cannot
leave the box. The acceptance test written for it was unrunnable.

WHY A PREDICATE AND NOT A PUBLISH CALL. Four kinds go through that same path:
IdentityPublished, DoctrinePublished, WallPostPublished, ChannelPurposePublished
— each one's own doc says another peer consumes it. Adding `router.publish` to
`publish_identity` fixes one and leaves three, which is how there came to be
four. Per Joel's rule (logic at the deepest level, thin on the way out, never
logic twice) the decision belongs on the KIND, where an exhaustive match makes
the compiler ask the question of every variant added later.

`is_lifecycle` is NOT this set and must not be substituted for it: it includes
WireEstablished/WireLost (this scope's transport), PeerArrived/PeerDeparted (the
LOCAL trust registry), RoomJoined/RoomParted and SubscriptionAdvanced. "My wire
came up" is nobody else's event. `a_scopes_own_observations_never_cross` exists
to catch exactly that substitution.

Mutation-proven: flipping SubscriptionAdvanced to cross fails BOTH new tests and
leaves the pre-existing round-trip test green.

NOT claimed here: doctrine and wall posts share the code path, so the same defect
is implied, but I have no wire evidence for them and am not asserting it. (A
substring scan of bus payloads appeared to show thousands of "doctrine" hits;
every one was chat text discussing doctrine, including my own report quoting the
term. Searching a corpus that talks about itself measures the conversation.)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE