### PR TITLE
feat(cli): airc inbox --all — every subscribed room, grouped, newest activity first

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -752,6 +752,14 @@ pub enum Command {
         since_event_id: Option<String>,
         #[arg(long)]
         limit: Option<usize>,
+        /// EVERY subscribed room, grouped, newest activity first — the
+        /// one-room blindness fix (card a0772bba, 2026-09-06: seven hours
+        /// of a peer's reports sat in a room the reader was not looking at,
+        /// and the fleet's silent-means-down rule read a reporting node as
+        /// down). `--limit` applies per room. Refused alongside `--room` or
+        /// a cursor: one scope-wide view, not a paged one.
+        #[arg(long, conflicts_with_all = ["room", "since_lamport", "since_event_id"])]
+        all: bool,
         /// Emit a single JSON document on stdout instead of
         /// human-readable text. Shape mirrors `airc events list
         /// --json` and `airc publish` for machine consumers

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -2716,6 +2716,79 @@ pub async fn run_inbox(
     Ok(())
 }
 
+/// `airc inbox --all` — the newest `limit` events of EVERY subscribed room,
+/// grouped by room, rooms ordered by their newest event (most recent first).
+/// The one-room blindness fix (card a0772bba): a reader that can only see
+/// one room at a time turns every fleet rule that depends on hearing a peer
+/// — silent-means-down, review windows, claim boundaries — into a coin flip.
+/// Reads only; never moves the default-room pointer, never joins.
+pub async fn run_inbox_all(
+    home: &Path,
+    socket: Option<PathBuf>,
+    limit: Option<usize>,
+    as_json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = match socket {
+        Some(socket) => {
+            let socket = ensure_daemon_running(home, socket, Vec::new()).await?;
+            Airc::attach(home, socket).await?
+        }
+        None => attached_airc(home).await?,
+    };
+    let per_room = limit.unwrap_or(8).max(1);
+    let set = airc.subscription_set().await?;
+    let mut groups: Vec<(airc_lib::Room, Vec<airc_core::TranscriptEvent>)> = Vec::new();
+    for sub in set.all() {
+        let room = sub.as_room();
+        let events = airc.page_recent_in(&room, per_room).await?;
+        groups.push((room, events));
+    }
+    // Newest activity first; a room with nothing sinks to the bottom.
+    groups.sort_by_key(|(_, events)| {
+        std::cmp::Reverse(events.last().map(|e| e.occurred_at_ms).unwrap_or(0))
+    });
+    if as_json {
+        let rooms: Vec<serde_json::Value> = groups
+            .iter()
+            .map(|(room, events)| {
+                serde_json::json!({
+                    "room": room.name,
+                    "channel": room.channel.to_string(),
+                    "count": events.len(),
+                    "events": events,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({ "rooms": rooms }))?
+        );
+        return Ok(());
+    }
+    println!(
+        "inbox --all: {} subscribed room(s), newest {} per room, most recent room first",
+        groups.len(),
+        per_room
+    );
+    for (room, events) in &groups {
+        println!();
+        if events.is_empty() {
+            println!("── {} (channel {}) — no events", room.name, room.channel);
+            continue;
+        }
+        println!(
+            "── {} (channel {}) — {} event(s)",
+            room.name,
+            room.channel,
+            events.len()
+        );
+        for event in events {
+            print_event(event);
+        }
+    }
+    Ok(())
+}
+
 /// Emit a single JSON document for `airc inbox --json`.
 ///
 /// Shape: `{ count, events, cursor: {lamport, event_id} | null }`.

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -492,18 +492,23 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             since_lamport,
             since_event_id,
             limit,
+            all,
             json,
         } => {
-            commands::run_inbox(
-                &home,
-                socket,
-                room.named(),
-                since_lamport,
-                since_event_id,
-                limit,
-                json,
-            )
-            .await
+            if all {
+                commands::run_inbox_all(&home, socket, limit, json).await
+            } else {
+                commands::run_inbox(
+                    &home,
+                    socket,
+                    room.named(),
+                    since_lamport,
+                    since_event_id,
+                    limit,
+                    json,
+                )
+                .await
+            }
         }
 
         Command::Room { name } => commands::run_room(&home, name).await,


### PR DESCRIPTION
## What
`airc inbox --all [--limit N] [--json]`: the newest N events of EVERY subscribed room, grouped by room, rooms ordered by most recent activity; `--json` emits one document `{rooms:[{room, channel, count, events}]}`. Read-only — never moves the default-room pointer, never joins. Refused alongside `--room` or a cursor.

## Why (card a0772bba)
2026-09-06: BigMama posted seven hours of status into one room while the M5 read another; the fleet's silent-means-down rule read a reporting node as down, and a real outage (her daemon socket, from my airc merges' fleet restart) was misattributed on top. A reader that can only see one room at a time turns every rule that depends on hearing a peer into a coin flip. The command already enumerated the rooms it was hiding; now it shows them.

Verified live on the M5 against the running daemon (the airc repo scope: general + cambriantech, grouped, most recent first). Reply-to-origin and the "not in this room" vs "down" presence signal are the next slices on the card.

**Merge note:** an airc canary merge restarts every daemon on the fleet — merge at a quiet hour, announced first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo