### PR TITLE
fix(identity): the "default" sentinel is not a name — stop the floor publishing it

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -2095,7 +2095,7 @@ impl Airc {
             None => true,
             Some(stored) => stored.identity.name.trim().is_empty(),
         };
-        if needs_floor && !self.agent_name().trim().is_empty() {
+        if needs_floor && is_a_real_name(self.agent_name()) {
             // Seed + broadcast from the agent-name floor (set_local_identity_card
             // persists AND emits to every subscribed room).
             let identity = airc_core::identity::Identity {
@@ -3043,6 +3043,39 @@ mod publish_identity_tests {
         );
     }
 
+    // what this catches: the agent-name floor grounding a scope that never claimed a
+    // name. `agent_name()` resolves to DEFAULT_AGENT_NAME ("default") when neither
+    // open_as nor $AIRC_AGENT_NAME supplied one, so the floor's non-empty check passed
+    // on the SENTINEL and published a card asserting name="default".
+    //
+    // Observed on IntelMac 2026-09-05 22:28:44 UTC, nine minutes after #1385 installed:
+    //     {"name":"default","pronouns":"","role":"","bio":"", ...}
+    // for this scope's room-facing peer. That is worse than the "not published yet" it
+    // replaced — an honest unknown became a false name, and every unnamed scope on the
+    // grid asserts the SAME false name, so they collide the moment cards cross the wire.
+    #[test]
+    fn the_default_sentinel_is_not_a_name_and_never_grounds_a_citizen() {
+        assert!(
+            !is_a_real_name(airc_store::DEFAULT_AGENT_NAME),
+            "the sentinel meaning `no name was given` must never be published AS a name"
+        );
+        assert!(!is_a_real_name(""), "empty is not a name");
+        assert!(!is_a_real_name("   "), "whitespace is not a name");
+    }
+
+    // what this catches: over-correcting and breaking the floor for the case it exists
+    // for. A citizen opened as Ivar (the groundedness incident this floor was written
+    // after) must still be grounded by its agent_name; only the no-name case declines.
+    #[test]
+    fn a_citizen_that_claimed_a_name_still_gets_the_floor() {
+        assert!(is_a_real_name("Ivar"));
+        assert!(is_a_real_name("Solveig"));
+        assert!(
+            is_a_real_name("  Memento  "),
+            "a real name survives trimming"
+        );
+    }
+
     // what this catches: JOIN ITSELF not grounding the peer by name — the gap that
     // made every agent scope on the fleet render as `peer-<hex>` while Continuum
     // personas were named. `subscribe_room`'s doc has always claimed join publishes
@@ -3204,4 +3237,35 @@ mod scoped_state_tests {
             .await
             .expect("delete is idempotent");
     }
+}
+
+/// Is this `agent_name` a NAME, or the sentinel that means no name was given?
+///
+/// `agent_name()` resolves to [`airc_store::DEFAULT_AGENT_NAME`] — the literal string
+/// `"default"` — whenever neither `open_as` nor `$AIRC_AGENT_NAME` supplied one
+/// (`airc-identity/src/lib.rs`: `None => Ok(DEFAULT_AGENT_NAME.to_string())`). That
+/// sentinel is the ABSENCE of a name wearing the same type as a name, and the
+/// agent-name floor in [`Airc::publish_identity`] read it as the presence of one.
+///
+/// Measured on IntelMac 2026-09-05, 22:28:44 UTC — nine minutes after airc#1385 was
+/// installed at 17:19 local — the identity index gained a card for this scope's
+/// room-facing peer reading, in full:
+///
+///     {"name":"default","pronouns":"","role":"","bio":"","status":"", ...}
+///
+/// That is strictly worse than what #1385 replaced. Before it, an unnamed scope
+/// published nothing and `whois` said "identity: not published yet", which is an honest
+/// unknown. After it, the scope publishes a card asserting its name IS "default" — a
+/// false name, and one that every unnamed scope on every machine asserts identically.
+/// The moment cards actually cross the wire (card 9cfaeece), the grid fills with
+/// colliding citizens all called "default", which is the failure the floor was written
+/// to prevent (`docs/architecture/PERSONA-GROUNDEDNESS.md`, the "Ivar" incident).
+///
+/// The floor's purpose is intact and unchanged for the case it was built for: a citizen
+/// opened via `open_as("Ivar")` or `$AIRC_AGENT_NAME=Ivar` still gets grounded as Ivar.
+/// This only declines to invent a name for a scope that never claimed one — no name is
+/// not a name, and the substrate does not guess (see the no-fallbacks rule).
+fn is_a_real_name(agent_name: &str) -> bool {
+    let n = agent_name.trim();
+    !n.is_empty() && n != airc_store::DEFAULT_AGENT_NAME
 }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -3250,8 +3250,7 @@ mod scoped_state_tests {
 /// Measured on IntelMac 2026-09-05, 22:28:44 UTC — nine minutes after airc#1385 was
 /// installed at 17:19 local — the identity index gained a card for this scope's
 /// room-facing peer reading, in full:
-///
-///     {"name":"default","pronouns":"","role":"","bio":"","status":"", ...}
+/// `{"name":"default","pronouns":"","role":"","bio":"","status":"", ...}`
 ///
 /// That is strictly worse than what #1385 replaced. Before it, an unnamed scope
 /// published nothing and `whois` said "identity: not published yet", which is an honest


### PR DESCRIPTION
**Card 9b856e25. This is a regression from my own merged #1385, and it gates card 9cfaeece slice 2 — land this first.**

## Measured

The identity index gained this card at **22:28:44 UTC on 2026-09-05**, nine minutes after #1385 installed at 17:19 local, for this scope's room-facing peer:

```json
{"name":"default","pronouns":"","role":"","bio":"","status":""}
```

## Mechanism

`publish_identity`'s agent-name floor fires when no identity is set and `agent_name()` is non-empty. But `agent_name()` resolves to `DEFAULT_AGENT_NAME` — the literal string `"default"` — whenever neither `open_as` nor `$AIRC_AGENT_NAME` supplied one:

```rust
// airc-identity/src/lib.rs
None => Ok(airc_store::DEFAULT_AGENT_NAME.to_string()),
```

The sentinel meaning *"no name was given"* is non-empty, so the floor read the **absence** of a name as the presence of one and published it.

## Why this is worse than what it replaced

| | behaviour |
|---|---|
| before #1385 | publishes nothing; `whois` says "identity: not published yet" — an honest unknown |
| after #1385 | publishes a card asserting its name **is** `"default"` — a false name, identical on every unnamed scope on the grid |

It is invisible today only because identity cards never leave the box (card 9cfaeece). The moment that lands, the grid fills with colliding citizens all called `default` — precisely the confabulation the floor was written to prevent (the "Ivar" incident, `docs/architecture/PERSONA-GROUNDEDNESS.md`).

#1385 was right that join must publish. It was wrong to let the floor invent a name for a scope that never claimed one.

## The fix

`is_a_real_name(agent_name)` — non-empty **and** not the sentinel. The floor is unchanged for the case it exists for: `open_as("Ivar")` or `$AIRC_AGENT_NAME=Ivar` still grounds as Ivar. A scope that never claimed a name publishes nothing again, because no name is not a name and the substrate does not guess.

## Mutation-proven

Reverting the guard to the plain non-empty check fails **only** `the_default_sentinel_is_not_a_name_and_never_grounds_a_citizen`, while both pre-existing #1385 tests — `publish_identity_grounds_named_citizen_from_agent_name` and `join_alone_grounds_the_peer_by_name_without_an_explicit_publish` — stay green. The test catches this regression and nothing else.

## Not fixed here

This machine carries at least three peer identities: `5159a48b` holds the real "IntelMac" card, `9bb24964` is what the room sees and is the one that got `"default"`, and `cdff6a9d` claimed tonight's work cards. Even with this fix the room-facing peer stays *unnamed* rather than becoming IntelMac — it just stops lying about it. Separate card.

Refs: #1385, card 9cfaeece (airc#1386), `docs/architecture/PERSONA-GROUNDEDNESS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
