### PR TITLE
feat(lib): the wall is a cached projection resumed from its cursor, like the board

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1328,21 +1328,33 @@ impl Airc {
         room: &crate::Room,
         category_filter: Option<&str>,
     ) -> Result<Vec<airc_core::doctrine::WallPostPublished>, AircError> {
-        let events = self
-            .room_transcripts_since(
+        // The wall is a cached projection of the room's transcript, resumed
+        // strictly after its snapshot cursor exactly like the work board
+        // (2026-09-06: a from-zero walk cost 27–128 s per read on the fleet
+        // and every citizen tick paid a 30 s deadline to it). Discriminate on
+        // each event's self-describing body, NOT its transcript `kind` — see
+        // [`wall_post_from_event`] for why the kind is unreliable on the
+        // daemon-attached read path.
+        let wall = self
+            .project_room_with_cache(
                 room,
-                &crate::work_board_cache::zero_transcript_cursor(),
                 WALL_PROJECTION_PAGE_SIZE,
+                |events| {
+                    Ok(WallProjection(
+                        events
+                            .into_iter()
+                            .filter_map(wall_post_from_event)
+                            .collect(),
+                    ))
+                },
+                |wall, events| {
+                    wall.0
+                        .extend(events.into_iter().filter_map(wall_post_from_event));
+                    Ok(())
+                },
             )
             .await?;
-        // Discriminate on each event's self-describing body, NOT its
-        // transcript `kind` — see [`wall_post_from_event`] for why the
-        // kind is unreliable on the daemon-attached read path.
-        let posts: Vec<_> = events
-            .into_iter()
-            .filter_map(wall_post_from_event)
-            .collect();
-        Ok(project_wall_posts(posts, category_filter))
+        Ok(project_wall_posts(wall.0, category_filter))
     }
 
     /// **Card 1224aac2 slice 1.** Reserved wall-post category name for
@@ -2528,6 +2540,19 @@ fn warn_subscription_rebinds(rebinds: &[subscriptions::SubscriptionRebind]) {
 /// which is worse than a slow read. Declared once so `wall_posts` and
 /// `wall_posts_in` can never disagree about what "the wall" means.
 pub const WALL_PROJECTION_PAGE_SIZE: usize = 500;
+
+/// Every wall post ever published on one room, in transcript order — the
+/// snapshot the wall read resumes from. Supersedes/category filtering is
+/// applied on top by [`project_wall_posts`], so the snapshot stays the raw
+/// fold and a filter change never invalidates it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct WallProjection(pub(crate) Vec<airc_core::doctrine::WallPostPublished>);
+
+impl crate::work_board_cache::CachedProjection for WallProjection {
+    const DIR: &'static str = "wall-cache";
+    const LABEL: &'static str = "wall cache";
+    const VERSION: u32 = 1;
+}
 
 fn wall_post_from_event(
     event: airc_core::TranscriptEvent,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -2,8 +2,8 @@
 
 use crate::time::now_ms;
 use crate::work_board_cache::{
-    cursor_strictly_before, zero_transcript_cursor, WorkBoardCache, WorkBoardCacheSource,
-    WORK_BOARD_CACHE_FORMAT_VERSION,
+    cursor_strictly_before, zero_transcript_cursor, CachedProjection, ProjectionCache,
+    WorkBoardCacheSource,
 };
 use crate::{Airc, AircError, Room};
 use airc_core::EventId;
@@ -930,14 +930,47 @@ impl Airc {
         room: &crate::Room,
         page_size: usize,
     ) -> Result<WorkBoardProjection, AircError> {
+        self.project_room_with_cache(
+            room,
+            page_size,
+            |transcripts| {
+                airc_work_store::project_transcripts(transcripts).map_err(AircError::from)
+            },
+            |projection, transcripts| {
+                airc_work_store::apply_transcripts(projection, transcripts)
+                    .map(|_newest| ())
+                    .map_err(AircError::from)
+            },
+        )
+        .await
+    }
+
+    /// ONE resume rule for every cached projection of a room's transcript
+    /// (the work board, the wall): load the snapshot for this read path,
+    /// resume strictly after its cursor with `apply`, and on any anomaly —
+    /// no snapshot, a cursor the log no longer agrees with — rebuild from
+    /// event zero with `build`. The snapshot is saved after either path.
+    /// The cache is an accelerator, never an authority.
+    pub(crate) async fn project_room_with_cache<P, B, A>(
+        &self,
+        room: &crate::Room,
+        page_size: usize,
+        build: B,
+        apply: A,
+    ) -> Result<P, AircError>
+    where
+        P: CachedProjection,
+        B: FnOnce(Vec<airc_core::TranscriptEvent>) -> Result<P, AircError>,
+        A: FnOnce(&mut P, Vec<airc_core::TranscriptEvent>) -> Result<(), AircError>,
+    {
         let source = if self.is_daemon_attached() {
             WorkBoardCacheSource::Daemon
         } else {
             WorkBoardCacheSource::Store
         };
-        if let Some(cache) = WorkBoardCache::load(self.home(), room.channel, source) {
+        if let Some(cache) = ProjectionCache::<P>::load(self.home(), room.channel, source) {
             if let Some(projection) = self
-                .resume_work_board(room, cache, source, page_size)
+                .resume_projection(room, cache, source, page_size, apply)
                 .await?
             {
                 return Ok(projection);
@@ -949,10 +982,10 @@ impl Airc {
             .room_transcripts_since(room, &zero_transcript_cursor(), page_size)
             .await?;
         let cursor = transcripts.last().map(airc_core::TranscriptEvent::cursor);
-        let projection = airc_work_store::project_transcripts(transcripts)?;
+        let projection = build(transcripts)?;
         if let Some(cursor) = cursor {
-            WorkBoardCache {
-                version: WORK_BOARD_CACHE_FORMAT_VERSION,
+            ProjectionCache {
+                version: P::VERSION,
                 channel: room.channel,
                 source,
                 cursor,
@@ -963,20 +996,24 @@ impl Airc {
         Ok(projection)
     }
 
-    /// Resume the work-board projection from a persisted snapshot:
-    /// fetch only the transcript events strictly after the snapshot's
-    /// cursor and fold them in with the same windowed-apply rule the
-    /// full replay uses. Returns `Ok(None)` when the snapshot must be
-    /// discarded (the log disagrees with its cursor) — the caller
-    /// rebuilds from scratch. Transport/store errors propagate; they
-    /// are not a cache problem.
-    async fn resume_work_board(
+    /// Resume a cached projection from a persisted snapshot: fetch only
+    /// the transcript events strictly after the snapshot's cursor and
+    /// fold them in with `apply` — the same fold the full replay uses.
+    /// Returns `Ok(None)` when the snapshot must be discarded (the log
+    /// disagrees with its cursor) — the caller rebuilds from scratch.
+    /// Transport/store errors propagate; they are not a cache problem.
+    async fn resume_projection<P, A>(
         &self,
         room: &crate::Room,
-        cache: WorkBoardCache,
+        cache: ProjectionCache<P>,
         source: WorkBoardCacheSource,
         page_size: usize,
-    ) -> Result<Option<WorkBoardProjection>, AircError> {
+        apply: A,
+    ) -> Result<Option<P>, AircError>
+    where
+        P: CachedProjection,
+        A: FnOnce(&mut P, Vec<airc_core::TranscriptEvent>) -> Result<(), AircError>,
+    {
         let new_transcripts = self
             .room_transcripts_since(room, &cache.cursor, page_size)
             .await?;
@@ -992,9 +1029,11 @@ impl Airc {
                 return Ok(Some(cache.projection));
             }
             eprintln!(
-                "work board cache: snapshot cursor (lamport {}) is not the tip of channel {} — \
+                "{}: snapshot cursor (lamport {}) is not the tip of channel {} — \
                  log rewound or replaced; rebuilding projection from scratch",
-                cache.cursor.lamport, room.channel
+                P::LABEL,
+                cache.cursor.lamport,
+                room.channel
             );
             return Ok(None);
         };
@@ -1005,9 +1044,12 @@ impl Airc {
         let first_cursor = first.cursor();
         if !cursor_strictly_before(&cache.cursor, &first_cursor) {
             eprintln!(
-                "work board cache: channel {} returned event at lamport {} not strictly after \
+                "{}: channel {} returned event at lamport {} not strictly after \
                  snapshot cursor (lamport {}) — rebuilding projection from scratch",
-                room.channel, first_cursor.lamport, cache.cursor.lamport
+                P::LABEL,
+                room.channel,
+                first_cursor.lamport,
+                cache.cursor.lamport
             );
             return Ok(None);
         }
@@ -1020,9 +1062,9 @@ impl Airc {
             .last()
             .map(airc_core::TranscriptEvent::cursor)
             .unwrap_or(first_cursor);
-        airc_work_store::apply_transcripts(&mut projection, new_transcripts)?;
-        WorkBoardCache {
-            version: WORK_BOARD_CACHE_FORMAT_VERSION,
+        apply(&mut projection, new_transcripts)?;
+        ProjectionCache {
+            version: P::VERSION,
             channel: room.channel,
             source,
             cursor: newest,

--- a/crates/airc-lib/src/work_board_cache.rs
+++ b/crates/airc-lib/src/work_board_cache.rs
@@ -30,6 +30,7 @@ use std::path::{Path, PathBuf};
 
 use airc_core::{EventId, RoomId, TranscriptCursor};
 use airc_work::WorkBoardProjection;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 /// Bump when the persisted shape (or projection semantics feeding it)
@@ -69,20 +70,42 @@ pub(crate) enum WorkBoardCacheSource {
     Store,
 }
 
+/// A projection of one room's transcript that can be snapshotted and
+/// resumed strictly after a cursor. The work board was the first; the
+/// wall is the second (2026-09-06: a from-zero wall walk over a 244k-event
+/// room took 27–128 s per read on the fleet, inside a 30 s deadline).
+/// One cache shape, one resume rule, N projections — the next projection
+/// implements this and gets the snapshot for free.
+pub(crate) trait CachedProjection: Serialize + DeserializeOwned + Clone {
+    /// Subdirectory of the scope home holding one snapshot per room.
+    const DIR: &'static str;
+    /// Human label for the loud rebuild lines.
+    const LABEL: &'static str;
+    /// Bump when the persisted shape (or the projection semantics feeding
+    /// it) changes; old snapshots are then discarded and rebuilt.
+    const VERSION: u32;
+}
+
+impl CachedProjection for WorkBoardProjection {
+    const DIR: &'static str = CACHE_DIR;
+    const LABEL: &'static str = "work board cache";
+    const VERSION: u32 = WORK_BOARD_CACHE_FORMAT_VERSION;
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct WorkBoardCache {
+pub(crate) struct ProjectionCache<P> {
     pub version: u32,
     pub channel: RoomId,
     pub source: WorkBoardCacheSource,
     /// Cursor of the newest transcript event folded into `projection`
-    /// (work event or not) — the strictly-after resume point.
+    /// (a projected event or not) — the strictly-after resume point.
     pub cursor: TranscriptCursor,
-    pub projection: WorkBoardProjection,
+    pub projection: P,
 }
 
-impl WorkBoardCache {
+impl<P: CachedProjection> ProjectionCache<P> {
     pub fn path(home: &Path, channel: RoomId) -> PathBuf {
-        home.join(CACHE_DIR).join(format!("{channel}.json"))
+        home.join(P::DIR).join(format!("{channel}.json"))
     }
 
     /// Load the snapshot for `channel`, or `None` when the caller must
@@ -97,7 +120,8 @@ impl WorkBoardCache {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
             Err(error) => {
                 eprintln!(
-                    "work board cache: failed to read {} ({error}) — rebuilding projection from scratch",
+                    "{}: failed to read {} ({error}) — rebuilding projection from scratch",
+                    P::LABEL,
                     path.display()
                 );
                 return None;
@@ -107,23 +131,27 @@ impl WorkBoardCache {
             Ok(cache) => cache,
             Err(error) => {
                 eprintln!(
-                    "work board cache: corrupt snapshot {} ({error}) — rebuilding projection from scratch",
+                    "{}: corrupt snapshot {} ({error}) — rebuilding projection from scratch",
+                    P::LABEL,
                     path.display()
                 );
                 return None;
             }
         };
-        if cache.version != WORK_BOARD_CACHE_FORMAT_VERSION {
+        if cache.version != P::VERSION {
             eprintln!(
-                "work board cache: snapshot {} has format v{} (current v{WORK_BOARD_CACHE_FORMAT_VERSION}) — rebuilding projection from scratch",
+                "{}: snapshot {} has format v{} (current v{}) — rebuilding projection from scratch",
+                P::LABEL,
                 path.display(),
-                cache.version
+                cache.version,
+                P::VERSION
             );
             return None;
         }
         if cache.channel != channel {
             eprintln!(
-                "work board cache: snapshot {} is for channel {} (expected {channel}) — rebuilding projection from scratch",
+                "{}: snapshot {} is for channel {} (expected {channel}) — rebuilding projection from scratch",
+                P::LABEL,
                 path.display(),
                 cache.channel
             );
@@ -131,7 +159,8 @@ impl WorkBoardCache {
         }
         if cache.source != source {
             eprintln!(
-                "work board cache: snapshot {} was projected from the {:?} log but this read uses {:?} — rebuilding projection from scratch",
+                "{}: snapshot {} was projected from the {:?} log but this read uses {:?} — rebuilding projection from scratch",
+                P::LABEL,
                 path.display(),
                 cache.source,
                 source
@@ -148,7 +177,8 @@ impl WorkBoardCache {
         let path = Self::path(home, self.channel);
         if let Err(error) = self.try_save(&path) {
             eprintln!(
-                "work board cache: failed to persist snapshot {} ({error}) — next read rebuilds from scratch",
+                "{}: failed to persist snapshot {} ({error}) — next read rebuilds from scratch",
+                P::LABEL,
                 path.display()
             );
         }
@@ -180,8 +210,8 @@ impl WorkBoardCache {
 mod tests {
     use super::*;
 
-    fn sample(channel: RoomId) -> WorkBoardCache {
-        WorkBoardCache {
+    fn sample(channel: RoomId) -> ProjectionCache<WorkBoardProjection> {
+        ProjectionCache {
             version: WORK_BOARD_CACHE_FORMAT_VERSION,
             channel,
             source: WorkBoardCacheSource::Daemon,
@@ -199,8 +229,12 @@ mod tests {
         let channel = RoomId::from_u128(1);
         let cache = sample(channel);
         cache.save(home.path());
-        let loaded = WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon)
-            .expect("snapshot loads back");
+        let loaded = ProjectionCache::<WorkBoardProjection>::load(
+            home.path(),
+            channel,
+            WorkBoardCacheSource::Daemon,
+        )
+        .expect("snapshot loads back");
         assert_eq!(loaded, cache);
     }
 
@@ -219,7 +253,7 @@ mod tests {
                     let home = home.path();
                     scope.spawn(move || {
                         let cache = sample(channel);
-                        cache.try_save(&WorkBoardCache::path(home, channel))
+                        cache.try_save(&ProjectionCache::<WorkBoardProjection>::path(home, channel))
                     })
                 })
                 .collect::<Vec<_>>()
@@ -230,13 +264,18 @@ mod tests {
         for r in results {
             r.expect("every concurrent save must persist — shared tmp names race");
         }
-        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon).is_some());
+        assert!(ProjectionCache::<WorkBoardProjection>::load(
+            home.path(),
+            channel,
+            WorkBoardCacheSource::Daemon
+        )
+        .is_some());
     }
 
     #[test]
     fn missing_file_is_silent_cold_start() {
         let home = tempfile::tempdir().expect("tempdir");
-        assert!(WorkBoardCache::load(
+        assert!(ProjectionCache::<WorkBoardProjection>::load(
             home.path(),
             RoomId::from_u128(1),
             WorkBoardCacheSource::Daemon
@@ -248,10 +287,15 @@ mod tests {
     fn corrupt_json_is_discarded() {
         let home = tempfile::tempdir().expect("tempdir");
         let channel = RoomId::from_u128(1);
-        let path = WorkBoardCache::path(home.path(), channel);
+        let path = ProjectionCache::<WorkBoardProjection>::path(home.path(), channel);
         std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
         std::fs::write(&path, b"{ not json").expect("write garbage");
-        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon).is_none());
+        assert!(ProjectionCache::<WorkBoardProjection>::load(
+            home.path(),
+            channel,
+            WorkBoardCacheSource::Daemon
+        )
+        .is_none());
     }
 
     #[test]
@@ -261,7 +305,12 @@ mod tests {
         let mut cache = sample(channel);
         cache.version = WORK_BOARD_CACHE_FORMAT_VERSION + 1;
         cache.save(home.path());
-        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon).is_none());
+        assert!(ProjectionCache::<WorkBoardProjection>::load(
+            home.path(),
+            channel,
+            WorkBoardCacheSource::Daemon
+        )
+        .is_none());
     }
 
     #[test]
@@ -270,10 +319,10 @@ mod tests {
         let written = RoomId::from_u128(1);
         let cache = sample(written);
         // Force the file under a DIFFERENT channel's name.
-        let path = WorkBoardCache::path(home.path(), RoomId::from_u128(2));
+        let path = ProjectionCache::<WorkBoardProjection>::path(home.path(), RoomId::from_u128(2));
         std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
         std::fs::write(&path, serde_json::to_vec(&cache).expect("encode")).expect("write");
-        assert!(WorkBoardCache::load(
+        assert!(ProjectionCache::<WorkBoardProjection>::load(
             home.path(),
             RoomId::from_u128(2),
             WorkBoardCacheSource::Daemon
@@ -286,7 +335,12 @@ mod tests {
         let home = tempfile::tempdir().expect("tempdir");
         let channel = RoomId::from_u128(1);
         sample(channel).save(home.path());
-        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Store).is_none());
+        assert!(ProjectionCache::<WorkBoardProjection>::load(
+            home.path(),
+            channel,
+            WorkBoardCacheSource::Store
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/airc-lib/tests/wall_cache_resumes.rs
+++ b/crates/airc-lib/tests/wall_cache_resumes.rs
@@ -1,0 +1,82 @@
+//! The wall is a cached projection, resumed strictly after its snapshot cursor —
+//! the second instance of the work board's cache (2026-09-06: a from-zero wall
+//! walk cost 27–128 s per read across the fleet, inside a 30 s deadline).
+//!
+//! What this catches: a wall read that stops snapshotting (the cache file never
+//! appears), a resume that drops or duplicates posts across the snapshot seam, or
+//! a corrupt snapshot served instead of rebuilt.
+
+mod common;
+
+use airc_lib::Airc;
+use common::Machine;
+
+const CATEGORY: &str = "standing";
+
+async fn publish(airc: &Airc, body: &str) {
+    airc.publish_wall_post(CATEGORY.to_string(), body.to_string(), None)
+        .await
+        .expect("publish wall post");
+}
+
+async fn bodies(airc: &Airc, room: &airc_lib::Room) -> Vec<String> {
+    let mut bodies: Vec<String> = airc
+        .wall_posts_in(room, Some(CATEGORY))
+        .await
+        .expect("wall read")
+        .into_iter()
+        .map(|post| post.body)
+        .collect();
+    bodies.sort();
+    bodies
+}
+
+#[tokio::test]
+async fn the_wall_snapshots_and_resumes_across_its_cursor_without_gap_or_dup() {
+    let machine = Machine::boot().await;
+    let alice = machine.attach("alice").await;
+    let room = alice.join("wall-room").await.expect("join");
+
+    publish(&alice, "A").await;
+    publish(&alice, "B").await;
+    assert_eq!(
+        bodies(&alice, &room).await,
+        vec!["A".to_string(), "B".to_string()]
+    );
+
+    let snapshot = alice
+        .home()
+        .join("wall-cache")
+        .join(format!("{}.json", room.channel));
+    assert!(
+        snapshot.is_file(),
+        "the first read snapshots the wall at {}",
+        snapshot.display()
+    );
+    let first = std::fs::read(&snapshot).expect("snapshot bytes");
+
+    // A later post lands strictly after the snapshot cursor: the resume folds
+    // it in (no gap) without re-adding the earlier ones (no dup), and the
+    // snapshot advances.
+    publish(&alice, "C").await;
+    assert_eq!(
+        bodies(&alice, &room).await,
+        vec!["A".to_string(), "B".to_string(), "C".to_string()]
+    );
+    assert_ne!(
+        std::fs::read(&snapshot).expect("snapshot bytes"),
+        first,
+        "the snapshot advanced"
+    );
+
+    // A corrupt snapshot is discarded and rebuilt, never served.
+    std::fs::write(&snapshot, b"{ not json").expect("corrupt");
+    assert_eq!(
+        bodies(&alice, &room).await,
+        vec!["A".to_string(), "B".to_string(), "C".to_string()]
+    );
+    assert!(
+        std::fs::read(&snapshot).expect("bytes").starts_with(b"{\""),
+        "rebuilt snapshot persisted"
+    );
+}


### PR DESCRIPTION
## What
`ProjectionCache<P: CachedProjection>` generalizes the work-board snapshot (same on-disk fields and anomaly rules); `Airc::project_room_with_cache` is the one resume rule; the wall (`WallProjection`, every post on the room in order) is the second instance. `wall_posts_in` loads `<home>/wall-cache/<channel>.json` and pages strictly after its cursor; category/supersedes filtering stays on top so a filter change never invalidates the snapshot.

## Why (measured)
After #1389 bounded the per-page cost, a from-zero wall walk still took 27 s (IntelMac, 8 posts) to 98–128 s (BigMama, half never returned) per read on rooms of 200k–470k bus_events — inside continuum's 30 s perception deadline, paid on every citizen tick. The board never paid it because it resumes from a snapshot; now the wall does too. Continuum card 5f95836c.

## Tests
`wall_cache_resumes::the_wall_snapshots_and_resumes_across_its_cursor_without_gap_or_dup` (snapshot appears; later post folded in, no gap/dup; snapshot advances; corrupt snapshot rebuilt). Whole airc-lib suite 457/457; pre-push fmt+clippy gate clean.

## Acceptance (continuum, after the pin bump)
`wall.read.phase` exit rows with `wall_ms` well under the 30 s deadline on every node from the second read on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo