### PR TITLE
feat(merger): the gate can finally SEE who wrote the PR — non-author approval, with UNKNOWN kept apart from NONE

### DIFF
--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -70,7 +70,9 @@ impl GhClient for ShellGhClient {
                 "--repo",
                 args.repo.as_str(),
                 "--json",
-                "state,mergeable,statusCheckRollup,mergedAt",
+                // author + reviews: card 267d68f5 — the gate cannot require a NON-AUTHOR
+                // approval without knowing who wrote the PR and who reviewed it.
+                "state,mergeable,statusCheckRollup,mergedAt,author,reviews",
             ])
             .output()
             .await

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -1076,6 +1076,8 @@ mod tests {
             mergeable: "".to_string(),
             status_check_rollup: None,
             merged_at: Some("2026-06-01T07:04:07Z".to_string()),
+            author: None,
+            reviews: None,
         };
         let baseline = std::collections::HashSet::new();
         let policy = GatePolicy::default_for_merger(0);
@@ -1100,6 +1102,8 @@ mod tests {
             mergeable: "".to_string(),
             status_check_rollup: None,
             merged_at: Some("2026-09-04T16:46:08Z".to_string()),
+            author: None,
+            reviews: None,
         };
         match evaluate_gh_view(&view, &empty_baseline(), empty_policy()) {
             GateResult::AlreadyMerged { merged_at_ms } => {
@@ -1121,6 +1125,8 @@ mod tests {
             mergeable: "".to_string(),
             status_check_rollup: None,
             merged_at: None,
+            author: None,
+            reviews: None,
         };
         match evaluate_gh_view(&view, &empty_baseline(), empty_policy()) {
             GateResult::NotReady(reason) => assert!(reason.contains("CLOSED"), "{reason}"),
@@ -1139,6 +1145,8 @@ mod tests {
             mergeable: "".to_string(),
             status_check_rollup: None,
             merged_at: None,
+            author: None,
+            reviews: None,
         };
         let baseline = std::collections::HashSet::new();
         let policy = GatePolicy::default_for_merger(0);
@@ -1158,6 +1166,8 @@ mod tests {
             mergeable: "".to_string(),
             status_check_rollup: None,
             merged_at: None,
+            author: None,
+            reviews: None,
         };
         let baseline = std::collections::HashSet::new();
         let policy = GatePolicy::default_for_merger(0);

--- a/crates/airc-lib/src/gh/client.rs
+++ b/crates/airc-lib/src/gh/client.rs
@@ -270,6 +270,92 @@ pub struct PrView {
     /// an already-merged PR.
     #[serde(default, rename = "mergedAt")]
     pub merged_at: Option<String>,
+    /// Who opened the PR. Card 267d68f5: the gate could not previously SEE this, so
+    /// "one no-objection from any peer" was satisfiable by the author's own approval on
+    /// a board where every peer authors cards.
+    #[serde(default)]
+    pub author: Option<GhActor>,
+    /// Reviews on the PR, newest state per reviewer. Used only to answer one question:
+    /// did somebody who is NOT the author approve?
+    #[serde(default)]
+    pub reviews: Option<Vec<GhReview>>,
+}
+
+/// A GitHub actor (`author`, a review's `author`). Only the login matters here.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
+pub struct GhActor {
+    #[serde(default)]
+    pub login: String,
+}
+
+/// One review on a PR. `state` is APPROVED / CHANGES_REQUESTED / COMMENTED / DISMISSED.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GhReview {
+    #[serde(default)]
+    pub author: Option<GhActor>,
+    #[serde(default)]
+    pub state: String,
+}
+
+impl PrView {
+    /// Did a peer who is NOT the author approve this PR?
+    ///
+    /// The whole of card 267d68f5. The merger's doc has always said the multi-author case
+    /// "should require a non-author LGTM" and that its behaviour was only "appropriate for
+    /// single-author scopes" — but `pr_view` never fetched `author` or `reviews`, so the
+    /// gate was structurally incapable of asking. It merged on green alone.
+    ///
+    /// Measured 2026-09-06: three peers author cards on one board, and `.airc/POLICY.md`
+    /// says "one no-objection from ANY connected peer + green = merge". With no author
+    /// known, the author's own approval satisfies that. On the night the policy landed, a
+    /// watcher merged a PR on one peer's review because the comment happened to name a
+    /// second peer — before that peer had spoken.
+    ///
+    /// CHANGES_REQUESTED is not silence and not approval: a PR carrying an unresolved
+    /// change request is never non-author-approved, even if a later COMMENTED review
+    /// exists. Approval must be the reviewer's LATEST state.
+    pub fn non_author_approval(&self) -> NonAuthorApproval {
+        let author = self.author.as_ref().map(|a| a.login.as_str()).unwrap_or("");
+        // UNKNOWN, not "absent". `reviews: None` means this PrView came from a path that
+        // never fetched them (the REST dialect normaliser cannot without a second call) —
+        // NOT that nobody approved. Collapsing those two is the defect class this whole
+        // evening kept turning up: COULD-NOT-LOOK rendered as NOT-THERE. The merger must
+        // be able to say "I cannot verify a review" instead of "this was not reviewed".
+        let Some(reviews) = self.reviews.as_ref() else {
+            return NonAuthorApproval::Unknown;
+        };
+        // Latest state per reviewer, in gh's chronological order.
+        let mut latest: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+        for r in reviews {
+            let login = r.author.as_ref().map(|a| a.login.as_str()).unwrap_or("");
+            if login.is_empty() || (!author.is_empty() && login == author) {
+                continue; // the author's own review is never the second pair of eyes
+            }
+            match r.state.as_str() {
+                // COMMENTED / DISMISSED do not change a standing verdict.
+                "APPROVED" | "CHANGES_REQUESTED" => {
+                    latest.insert(login, r.state.as_str());
+                }
+                _ => {}
+            }
+        }
+        if latest.values().any(|s| *s == "APPROVED") {
+            NonAuthorApproval::Approved
+        } else {
+            NonAuthorApproval::None
+        }
+    }
+}
+
+/// Whether a peer who is not the author approved — with UNKNOWN kept distinct from NONE.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonAuthorApproval {
+    /// A non-author reviewer's latest state is APPROVED.
+    Approved,
+    /// Reviews were fetched and none of them is a non-author approval.
+    None,
+    /// Reviews were not fetched on this path. Not evidence of absence.
+    Unknown,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -367,6 +453,19 @@ impl PrView {
                 .get("merged_at")
                 .and_then(|v| v.as_str())
                 .map(str::to_string),
+            // REST calls the author `user`; normalise it to the GraphQL name like every
+            // other field crossing this boundary.
+            author: pr_json
+                .get("user")
+                .and_then(|u| u.get("login"))
+                .and_then(|l| l.as_str())
+                .map(|login| GhActor {
+                    login: login.to_string(),
+                }),
+            // REST serves reviews from a SEPARATE endpoint (/pulls/N/reviews), so this
+            // path genuinely does not know. `None` is the honest answer and reads as
+            // Unknown, never as "nobody approved".
+            reviews: None,
         };
         view.canonicalize();
         view
@@ -549,6 +648,105 @@ pub fn parse_pr_url(stdout: &str) -> Result<PrCreated, GhError> {
 
 #[cfg(test)]
 mod tests {
+
+    // what this catches: the author's own approval counting as the second pair of eyes.
+    // Card 267d68f5. `.airc/POLICY.md` says "one no-objection from ANY connected peer +
+    // green = merge"; on a board where all three peers author cards, that is satisfiable
+    // by the author approving their own PR unless the gate knows who wrote it. Before this
+    // change `pr_view` fetched neither `author` nor `reviews`, so it could not ask.
+    #[test]
+    fn an_authors_own_approval_is_not_a_non_author_approval() {
+        let v = PrView {
+            state: "OPEN".into(),
+            mergeable: "MERGEABLE".into(),
+            status_check_rollup: None,
+            merged_at: None,
+            author: Some(GhActor {
+                login: "alice".into(),
+            }),
+            reviews: Some(vec![GhReview {
+                author: Some(GhActor {
+                    login: "alice".into(),
+                }),
+                state: "APPROVED".into(),
+            }]),
+        };
+        assert_eq!(v.non_author_approval(), NonAuthorApproval::None);
+    }
+
+    // what this catches: a real peer review not counting.
+    #[test]
+    fn a_peers_approval_counts() {
+        let v = PrView {
+            state: "OPEN".into(),
+            mergeable: "MERGEABLE".into(),
+            status_check_rollup: None,
+            merged_at: None,
+            author: Some(GhActor {
+                login: "alice".into(),
+            }),
+            reviews: Some(vec![GhReview {
+                author: Some(GhActor {
+                    login: "bob".into(),
+                }),
+                state: "APPROVED".into(),
+            }]),
+        };
+        assert_eq!(v.non_author_approval(), NonAuthorApproval::Approved);
+    }
+
+    // what this catches: an approval that was later superseded by the SAME reviewer asking
+    // for changes. Approval must be the reviewer's LATEST state, or a stale LGTM outlives
+    // the objection that replaced it.
+    #[test]
+    fn changes_requested_supersedes_that_reviewers_earlier_approval() {
+        let v = PrView {
+            state: "OPEN".into(),
+            mergeable: "MERGEABLE".into(),
+            status_check_rollup: None,
+            merged_at: None,
+            author: Some(GhActor {
+                login: "alice".into(),
+            }),
+            reviews: Some(vec![
+                GhReview {
+                    author: Some(GhActor {
+                        login: "bob".into(),
+                    }),
+                    state: "APPROVED".into(),
+                },
+                GhReview {
+                    author: Some(GhActor {
+                        login: "bob".into(),
+                    }),
+                    state: "CHANGES_REQUESTED".into(),
+                },
+            ]),
+        };
+        assert_eq!(v.non_author_approval(), NonAuthorApproval::None);
+    }
+
+    // what this catches: UNKNOWN collapsing into NONE — the defect class that cost this
+    // fleet an evening in three other places (a route "not measured" rendered as "nothing
+    // ever crossed", an unfetched identity card rendered as "not published"). A PrView from
+    // a path that never fetched reviews knows NOTHING about approval; it must not be
+    // reported as "nobody approved", because the merger's response to those two differs.
+    #[test]
+    fn unfetched_reviews_are_unknown_never_a_denial() {
+        let v = PrView {
+            state: "OPEN".into(),
+            mergeable: "MERGEABLE".into(),
+            status_check_rollup: None,
+            merged_at: None,
+            author: Some(GhActor {
+                login: "alice".into(),
+            }),
+            reviews: None,
+        };
+        assert_eq!(v.non_author_approval(), NonAuthorApproval::Unknown);
+        assert_ne!(v.non_author_approval(), NonAuthorApproval::None);
+    }
+
     use super::*;
 
     /// what this catches (#356): the two `GhClient` impls read the SAME
@@ -1024,6 +1222,8 @@ pub mod mock {
                 mergeable: "MERGEABLE".to_string(),
                 status_check_rollup: Some(Vec::new()),
                 merged_at: None,
+                author: None,
+                reviews: None,
             }
         }
 


### PR DESCRIPTION
**Card 267d68f5.** Prerequisite for the first two review rules in `.airc/POLICY.md`, which landed tonight and which the merger currently **cannot enforce**.

## Why the gate could not ask

`pr_view` requested exactly:

```
--json state,mergeable,statusCheckRollup,mergedAt
```

No author. No reviews. So `check_pr_gate` was structurally incapable of telling *"a peer approved"* from *"nobody looked"*, and equally incapable of noticing the only approval came from the person who opened the PR. Both policy rules collapse to **green = merge**.

The merger's own module doc has always said so:

> *"Peer-LGTM convention (card 267d68f5): for multi-author rooms we should require a non-author LGTM. **For now, ANY Review card auto-merges if green** — appropriate for single-author scopes."*

Three peers author on one board. That is the case it says it does not cover.

## Measured, 2026-09-06

The policy says *"one no-objection from ANY connected peer + green = merge"*. With no author known, the author's own approval satisfies it.

- A watcher merged #3780 on one peer's review because that comment happened to *name* a second peer — before the second peer had spoken.
- When I went to start the merger daemon on my node **as I had promised**, it would have auto-merged my own unreviewed airc#1386 and #1387 the moment CI went green — the exact failure the policy exists to prevent, by me, to me. I did not start it.

## What this adds

`author` + `reviews` on the fetch, and `PrView::non_author_approval()` answering one question: *did somebody who is not the author approve?*

Latest state per reviewer, so a `CHANGES_REQUESTED` supersedes that same reviewer's earlier `APPROVED` — a stale LGTM must not outlive the objection that replaced it.

## The tri-state is the point

`reviews: None` means this `PrView` came from a path that never fetched them — the REST dialect normaliser **cannot**, because REST serves reviews from a separate endpoint. That is `Unknown`, and it is **not** evidence that nobody approved.

Collapsing those two is the defect class this fleet hit three times tonight:

| surface | rendered as |
|---|---|
| route "present but NONE MEASURED" | "nothing has ever crossed" |
| identity card never fetched | "identity not published yet" |
| `lsof` returning nothing | "the process is dead" |

The merger must be able to say *"I cannot verify a review"* rather than *"this was not reviewed"* — its correct response to those differs.

## Deliberately not included

**Wiring the gate.** This lands the capability and its tests. Making `check_pr_gate` refuse on `None`/`Unknown` is a policy change with live blast radius — it stops merges — and belongs in its own reviewed change rather than riding in on data plumbing.

## Mutation-proven, both directions

| mutation | result |
|---|---|
| stop excluding the author | **only** `an_authors_own_approval_is_not_a_non_author_approval` fails |
| collapse `Unknown` into `None` | **only** `unfetched_reviews_are_unknown_never_a_denial` fails |

## Acceptance verb

Per `.airc/POLICY.md`. Runs on your own node, no daemon, no merge:

```
cargo test -p airc-lib --lib gh::client
```

Expect **24 passed**, including the four named above. Then confirm the fetch actually asks for the fields — the bug was that it never did:

```
grep -n 'author,reviews' crates/airc-cli/src/gh_client.rs
```

Must show the `--json` list containing `author` and `reviews`. Without that line the tests still pass and the gate is still blind, which is precisely how this shipped blind the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE
