### PR TITLE
fix(bus): a cursor resume is bounded by its page limit, never by the channel's depth

### DIFF
--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -967,11 +967,23 @@ impl EventRouter {
     /// strictly after its last cursor, recent-from-ring + deep-from-sink,
     /// merged in total order with no dup. A lagging `Durable` subscriber calls
     /// this to resume; fan-out to others was never blocked.
+    ///
+    /// `limit` bounds the answer AND the work: the deep leg is one indexed
+    /// `LIMIT limit` query (never the channel's whole remainder), and the
+    /// merged page is cut to `limit` in total order. Pagination is the
+    /// caller's job — pass the last returned cursor back in. Measured
+    /// 2026-09-06 (continuum M5, the wall projection): with `usize::MAX`
+    /// here every 500-event inbox page materialized the entire remaining
+    /// transcript (academy 244k rows, cambriantech 472k), so a from-zero
+    /// walk was O(n²/page) and never returned inside the callers' 30 s
+    /// deadline, while the board — resuming from a saved cursor — was instant.
     pub async fn resume_from_cursor(
         &self,
         channel: RoomId,
         from_cursor: Option<Cursor>,
+        limit: usize,
     ) -> crate::Result<Vec<Arc<Envelope>>> {
+        let limit = limit.max(1);
         // Recent from ring (snapshot under lock; no await held).
         let (ring_events, ring_oldest) = {
             let shard = self.shard_for(channel);
@@ -986,11 +998,7 @@ impl EventRouter {
         };
 
         // Deep from sink for the window older than the ring.
-        let deep = self
-            .inner
-            .sink
-            .page(channel, from_cursor, usize::MAX)
-            .await?;
+        let deep = self.inner.sink.page(channel, from_cursor, limit).await?;
 
         let mut out: Vec<Arc<Envelope>> = Vec::new();
         for env in deep {
@@ -1018,6 +1026,9 @@ impl EventRouter {
                 .then_with(|| a.event_id.0.cmp(&b.event_id.0))
         });
         out.dedup_by(|a, b| a.event_id == b.event_id);
+        // Deep rows all precede ring rows in total order, so the first `limit`
+        // of the merge are exactly the first `limit` after the cursor.
+        out.truncate(limit);
         Ok(out)
     }
 

--- a/crates/airc-bus/tests/durable_tail.rs
+++ b/crates/airc-bus/tests/durable_tail.rs
@@ -35,6 +35,7 @@ struct CountingSink {
     page_calls: AtomicU64,
     page_tail_calls: AtomicU64,
     max_page_tail_limit: AtomicUsize,
+    max_page_limit: AtomicUsize,
 }
 
 impl CountingSink {
@@ -44,7 +45,12 @@ impl CountingSink {
             page_calls: AtomicU64::new(0),
             page_tail_calls: AtomicU64::new(0),
             max_page_tail_limit: AtomicUsize::new(0),
+            max_page_limit: AtomicUsize::new(0),
         }
+    }
+
+    fn max_page_limit(&self) -> usize {
+        self.max_page_limit.load(Ordering::SeqCst)
     }
 
     fn page_calls(&self) -> u64 {
@@ -63,6 +69,7 @@ impl CountingSink {
         self.page_calls.store(0, Ordering::SeqCst);
         self.page_tail_calls.store(0, Ordering::SeqCst);
         self.max_page_tail_limit.store(0, Ordering::SeqCst);
+        self.max_page_limit.store(0, Ordering::SeqCst);
     }
 }
 
@@ -79,6 +86,7 @@ impl DurableSink for CountingSink {
         limit: usize,
     ) -> Result<Vec<Envelope>, BusError> {
         self.page_calls.fetch_add(1, Ordering::SeqCst);
+        self.max_page_limit.fetch_max(limit, Ordering::SeqCst);
         self.inner.page(channel, from_cursor, limit).await
     }
 
@@ -501,5 +509,66 @@ async fn tail_surfaces_sink_error_instead_of_scanning() {
     assert!(
         result.is_err(),
         "reverse-page failure is loud, not a scan fallback"
+    );
+}
+
+/// Regression (continuum 2026-09-06, the wall projection that never
+/// returned): a cursor resume must do work bounded by its page, never by
+/// the channel's remaining depth. Before, `resume_from_cursor` asked the
+/// sink for `usize::MAX` rows on every page and the daemon truncated in
+/// memory, so a from-zero walk of a 244k-event room materialized O(n²/page)
+/// rows and outlived every caller's deadline. Now: each page is ONE sink
+/// read of at most `limit` rows, pages chain by the last returned cursor
+/// with no gap and no dup, and a short page means the channel is exhausted.
+#[tokio::test]
+async fn cursor_resume_pages_are_bounded_by_limit_not_by_room_depth() {
+    const DEEP: u128 = 1_200;
+    const PAGE: usize = 500;
+
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0xb0b0);
+    for n in 0..DEEP {
+        router
+            .publish(event(channel, n, DeliveryClass::Durable))
+            .await
+            .expect("publish");
+        if n % 256 == 0 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    let mut from = None;
+    let mut seen: Vec<u128> = Vec::new();
+    let mut pages = 0;
+    loop {
+        sink.reset();
+        let page = router
+            .resume_from_cursor(channel, from, PAGE)
+            .await
+            .expect("resume");
+        pages += 1;
+        assert!(page.len() <= PAGE, "a page never exceeds its limit");
+        assert!(
+            sink.page_calls() <= 1,
+            "one sink read per page, got {}",
+            sink.page_calls()
+        );
+        assert!(
+            sink.max_page_limit() <= PAGE,
+            "the sink read is bounded by the page, asked for {}",
+            sink.max_page_limit()
+        );
+        let short = page.len() < PAGE;
+        from = page.last().map(|e| e.cursor());
+        seen.extend(markers(&page));
+        if short || from.is_none() {
+            break;
+        }
+    }
+    assert_eq!(pages, 3, "1200 events at 500/page = 500 + 500 + 200");
+    assert_eq!(
+        seen,
+        (0..DEEP).collect::<Vec<_>>(),
+        "the chained pages are the whole channel in order, no gap, no dup"
     );
 }

--- a/crates/airc-bus/tests/slow_subscriber.rs
+++ b/crates/airc-bus/tests/slow_subscriber.rs
@@ -84,7 +84,7 @@ async fn lagging_subscriber_never_stalls_fanout_and_resumes_from_sink() {
         tokio::time::sleep(Duration::from_millis(5)).await;
         waited += 5;
     }
-    let resumed = r.resume_from_cursor(ch, None).await.unwrap();
+    let resumed = r.resume_from_cursor(ch, None, usize::MAX).await.unwrap();
     let resumed_markers: Vec<u128> = resumed.iter().map(|e| e.event_id.0.as_u128()).collect();
     assert_eq!(
         resumed_markers, expected,

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -261,29 +261,43 @@ async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Respons
                 }
             }
         }
-        // "First N after the cursor" when resuming.
+        // "First N after the cursor" when resuming. Each router page is
+        // bounded by `limit` (one indexed query), and the durable + kinds
+        // predicates are applied per page; a page they thin below `limit`
+        // pulls the next page from the last raw cursor, so a short answer
+        // still means "the channel is exhausted" to the client's paging loop.
         Some(c) => {
-            let from = Some(Cursor::new(Seq::new(c.epoch, c.counter), c.event_id));
-            let mut events = match state.router.resume_from_cursor(channel, from).await {
-                Ok(events) => events,
-                Err(error) => {
-                    return Response::Error {
-                        message: format!("inbox: {error}"),
+            let mut from = Some(Cursor::new(Seq::new(c.epoch, c.counter), c.event_id));
+            let mut events: Vec<Arc<Envelope>> = Vec::new();
+            loop {
+                let batch = match state.router.resume_from_cursor(channel, from, limit).await {
+                    Ok(events) => events,
+                    Err(error) => {
+                        return Response::Error {
+                            message: format!("inbox: {error}"),
+                        }
                     }
+                };
+                let exhausted = batch.len() < limit;
+                let last_raw = batch.last().map(|e| e.cursor());
+                // `inbox` is the DURABLE transcript. `resume_from_cursor`
+                // merges the hot ring (which transiently holds every class,
+                // incl. StreamChunk / EphemeralLatest for live attach-replay)
+                // with the sink, so filter to durable here — non-durable
+                // classes never belong in a replay (§3.4). The kinds filter
+                // composes the same way.
+                events.extend(batch.into_iter().filter(|env| {
+                    env.delivery.is_durable()
+                        && kinds.as_ref().is_none_or(|kinds| kinds.contains(&env.kind))
+                }));
+                if events.len() >= limit || exhausted {
+                    break;
                 }
-            };
-            // `inbox` is the DURABLE transcript. `resume_from_cursor`
-            // merges the hot ring (which transiently holds every class,
-            // incl. StreamChunk / EphemeralLatest for live attach-replay)
-            // with the sink, so filter to durable here — non-durable
-            // classes never belong in a replay (§3.4). The kinds filter
-            // composes the same way, and BOTH run before `truncate`, so
-            // `since` + `kinds` still means "the first N matching events
-            // after the cursor."
-            events.retain(|env| {
-                env.delivery.is_durable()
-                    && kinds.as_ref().is_none_or(|kinds| kinds.contains(&env.kind))
-            });
+                match last_raw {
+                    Some(cursor) => from = Some(cursor),
+                    None => break,
+                }
+            }
             events.truncate(limit);
             events
         }


### PR DESCRIPTION
## What
`EventRouter::resume_from_cursor` takes a `limit`: the deep leg is one indexed `LIMIT` query and the merged page is cut to `limit` in total order. `handle_inbox` chains pages by the last raw cursor while applying the durable/kinds predicates, so a short page still means "exhausted" to the client's paging loop.

## Why (measured)
Before, every inbox page asked the sink for `usize::MAX` rows and truncated in memory, so a from-zero walk of a room was O(n²/page). On continuum's M5 the wall projection (`wall_posts_in` → `room_transcripts_since` from a zero cursor, 500/page) never returned inside the readers' 30 s deadline over academy (244,037 bus_events) and cambriantech (472,504), while the work board — resuming from a saved cursor — answered in 0 ms through the same daemon (`board.read.phase` 149/149 complete, `wall.read.phase` 3 enter / 0 exit). BigMama measured the same on the 5090 (143–148 s, two calls never returned). Every citizen tick on every node paid the 30 s deadline to this.

## After
A from-zero wall read over a 244k-event room is ~488 pages × one indexed query instead of never. The wall's own cursor cache (continuum card 5f95836c) is the second fix and stays worth doing; this one removes the per-page cost it would have hidden.

## Tests
`durable_tail::cursor_resume_pages_are_bounded_by_limit_not_by_room_depth` (1,200 events, 3 pages, one bounded sink read each, whole channel in order). airc-bus + airc-daemon green.

## Acceptance verb (continuum, after the pin bump)
`debug/probes/query {"class":"wall.read.phase"}` shows `exit` rows with `wall_ms` for every `enter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo